### PR TITLE
Add 3 more ddr controllers in CL

### DIFF
--- a/Makefile.machine.include
+++ b/Makefile.machine.include
@@ -48,4 +48,4 @@ CL_MANYCORE_HOST_COORD_Y             := 0
 CL_MANYCORE_DIM_X                    := $(BSG_MACHINE_GLOBAL_X)
 CL_MANYCORE_DIM_Y                    := $(shell expr $(BSG_MACHINE_GLOBAL_Y) - 1)
 
-CL_MANYCORE_MEM_CFG                  := e_vcache_blocking_axi4_f1_model
+CL_MANYCORE_MEM_CFG                  := e_vcache_blocking_axi4_f1_ddrx4_model

--- a/hardware/axi4_clock_converter.v
+++ b/hardware/axi4_clock_converter.v
@@ -1,0 +1,195 @@
+/**
+*  axi4_clock_converter.v
+*
+*/
+`include "bsg_axi_bus_pkg.vh"
+
+module axi4_clock_converter #(
+  parameter device_family = "inv"
+  , parameter s_axi_aclk_ratio_p = "inv"
+  , parameter m_axi_aclk_ratio_p = "inv"
+  , parameter is_aclk_async_p = "inv"
+  , parameter axi4_id_width_p = "inv"
+  , parameter axi4_addr_width_p = "inv"
+  , parameter axi4_data_width_p = "inv"
+  , localparam axi4_mosi_bus_width_lp = `bsg_axi4_mosi_bus_width(1, axi4_id_width_p, axi4_addr_width_p, axi4_data_width_p)
+  , localparam axi4_miso_bus_width_lp = `bsg_axi4_miso_bus_width(1, axi4_id_width_p, axi4_addr_width_p, axi4_data_width_p)
+) (
+  input                               clk_src_i
+  ,input                               reset_src_i
+  ,input                               clk_dst_i
+  ,input                               reset_dst_i
+  ,input  [axi4_mosi_bus_width_lp-1:0] s_axi4_src_i
+  ,output [axi4_miso_bus_width_lp-1:0] s_axi4_src_o
+  ,output [axi4_mosi_bus_width_lp-1:0] m_axi4_dst_o
+  ,input  [axi4_miso_bus_width_lp-1:0] m_axi4_dst_i
+);
+
+  `declare_bsg_axi4_bus_s(1, axi4_id_width_p, axi4_addr_width_p, axi4_data_width_p, bsg_axi4_mosi_bus_s, bsg_axi4_miso_bus_s);
+  bsg_axi4_mosi_bus_s s_axi4_li_cast, m_axi4_lo_cast;
+  bsg_axi4_miso_bus_s s_axi4_lo_cast, m_axi4_li_cast;
+
+  assign s_axi4_li_cast = s_axi4_src_i;
+  assign s_axi4_src_o = s_axi4_lo_cast;
+
+  assign m_axi4_dst_o = m_axi4_lo_cast;
+  assign m_axi4_li_cast = m_axi4_dst_i;
+
+
+`ifndef USE_IP_GEN
+axi_clock_converter_v2_1_18_axi_clock_converter #(
+    .C_FAMILY                   (device_family     ),
+    .C_AXI_ID_WIDTH             (axi4_id_width_p        ),
+    .C_AXI_ADDR_WIDTH           (axi4_addr_width_p      ),
+    .C_AXI_DATA_WIDTH           (axi4_data_width_p      ),
+    .C_S_AXI_ACLK_RATIO         (s_axi_aclk_ratio_p),
+    .C_M_AXI_ACLK_RATIO         (m_axi_aclk_ratio_p),
+    .C_AXI_IS_ACLK_ASYNC        (is_aclk_async_p   ),
+    .C_AXI_PROTOCOL             (0                 ),
+    .C_AXI_SUPPORTS_USER_SIGNALS(0                 ),
+    .C_AXI_AWUSER_WIDTH         (1                 ),
+    .C_AXI_ARUSER_WIDTH         (1                 ),
+    .C_AXI_WUSER_WIDTH          (1                 ),
+    .C_AXI_RUSER_WIDTH          (1                 ),
+    .C_AXI_BUSER_WIDTH          (1                 ),
+    .C_AXI_SUPPORTS_WRITE       (1                 ),
+    .C_AXI_SUPPORTS_READ        (1                 ),
+    .C_SYNCHRONIZER_STAGE       (3                 )
+) inst
+`else
+axi_clock_converter_0 inst_ip
+`endif
+    (
+    .s_axi_aclk    (clk_src_i              ),
+    .s_axi_aresetn (~reset_src_i           ),
+`ifndef USE_IP_GEN
+    .s_axi_awid    ('0                     ),
+`endif
+    .s_axi_awaddr  (s_axi4_li_cast.awaddr  ),
+    .s_axi_awlen   (s_axi4_li_cast.awlen   ),
+    .s_axi_awsize  (s_axi4_li_cast.awsize  ),
+    .s_axi_awburst (s_axi4_li_cast.awburst ),
+    .s_axi_awlock  (s_axi4_li_cast.awlock  ),
+    .s_axi_awcache (s_axi4_li_cast.awcache ),
+    .s_axi_awprot  (s_axi4_li_cast.awprot  ),
+    .s_axi_awregion(s_axi4_li_cast.awregion),
+    .s_axi_awqos   (s_axi4_li_cast.awqos   ),
+`ifndef USE_IP_GEN
+    .s_axi_awuser  ('0                     ),
+`endif
+    .s_axi_awvalid (s_axi4_li_cast.awvalid ),
+    .s_axi_awready (s_axi4_lo_cast.awready ),
+
+`ifndef USE_IP_GEN
+    .s_axi_wid     ('0                     ),
+`endif
+    .s_axi_wdata   (s_axi4_li_cast.wdata   ),
+    .s_axi_wstrb   (s_axi4_li_cast.wstrb   ),
+    .s_axi_wlast   (s_axi4_li_cast.wlast   ),
+`ifndef USE_IP_GEN
+    .s_axi_wuser   ('0                     ),
+`endif
+    .s_axi_wvalid  (s_axi4_li_cast.wvalid  ),
+    .s_axi_wready  (s_axi4_lo_cast.wready  ),
+
+    .s_axi_bid     (s_axi4_lo_cast.bid     ),
+    .s_axi_bresp   (s_axi4_lo_cast.bresp   ),
+`ifndef USE_IP_GEN
+    .s_axi_buser   (                       ),
+`endif
+    .s_axi_bvalid  (s_axi4_lo_cast.bvalid  ),
+    .s_axi_bready  (s_axi4_li_cast.bready  ),
+
+    .s_axi_arid    (s_axi4_li_cast.arid    ),
+    .s_axi_araddr  (s_axi4_li_cast.araddr  ),
+    .s_axi_arlen   (s_axi4_li_cast.arlen   ),
+    .s_axi_arsize  (s_axi4_li_cast.arsize  ),
+    .s_axi_arburst (s_axi4_li_cast.arburst ),
+    .s_axi_arlock  (s_axi4_li_cast.arlock  ),
+    .s_axi_arcache (s_axi4_li_cast.arcache ),
+    .s_axi_arprot  (s_axi4_li_cast.arprot  ),
+    .s_axi_arregion(s_axi4_li_cast.arregion),
+    .s_axi_arqos   (s_axi4_li_cast.arqos   ),
+`ifndef USE_IP_GEN
+    .s_axi_aruser  ('0                     ),
+`endif
+    .s_axi_arvalid (s_axi4_li_cast.arvalid ),
+    .s_axi_arready (s_axi4_lo_cast.arready ),
+
+    .s_axi_rid     (s_axi4_lo_cast.rid     ),
+    .s_axi_rdata   (s_axi4_lo_cast.rdata   ),
+    .s_axi_rresp   (s_axi4_lo_cast.rresp   ),
+    .s_axi_rlast   (s_axi4_lo_cast.rlast   ),
+`ifndef USE_IP_GEN
+    .s_axi_ruser   (                       ),
+`endif
+    .s_axi_rvalid  (s_axi4_lo_cast.rvalid  ),
+    .s_axi_rready  (s_axi4_li_cast.rready  ),
+
+    .m_axi_aclk    (clk_dst_i              ),
+    .m_axi_aresetn (~reset_dst_i           ),
+
+    .m_axi_awid    (m_axi4_lo_cast.awid    ), //
+    .m_axi_awaddr  (m_axi4_lo_cast.awaddr  ),
+    .m_axi_awlen   (m_axi4_lo_cast.awlen   ),
+    .m_axi_awsize  (m_axi4_lo_cast.awsize  ),
+    .m_axi_awburst (m_axi4_lo_cast.awburst ),
+    .m_axi_awlock  (m_axi4_lo_cast.awlock  ),
+    .m_axi_awcache (m_axi4_lo_cast.awcache ),
+    .m_axi_awprot  (m_axi4_lo_cast.awprot  ),
+    .m_axi_awregion(m_axi4_lo_cast.awregion),
+    .m_axi_awqos   (m_axi4_lo_cast.awqos   ),
+`ifndef USE_IP_GEN
+    .m_axi_awuser  (                       ),
+`endif
+    .m_axi_awvalid (m_axi4_lo_cast.awvalid ),
+    .m_axi_awready (m_axi4_li_cast.awready ),
+`ifndef USE_IP_GEN
+    .m_axi_wid     (                       ), // not defined
+`endif
+    .m_axi_wdata   (m_axi4_lo_cast.wdata   ),
+    .m_axi_wstrb   (m_axi4_lo_cast.wstrb   ),
+    .m_axi_wlast   (m_axi4_lo_cast.wlast   ),
+`ifndef USE_IP_GEN
+    .m_axi_wuser   (                       ),
+`endif
+    .m_axi_wvalid  (m_axi4_lo_cast.wvalid  ),
+    .m_axi_wready  (m_axi4_li_cast.wready  ),
+
+    .m_axi_bid     (m_axi4_li_cast.bid     ),
+    .m_axi_bresp   (m_axi4_li_cast.bresp   ),
+`ifndef USE_IP_GEN
+    .m_axi_buser   (1'H0                   ),
+`endif
+    .m_axi_bvalid  (m_axi4_li_cast.bvalid  ),
+    .m_axi_bready  (m_axi4_lo_cast.bready  ),
+
+    .m_axi_arid    (m_axi4_lo_cast.arid    ), //
+    .m_axi_araddr  (m_axi4_lo_cast.araddr  ),
+    .m_axi_arlen   (m_axi4_lo_cast.arlen   ),
+    .m_axi_arsize  (m_axi4_lo_cast.arsize  ),
+    .m_axi_arburst (m_axi4_lo_cast.arburst ),
+    .m_axi_arlock  (m_axi4_lo_cast.arlock  ),
+    .m_axi_arcache (m_axi4_lo_cast.arcache ),
+    .m_axi_arprot  (m_axi4_lo_cast.arprot  ),
+    .m_axi_arregion(m_axi4_lo_cast.arregion),
+    .m_axi_arqos   (m_axi4_lo_cast.arqos   ),
+`ifndef USE_IP_GEN
+    .m_axi_aruser  (                       ),
+`endif
+    .m_axi_arvalid (m_axi4_lo_cast.arvalid ),
+    .m_axi_arready (m_axi4_li_cast.arready ),
+
+    .m_axi_rid     (m_axi4_li_cast.rid     ),
+    .m_axi_rdata   (m_axi4_li_cast.rdata   ),
+    .m_axi_rresp   (m_axi4_li_cast.rresp   ),
+    .m_axi_rlast   (m_axi4_li_cast.rlast   ),
+`ifndef USE_IP_GEN
+    .m_axi_ruser   (1'H0                   ),
+`endif
+    .m_axi_rvalid  (m_axi4_li_cast.rvalid  ),
+    .m_axi_rready  (m_axi4_lo_cast.rready  )
+);
+
+
+endmodule

--- a/hardware/axi4_transpose_h2v.v
+++ b/hardware/axi4_transpose_h2v.v
@@ -1,0 +1,91 @@
+/**
+*  axi4_transpose_h2v.v
+*
+*/
+
+`include "bsg_axi_bus_pkg.vh"
+
+module axi4_transpose_h2v #(
+  parameter num_axi4_p = "inv"
+  , parameter axi4_id_width_p = "inv"
+  , parameter axi4_addr_width_p = "inv"
+  , parameter axi4_data_width_p = "inv"
+  , localparam axi4_mosi_bus_width_lp = `bsg_axi4_mosi_bus_width(1, axi4_id_width_p, axi4_addr_width_p, axi4_data_width_p)
+  , localparam axi4_miso_bus_width_lp = `bsg_axi4_miso_bus_width(1, axi4_id_width_p, axi4_addr_width_p, axi4_data_width_p)
+) (
+  input  [                       num_axi4_p-1:0][axi4_mosi_bus_width_lp-1:0] s_axi4_hs_i
+  ,output [                       num_axi4_p-1:0][axi4_miso_bus_width_lp-1:0] s_axi4_hs_o
+  ,output [num_axi4_p*axi4_mosi_bus_width_lp-1:0]                             m_axi4_vs_o
+  ,input  [num_axi4_p*axi4_miso_bus_width_lp-1:0]                             m_axi4_vs_i
+);
+
+  `declare_bsg_axi4_bus_s(1, axi4_id_width_p, axi4_addr_width_p, axi4_data_width_p, bsg_axi4_mosi_horizontal_s, bsg_axi4_miso_horizontal_s);
+  bsg_axi4_mosi_horizontal_s [num_axi4_p-1:0] s_axi4_h_li_cast;
+  bsg_axi4_miso_horizontal_s [num_axi4_p-1:0] s_axi4_h_lo_cast;
+
+  assign s_axi4_h_li_cast = s_axi4_hs_i;
+  assign s_axi4_hs_o = s_axi4_h_lo_cast;
+
+  `declare_bsg_axi4_bus_s(num_axi4_p, axi4_id_width_p, axi4_addr_width_p, axi4_data_width_p, bsg_axi4_mosi_vertical_s, bsg_axi4_miso_vertical_s);
+  bsg_axi4_mosi_vertical_s m_axi4_v_lo_cast;
+  bsg_axi4_miso_vertical_s m_axi4_v_li_cast;
+
+  assign m_axi4_vs_o = m_axi4_v_lo_cast;
+  assign m_axi4_v_li_cast = m_axi4_vs_i;
+
+  for (genvar i = 0; i < num_axi4_p; i++) begin : axi4_transpose_h2v
+    assign {
+      m_axi4_v_lo_cast.awid[i]
+      ,m_axi4_v_lo_cast.awaddr[i]
+      ,m_axi4_v_lo_cast.awlen[i]
+      ,m_axi4_v_lo_cast.awsize[i]
+      ,m_axi4_v_lo_cast.awburst[i]
+      ,m_axi4_v_lo_cast.awlock[i]
+      ,m_axi4_v_lo_cast.awcache[i]
+      ,m_axi4_v_lo_cast.awprot[i]
+      ,m_axi4_v_lo_cast.awqos[i]
+      ,m_axi4_v_lo_cast.awregion[i]
+      ,m_axi4_v_lo_cast.awvalid[i]
+
+      ,m_axi4_v_lo_cast.wdata[i]
+      ,m_axi4_v_lo_cast.wstrb[i]
+      ,m_axi4_v_lo_cast.wlast[i]
+      ,m_axi4_v_lo_cast.wvalid[i]
+
+      ,m_axi4_v_lo_cast.bready[i]
+
+      ,m_axi4_v_lo_cast.arid[i]
+      ,m_axi4_v_lo_cast.araddr[i]
+      ,m_axi4_v_lo_cast.arlen[i]
+      ,m_axi4_v_lo_cast.arsize[i]
+      ,m_axi4_v_lo_cast.arburst[i]
+      ,m_axi4_v_lo_cast.arlock[i]
+      ,m_axi4_v_lo_cast.arcache[i]
+      ,m_axi4_v_lo_cast.arprot[i]
+      ,m_axi4_v_lo_cast.arqos[i]
+      ,m_axi4_v_lo_cast.arregion[i]
+      ,m_axi4_v_lo_cast.arvalid[i]
+
+      ,m_axi4_v_lo_cast.rready[i]
+    } = s_axi4_h_li_cast[i];
+
+    assign s_axi4_h_lo_cast[i] =
+    {
+      m_axi4_v_li_cast.awready[i]
+      ,m_axi4_v_li_cast.wready[i]
+
+      ,m_axi4_v_li_cast.bid[i]
+      ,m_axi4_v_li_cast.bresp[i]
+      ,m_axi4_v_li_cast.bvalid[i]
+
+      ,m_axi4_v_li_cast.arready[i]
+
+      ,m_axi4_v_li_cast.rid[i]
+      ,m_axi4_v_li_cast.rdata[i]
+      ,m_axi4_v_li_cast.rresp[i]
+      ,m_axi4_v_li_cast.rlast[i]
+      ,m_axi4_v_li_cast.rvalid[i]
+    };
+  end
+
+endmodule

--- a/hardware/bsg_axi_bus_pkg.vh
+++ b/hardware/bsg_axi_bus_pkg.vh
@@ -1,19 +1,19 @@
 // Copyright (c) 2019, University of Washington All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
-// 
+//
 // Redistributions of source code must retain the above copyright notice, this list
 // of conditions and the following disclaimer.
-// 
+//
 // Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
-// 
+//
 // Neither the name of the copyright holder nor the names of its contributors may
 // be used to endorse or promote products derived from this software without
 // specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -28,6 +28,10 @@
 `ifndef BSG_AXI_BUS_PKG_VH
 `define BSG_AXI_BUS_PKG_VH
 
+
+// -----------------------------------------------------------
+// AXI-Lite (simple version)
+// -----------------------------------------------------------
 `define declare_bsg_axil_bus_s(slot_num_lp, mosi_struct_name, miso_struct_name) \
 typedef struct packed { \
   logic [slot_num_lp*32-1:0] awaddr ; \
@@ -57,85 +61,155 @@ typedef struct packed { \
   \
 } miso_struct_name
 
-`define bsg_axil_mosi_bus_width(slot_num_lp) \
-( slot_num_lp * (3*32 + 5 + 4) \
+`define bsg_axil_mosi_bus_width(slot_num_mp) \
+( slot_num_mp * (3*32 + 5 + 4) \
 )
 
-`define bsg_axil_miso_bus_width(slot_num_lp) \
-( slot_num_lp * (5 + 2*2 + 32) \
+`define bsg_axil_miso_bus_width(slot_num_mp) \
+( slot_num_mp * (5 + 2*2 + 32) \
 )
 
 
-`define declare_bsg_axi_bus_s(slot_num_lp, id_width_p, addr_width_p, data_width_p, mosi_struct_name, miso_struct_name) \
+// -----------------------------------------------------------
+// AXI4 (simple version)
+// -----------------------------------------------------------
+`define declare_bsg_axi_bus_s(slot_num_mp, id_width_mp, addr_width_mp, data_width_mp, mosi_struct_name, miso_struct_name) \
 typedef struct packed { \
-  logic [    slot_num_lp*id_width_p-1:0] awid   ; \
-  logic [  slot_num_lp*addr_width_p-1:0] awaddr ; \
-  logic [             slot_num_lp*8-1:0] awlen  ; \
-  logic [             slot_num_lp*3-1:0] awsize ; \
-  logic [               slot_num_lp-1:0] awvalid; \
-  logic [    slot_num_lp*id_width_p-1:0] wid    ; \
-  logic [  slot_num_lp*data_width_p-1:0] wdata  ; \
-  logic [slot_num_lp*data_width_p/8-1:0] wstrb  ; \
-  logic [               slot_num_lp-1:0] wlast  ; \
-  logic [               slot_num_lp-1:0] wvalid ; \
+  logic [slot_num_mp-1:0][    id_width_mp-1:0] awid   ; \
+  logic [slot_num_mp-1:0][  addr_width_mp-1:0] awaddr ; \
+  logic [slot_num_mp-1:0][              8-1:0] awlen  ; \
+  logic [slot_num_mp-1:0][              3-1:0] awsize ; \
+  logic [slot_num_mp-1:0]                      awvalid; \
+  logic [slot_num_mp-1:0][    id_width_mp-1:0] wid    ; \
+  logic [slot_num_mp-1:0][  data_width_mp-1:0] wdata  ; \
+  logic [slot_num_mp-1:0][data_width_mp/8-1:0] wstrb  ; \
+  logic [slot_num_mp-1:0]                      wlast  ; \
+  logic [slot_num_mp-1:0]                      wvalid ; \
   \
-  logic [slot_num_lp-1:0] bready; \
+  logic [slot_num_mp-1:0]                      bready ; \
   \
-  logic [  slot_num_lp*id_width_p-1:0] arid   ; \
-  logic [slot_num_lp*addr_width_p-1:0] araddr ; \
-  logic [           slot_num_lp*8-1:0] arlen  ; \
-  logic [           slot_num_lp*3-1:0] arsize ; \
-  logic [             slot_num_lp-1:0] arvalid; \
-  logic [             slot_num_lp-1:0] rready ; \
+  logic [slot_num_mp-1:0][    id_width_mp-1:0] arid   ; \
+  logic [slot_num_mp-1:0][  addr_width_mp-1:0] araddr ; \
+  logic [slot_num_mp-1:0][              8-1:0] arlen  ; \
+  logic [slot_num_mp-1:0][              3-1:0] arsize ; \
+  logic [slot_num_mp-1:0]                      arvalid; \
+  logic [slot_num_mp-1:0]                      rready ; \
 } mosi_struct_name; \
 \
 typedef struct packed { \
-  logic [slot_num_lp-1:0] awready; \
-  logic [slot_num_lp-1:0] wready ; \
+  logic [slot_num_mp-1:0] awready; \
+  logic [slot_num_mp-1:0] wready ; \
   \
-  logic [slot_num_lp*id_width_p-1:0] bid   ; \
-  logic [         slot_num_lp*2-1:0] bresp ; \
-  logic [           slot_num_lp-1:0] bvalid; \
-  logic [           slot_num_lp-1:0] bready; \
+  logic [slot_num_mp-1:0][id_width_mp-1:0] bid   ; \
+  logic [slot_num_mp-1:0][          2-1:0] bresp ; \
+  logic [slot_num_mp-1:0]                  bvalid; \
+  logic [slot_num_mp-1:0]                  bready; \
   \
-  logic [             slot_num_lp-1:0] arready; \
-  logic [  slot_num_lp*id_width_p-1:0] rid    ; \
-  logic [slot_num_lp*data_width_p-1:0] rdata  ; \
-  logic [           slot_num_lp*2-1:0] rresp  ; \
-  logic [             slot_num_lp-1:0] rlast  ; \
-  logic [             slot_num_lp-1:0] rvalid ; \
+  logic [slot_num_mp-1:0]                    arready; \
+  logic [slot_num_mp-1:0][  id_width_mp-1:0] rid    ; \
+  logic [slot_num_mp-1:0][data_width_mp-1:0] rdata  ; \
+  logic [slot_num_mp-1:0][            2-1:0] rresp  ; \
+  logic [slot_num_mp-1:0]                    rlast  ; \
+  logic [slot_num_mp-1:0]                    rvalid ; \
 } miso_struct_name
 
-`define bsg_axi_mosi_bus_width(slot_num_lp, id_width_p, addr_width_p, data_width_p) \
-( slot_num_lp * \
-  (3*id_width_p + 2*addr_width_p + 2*8 + 2*3 + 6 + data_width_p + data_width_p/8) \
+`define bsg_axi_mosi_bus_width(slot_num_mp, id_width_mp, addr_width_mp, data_width_mp) \
+( slot_num_mp * \
+  (3*id_width_mp + 2*addr_width_mp + 2*8 + 2*3 + 6 + data_width_mp + data_width_mp/8) \
 )
 
-`define bsg_axi_miso_bus_width(slot_num_lp, id_width_p, addr_width_p, data_width_p) \
-( slot_num_lp * \
-  (7 + 2*id_width_p + 2*2 + data_width_p) \
+`define bsg_axi_miso_bus_width(slot_num_mp, id_width_mp, addr_width_mp, data_width_mp) \
+( slot_num_mp * \
+  (7 + 2*id_width_mp + 2*2 + data_width_mp) \
 )
 
 
-`define declare_bsg_axis_bus_s(data_width_p, mosi_struct_name, miso_struct_name) \
+// -----------------------------------------------------------
+// AXI4 (optional signals are disabled)
+// -----------------------------------------------------------
+`define declare_bsg_axi4_bus_s(slot_num_mp, id_width_mp, addr_width_mp, data_width_mp, mosi_struct_name, miso_struct_name) \
 typedef struct packed { \
-  logic [  data_width_p-1:0] txd_tdata ; \
-  logic [data_width_p/8-1:0] txd_tkeep ; \
-  logic                      txd_tlast ; \
-  logic                      txd_tvalid; \
+  logic [slot_num_mp-1:0][  id_width_mp-1:0] awid    ; \
+  logic [slot_num_mp-1:0][addr_width_mp-1:0] awaddr  ; \
+  logic [slot_num_mp-1:0][            8-1:0] awlen   ; \
+  logic [slot_num_mp-1:0][            3-1:0] awsize  ; \
+  logic [slot_num_mp-1:0][            2-1:0] awburst ; \
+  logic [slot_num_mp-1:0]                    awlock  ; \
+  logic [slot_num_mp-1:0][            4-1:0] awcache ; \
+  logic [slot_num_mp-1:0][            3-1:0] awprot  ; \
+  logic [slot_num_mp-1:0][            4-1:0] awqos   ; \
+  logic [slot_num_mp-1:0][            4-1:0] awregion; \
+  logic [slot_num_mp-1:0]                    awvalid ; \
+  \
+  logic [slot_num_mp-1:0][  data_width_mp-1:0] wdata ; \
+  logic [slot_num_mp-1:0][data_width_mp/8-1:0] wstrb ; \
+  logic [slot_num_mp-1:0]                      wlast ; \
+  logic [slot_num_mp-1:0]                      wvalid; \
+  \
+  logic [slot_num_mp-1:0] bready; \
+  \
+  logic [slot_num_mp-1:0][  id_width_mp-1:0] arid    ; \
+  logic [slot_num_mp-1:0][addr_width_mp-1:0] araddr  ; \
+  logic [slot_num_mp-1:0][            8-1:0] arlen   ; \
+  logic [slot_num_mp-1:0][            3-1:0] arsize  ; \
+  logic [slot_num_mp-1:0][            2-1:0] arburst ; \
+  logic [slot_num_mp-1:0]                    arlock  ; \
+  logic [slot_num_mp-1:0][            4-1:0] arcache ; \
+  logic [slot_num_mp-1:0][            3-1:0] arprot  ; \
+  logic [slot_num_mp-1:0][            4-1:0] arqos   ; \
+  logic [slot_num_mp-1:0][            4-1:0] arregion; \
+  logic [slot_num_mp-1:0]                    arvalid ; \
+  \
+  logic [slot_num_mp-1:0] rready; \
+} mosi_struct_name; \
+\
+typedef struct packed { \
+  logic [slot_num_mp-1:0] awready; \
+  \
+  logic [slot_num_mp-1:0] wready; \
+  \
+  logic [slot_num_mp-1:0][id_width_mp-1:0] bid   ; \
+  logic [slot_num_mp-1:0][          2-1:0] bresp ; \
+  logic [slot_num_mp-1:0]                  bvalid; \
+  \
+  logic [slot_num_mp-1:0] arready; \
+  \
+  logic [slot_num_mp-1:0][  id_width_mp-1:0] rid   ; \
+  logic [slot_num_mp-1:0][data_width_mp-1:0] rdata ; \
+  logic [slot_num_mp-1:0][            2-1:0] rresp ; \
+  logic [slot_num_mp-1:0]                    rlast ; \
+  logic [slot_num_mp-1:0]                    rvalid; \
+} miso_struct_name
+
+`define bsg_axi4_mosi_bus_width(slot_num_mp, id_width_mp, addr_width_mp, data_width_mp) \
+( slot_num_mp * (2*id_width_mp + 2*addr_width_mp + 2*8 + 4*3 + 2*2 + 6*4 + 8 + data_width_mp + data_width_mp/8))
+
+`define bsg_axi4_miso_bus_width(slot_num_mp, id_width_mp, addr_width_mp, data_width_mp) \
+(slot_num_mp * (6 + 2*id_width_mp + 2*2 + data_width_mp))
+
+
+// -----------------------------------------------------------
+// AXI STREAM
+// -----------------------------------------------------------
+`define declare_bsg_axis_bus_s(data_width_mp, mosi_struct_name, miso_struct_name) \
+typedef struct packed { \
+  logic [  data_width_mp-1:0] txd_tdata ; \
+  logic [data_width_mp/8-1:0] txd_tkeep ; \
+  logic                       txd_tlast ; \
+  logic                       txd_tvalid; \
   \
   logic rxd_tready; \
 } mosi_struct_name; \
 \
 typedef struct packed { \
-  logic txd_tready; \
-  logic [  data_width_p-1:0] rxd_tdata ; \
-  logic [data_width_p/8-1:0] rxd_tkeep ; \
-  logic                      rxd_tlast ; \
-  logic                      rxd_tvalid; \
+  logic                       txd_tready; \
+  logic [  data_width_mp-1:0] rxd_tdata ; \
+  logic [data_width_mp/8-1:0] rxd_tkeep ; \
+  logic                       rxd_tlast ; \
+  logic                       rxd_tvalid; \
 } miso_struct_name
 
-`define bsg_axis_bus_width(data_width_p) \
-  (data_width_p + 3 + data_width_p/8)
+`define bsg_axis_bus_width(data_width_mp) \
+  (data_width_mp + 3 + data_width_mp/8)
 
 `endif

--- a/hardware/bsg_bladerunner_mem_cfg_pkg.v
+++ b/hardware/bsg_bladerunner_mem_cfg_pkg.v
@@ -7,15 +7,15 @@ package bsg_bladerunner_mem_cfg_pkg;
   `include "bsg_defines.v"
 
   localparam max_cfgs = 128;
-  localparam lg_max_cfgs = `BSG_SAFE_CLOG2(max_cfgs); 
+  localparam lg_max_cfgs = `BSG_SAFE_CLOG2(max_cfgs);
 
   // Bladerunner Memory Configuration enum
-  // 
+  //
   // The enum naming convention describes which memory system is being used.
   // It roughly divides into three levels of hierarchy.
   //
   // e_{cache/block_mem}_{interface}_{backend_memory}
-  //    
+  //
   //
   // LEVEL 1) What is attached to manycore link on the south side. This could be the
   //          last level of hierarchy, if it's block mem, or infinite memory, for
@@ -31,7 +31,7 @@ package bsg_bladerunner_mem_cfg_pkg;
   //          - aib_ (convert to AIB interface)
   //
   // LEVEL 3) What is being used as the last main memory.
-  //          - nonsynth_mem 
+  //          - nonsynth_mem
   //          - lpddr4 (ex. micron sim model)
   //          - f1_ddr
   //
@@ -41,7 +41,7 @@ package bsg_bladerunner_mem_cfg_pkg;
     // LEVEL 1) zero-latency, infinite capacity block mem.
     //          (uses associative array)
     e_infinite_mem
-    
+
     // LEVEL 1) bsg_manycore_vcache (blocking)
     // LEVEL 2) bsg_cache_to_axi
     // LEVEl 3) bsg_nonsynth_manycore_axi_mem
@@ -49,13 +49,14 @@ package bsg_bladerunner_mem_cfg_pkg;
     // e_vcache_blocking_axi4_f1_dram directs simulation to use the
     // slower, but more accurate, DDR Model. The default is
     // e_vcache_blocking_axi4_f1_model uses an (infinite) AXI memory
-    // model with low (1-2 cycle) latency in simulation. 
-    //                                      
+    // model with low (1-2 cycle) latency in simulation.
+    //
     // Either value produces the correct DDR4 Module in F1
     // implemenation
     , e_vcache_blocking_axi4_f1_dram
     , e_vcache_blocking_axi4_f1_model
-
+    , e_vcache_blocking_axi4_f1_ddrx4
+    , e_vcache_blocking_axi4_f1_ddr_modelx4 // memory model not well supported?
   } bsg_bladerunner_mem_cfg_e;
 
 endpackage

--- a/hardware/bsg_bladerunner_mem_cfg_pkg.v
+++ b/hardware/bsg_bladerunner_mem_cfg_pkg.v
@@ -56,7 +56,7 @@ package bsg_bladerunner_mem_cfg_pkg;
     , e_vcache_blocking_axi4_f1_dram
     , e_vcache_blocking_axi4_f1_model
     , e_vcache_blocking_axi4_f1_ddrx4
-    , e_vcache_blocking_axi4_f1_ddr_modelx4 // memory model not well supported?
+    , e_vcache_blocking_axi4_f1_ddrx4_model
   } bsg_bladerunner_mem_cfg_e;
 
 endpackage

--- a/hardware/cl_manycore.sv
+++ b/hardware/cl_manycore.sv
@@ -420,7 +420,7 @@ module cl_manycore
   else if (mem_cfg_p == e_vcache_blocking_axi4_f1_dram ||
            mem_cfg_p == e_vcache_blocking_axi4_f1_model ||
            mem_cfg_p == e_vcache_blocking_axi4_f1_ddrx4 ||
-           mem_cfg_p == e_vcache_blocking_axi4_f1_ddr_modelx4) begin: lv1_vcache
+           mem_cfg_p == e_vcache_blocking_axi4_f1_ddrx4_model) begin: lv1_vcache
 
     import bsg_cache_pkg::*;
 
@@ -615,7 +615,7 @@ module cl_manycore
   // LEVEL 2
   //
   if (mem_cfg_p == e_vcache_blocking_axi4_f1_ddrx4 ||
-      mem_cfg_p == e_vcache_blocking_axi4_f1_ddr_modelx4) begin: lv2_axi4_x4
+      mem_cfg_p == e_vcache_blocking_axi4_f1_ddrx4_model) begin: lv2_axi4_x4
 
     for (genvar i = 0; i < num_tiles_x_p; i++) begin : cache_to_axi
       bsg_cache_to_axi_hashed #(
@@ -927,7 +927,7 @@ module cl_manycore
 
   end // if (mem_cfg_p == e_vcache_blocking_axi4_f1_dram)
   else if (mem_cfg_p == e_vcache_blocking_axi4_f1_ddrx4 ||
-      mem_cfg_p == e_vcache_blocking_axi4_f1_ddr_modelx4) begin : axi4_x4_cast
+           mem_cfg_p == e_vcache_blocking_axi4_f1_ddrx4_model) begin : axi4_x4_cast
 
     localparam DEVICE_FAMILY_LP = "virtexuplus";
     localparam num_cl_ddr_lp = 3;
@@ -1104,8 +1104,7 @@ module cl_manycore
       .cl_RST_DIMM_D_N    (cl_RST_DIMM_D_N                                             )
     );
 
-  end
-
+  end 
 
    // manycore link
 

--- a/hardware/cl_manycore_defines.vh
+++ b/hardware/cl_manycore_defines.vh
@@ -1,19 +1,19 @@
 // Copyright (c) 2019, University of Washington All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
-// 
+//
 // Redistributions of source code must retain the above copyright notice, this list
 // of conditions and the following disclaimer.
-// 
+//
 // Redistributions in binary form must reproduce the above copyright notice, this
 // list of conditions and the following disclaimer in the documentation and/or
 // other materials provided with the distribution.
-// 
+//
 // Neither the name of the copyright holder nor the names of its contributors may
 // be used to endorse or promote products derived from this software without
 // specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 // ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -43,6 +43,25 @@
 // Define macros for the manycore hardware
 `define axi4_to_sh_ddr_num 2
 
+// Defining local macros that will instantiate the desired DDR controllers in
+// the CL.
+`ifndef DDR_A_ABSENT
+  `define DDR_A_PRESENT 1
+`else
+  `define DDR_A_PRESENT 0
+`endif
+
+`ifndef DDR_B_ABSENT
+  `define DDR_B_PRESENT 1
+`else
+  `define DDR_B_PRESENT 0
+`endif
+
+`ifndef DDR_D_ABSENT
+  `define DDR_D_PRESENT 1
+`else
+  `define DDR_D_PRESENT 0
+`endif
 
 `endif
 

--- a/hardware/cl_sh_ddr_wrapper.v
+++ b/hardware/cl_sh_ddr_wrapper.v
@@ -1,0 +1,401 @@
+/**
+*  cl_sh_ddr_wrapper.v
+*
+*/
+
+`include "bsg_axi_bus_pkg.vh"
+`include "cl_manycore_defines.vh"
+
+module cl_sh_ddr_wrapper #(
+  parameter num_axi4_p = 3
+  , parameter axi4_id_width_p = "inv"
+  , parameter axi4_addr_width_p = "inv"
+  , parameter axi4_data_width_p = "inv"
+  , localparam axi4_mosi_bus_width_lp = `bsg_axi4_mosi_bus_width(num_axi4_p, axi4_id_width_p, axi4_addr_width_p, axi4_data_width_p)
+  , localparam axi4_miso_bus_width_lp = `bsg_axi4_miso_bus_width(num_axi4_p, axi4_id_width_p, axi4_addr_width_p, axi4_data_width_p)
+) (
+  input                                     clk_i
+  ,input                                     reset_i
+  // ------------------- STATS -----------------------------------------------------------
+  ,output                                    cl_RST_DIMM_D_N
+  ,input  [            num_axi4_p-1:0][ 7:0] sh_ddr_stat_addr_i
+  ,input  [            num_axi4_p-1:0]       sh_ddr_stat_wr_i
+  ,input  [            num_axi4_p-1:0]       sh_ddr_stat_rd_i
+  ,input  [            num_axi4_p-1:0][31:0] sh_ddr_stat_wdata_i
+  ,output [            num_axi4_p-1:0]       ddr_sh_stat_ack_o
+  ,output [            num_axi4_p-1:0][31:0] ddr_sh_stat_rdata_o
+  ,output [            num_axi4_p-1:0][ 7:0] ddr_sh_stat_int_o
+  ,input  [axi4_mosi_bus_width_lp-1:0]       s_axi4_i
+  ,output [axi4_miso_bus_width_lp-1:0]       s_axi4_o
+  // ------------------- DDR4 x72 RDIMM 2100 Interface A ----------------------------------
+  ,input                                     CLK_300M_DIMM0_DP
+  ,input                                     CLK_300M_DIMM0_DN
+  ,output                                    M_A_ACT_N
+  ,output [                      16:0]       M_A_MA
+  ,output [                       1:0]       M_A_BA
+  ,output [                       1:0]       M_A_BG
+  ,output [                       0:0]       M_A_CKE
+  ,output [                       0:0]       M_A_ODT
+  ,output [                       0:0]       M_A_CS_N
+  ,output [                       0:0]       M_A_CLK_DN
+  ,output [                       0:0]       M_A_CLK_DP
+  ,output                                    M_A_PAR
+  ,inout  [                      63:0]       M_A_DQ
+  ,inout  [                       7:0]       M_A_ECC
+  ,inout  [                      17:0]       M_A_DQS_DP
+  ,inout  [                      17:0]       M_A_DQS_DN
+  ,output                                    cl_RST_DIMM_A_N
+  // ------------------- DDR4 x72 RDIMM 2100 Interface B ----------------------------------
+  ,input                                     CLK_300M_DIMM1_DP
+  ,input                                     CLK_300M_DIMM1_DN
+  ,output                                    M_B_ACT_N
+  ,output [                      16:0]       M_B_MA
+  ,output [                       1:0]       M_B_BA
+  ,output [                       1:0]       M_B_BG
+  ,output [                       0:0]       M_B_CKE
+  ,output [                       0:0]       M_B_ODT
+  ,output [                       0:0]       M_B_CS_N
+  ,output [                       0:0]       M_B_CLK_DN
+  ,output [                       0:0]       M_B_CLK_DP
+  ,output                                    M_B_PAR
+  ,inout  [                      63:0]       M_B_DQ
+  ,inout  [                       7:0]       M_B_ECC
+  ,inout  [                      17:0]       M_B_DQS_DP
+  ,inout  [                      17:0]       M_B_DQS_DN
+  ,output                                    cl_RST_DIMM_B_N
+  // ------------------- DDR4 x72 RDIMM 2100 Interface D ----------------------------------
+  ,input                                     CLK_300M_DIMM3_DP
+  ,input                                     CLK_300M_DIMM3_DN
+  ,output                                    M_D_ACT_N
+  ,output [                      16:0]       M_D_MA
+  ,output [                       1:0]       M_D_BA
+  ,output [                       1:0]       M_D_BG
+  ,output [                       0:0]       M_D_CKE
+  ,output [                       0:0]       M_D_ODT
+  ,output [                       0:0]       M_D_CS_N
+  ,output [                       0:0]       M_D_CLK_DN
+  ,output [                       0:0]       M_D_CLK_DP
+  ,output                                    M_D_PAR
+  ,inout  [                      63:0]       M_D_DQ
+  ,inout  [                       7:0]       M_D_ECC
+  ,inout  [                      17:0]       M_D_DQS_DP
+  ,inout  [                      17:0]       M_D_DQS_DN
+);
+
+`declare_bsg_axi4_bus_s(num_axi4_p, axi4_id_width_p, axi4_addr_width_p, axi4_data_width_p, bsg_axi4_hs_mosi_s, bsg_axi4_hs_miso_s);
+
+bsg_axi4_hs_mosi_s m_axi4_ddr_hs_lo;
+bsg_axi4_hs_miso_s m_axi4_ddr_hs_li;
+
+assign m_axi4_ddr_hs_lo = s_axi4_i;
+assign s_axi4_o         = m_axi4_ddr_hs_li;
+
+localparam axi4_ddr_id_width_lp   = 16 ;
+localparam axi4_ddr_addr_width_lp = 64 ;
+localparam axi4_ddr_data_width_lp = 512;
+
+`declare_bsg_axi4_bus_s(num_axi4_p, axi4_ddr_id_width_lp, axi4_ddr_addr_width_lp, axi4_data_width_p, axi4_cl_ddr_mosi_s, axi4_cl_ddr_miso_s);
+
+axi4_cl_ddr_mosi_s s_axi4_cl_ddr_li;
+axi4_cl_ddr_miso_s s_axi4_cl_ddr_lo;
+
+// signal cast to ddr
+//
+for (genvar i = 0; i < num_axi4_p; i++) begin : ddr_cast
+
+  // mosi
+  assign s_axi4_cl_ddr_li.awid[i] = m_axi4_ddr_hs_lo.awid[i];
+  assign s_axi4_cl_ddr_li.awaddr[i]  = m_axi4_ddr_hs_lo.awaddr[i];
+  assign s_axi4_cl_ddr_li.awlen[i]   = m_axi4_ddr_hs_lo.awlen[i];
+  assign s_axi4_cl_ddr_li.awsize[i]  = m_axi4_ddr_hs_lo.awsize[i];
+  assign s_axi4_cl_ddr_li.awburst[i] = m_axi4_ddr_hs_lo.awburst[i];
+  // assign s_axi4_cl_ddr_li.awlock[i] = m_axi4_ddr_hs_lo.awlock[i];
+  // assign s_axi4_cl_ddr_li.awcache[i] = m_axi4_ddr_hs_lo.awcache[i];
+  // assign s_axi4_cl_ddr_li.awprot[i] = m_axi4_ddr_hs_lo.awprot[i];
+  // assign s_axi4_cl_ddr_li.awqos[i] = m_axi4_ddr_hs_lo.awqos[i];
+  // assign s_axi4_cl_ddr_li.awregion[i] = m_axi4_ddr_hs_lo.awregion[i];
+  assign s_axi4_cl_ddr_li.awvalid[i] = m_axi4_ddr_hs_lo.awvalid[i];
+
+  assign s_axi4_cl_ddr_li.wdata[i]  = m_axi4_ddr_hs_lo.wdata[i];
+  assign s_axi4_cl_ddr_li.wstrb[i]  = m_axi4_ddr_hs_lo.wstrb[i];
+  assign s_axi4_cl_ddr_li.wlast[i]  = m_axi4_ddr_hs_lo.wlast[i];
+  assign s_axi4_cl_ddr_li.wvalid[i] = m_axi4_ddr_hs_lo.wvalid[i];
+
+  assign s_axi4_cl_ddr_li.bready[i] = m_axi4_ddr_hs_lo.bready[i];
+
+  assign s_axi4_cl_ddr_li.arid[i]    = m_axi4_ddr_hs_lo.arid[i];
+  assign s_axi4_cl_ddr_li.araddr[i]  = m_axi4_ddr_hs_lo.araddr[i];
+  assign s_axi4_cl_ddr_li.arlen[i]   = m_axi4_ddr_hs_lo.arlen[i];
+  assign s_axi4_cl_ddr_li.arsize[i]  = m_axi4_ddr_hs_lo.arsize[i];
+  assign s_axi4_cl_ddr_li.arburst[i] = m_axi4_ddr_hs_lo.arburst[i];
+  // assign s_axi4_cl_ddr_li.arlock[i] = m_axi4_ddr_hs_lo.arlock[i];
+  // assign s_axi4_cl_ddr_li.arcache[i] = m_axi4_ddr_hs_lo.arcache[i];
+  // assign s_axi4_cl_ddr_li.arprot[i] = m_axi4_ddr_hs_lo.arprot[i];
+  // assign s_axi4_cl_ddr_li.arqos[i] = m_axi4_ddr_hs_lo.arqos[i];
+  // assign s_axi4_cl_ddr_li.arregion[i] = m_axi4_ddr_hs_lo.arregion[i];
+  assign s_axi4_cl_ddr_li.arvalid[i] = m_axi4_ddr_hs_lo.arvalid[i];
+
+  assign s_axi4_cl_ddr_li.rready[i] = m_axi4_ddr_hs_lo.rready[i];
+
+  // miso
+  assign m_axi4_ddr_hs_li.awready[i] = s_axi4_cl_ddr_lo.awready[i];
+
+  assign m_axi4_ddr_hs_li.wready[i] = s_axi4_cl_ddr_lo.wready[i];
+
+  assign m_axi4_ddr_hs_li.bid[i]    = s_axi4_cl_ddr_lo.bid[i];
+  assign m_axi4_ddr_hs_li.bresp[i]  = s_axi4_cl_ddr_lo.bresp[i];
+  assign m_axi4_ddr_hs_li.bvalid[i] = s_axi4_cl_ddr_lo.bvalid[i];
+
+  assign m_axi4_ddr_hs_li.arready[i] = s_axi4_cl_ddr_lo.arready[i];
+
+  assign m_axi4_ddr_hs_li.rid[i]    = s_axi4_cl_ddr_lo.rid[i];
+  assign m_axi4_ddr_hs_li.rdata[i]  = s_axi4_cl_ddr_lo.rdata[i];
+  assign m_axi4_ddr_hs_li.rresp[i]  = s_axi4_cl_ddr_lo.rresp[i];
+  assign m_axi4_ddr_hs_li.rlast[i]  = s_axi4_cl_ddr_lo.rlast[i];
+  assign m_axi4_ddr_hs_li.rvalid[i] = s_axi4_cl_ddr_lo.rvalid[i];
+
+end : ddr_cast
+
+wire [15:0] cl_sh_ddr_wid_2d[2:0];
+
+assign cl_sh_ddr_wid_2d = '{16'b0, 16'b0, 16'b0};
+
+//convert to 2D
+logic [15:0] cl_sh_ddr_awid_2d   [2:0];
+logic [63:0] cl_sh_ddr_awaddr_2d [2:0];
+logic [ 7:0] cl_sh_ddr_awlen_2d  [2:0];
+logic [ 2:0] cl_sh_ddr_awsize_2d [2:0];
+logic [ 1:0] cl_sh_ddr_awburst_2d[2:0];
+logic        cl_sh_ddr_awvalid_2d[2:0];
+logic [ 2:0] sh_cl_ddr_awready_2d     ;
+
+logic [ 15:0] cl_sh_ddr_wid_2d   [2:0];
+logic [511:0] cl_sh_ddr_wdata_2d [2:0];
+logic [ 63:0] cl_sh_ddr_wstrb_2d [2:0];
+logic [  2:0] cl_sh_ddr_wlast_2d      ;
+logic [  2:0] cl_sh_ddr_wvalid_2d     ;
+logic [  2:0] sh_cl_ddr_wready_2d     ;
+
+logic [15:0] sh_cl_ddr_bid_2d   [2:0];
+logic [ 1:0] sh_cl_ddr_bresp_2d [2:0];
+logic [ 2:0] sh_cl_ddr_bvalid_2d     ;
+logic [ 2:0] cl_sh_ddr_bready_2d     ;
+
+logic [15:0] cl_sh_ddr_arid_2d   [2:0];
+logic [63:0] cl_sh_ddr_araddr_2d [2:0];
+logic [ 7:0] cl_sh_ddr_arlen_2d  [2:0];
+logic [ 2:0] cl_sh_ddr_arsize_2d [2:0];
+logic [ 1:0] cl_sh_ddr_arburst_2d[2:0];
+logic [ 2:0] cl_sh_ddr_arvalid_2d     ;
+logic [ 2:0] sh_cl_ddr_arready_2d     ;
+
+logic [ 15:0] sh_cl_ddr_rid_2d   [2:0];
+logic [511:0] sh_cl_ddr_rdata_2d [2:0];
+logic [  1:0] sh_cl_ddr_rresp_2d [2:0];
+logic [  2:0] sh_cl_ddr_rlast_2d      ;
+logic [  2:0] sh_cl_ddr_rvalid_2d     ;
+logic [  2:0] cl_sh_ddr_rready_2d     ;
+
+assign cl_sh_ddr_awid_2d    = '{s_axi4_cl_ddr_li.awid[2], s_axi4_cl_ddr_li.awid[1], s_axi4_cl_ddr_li.awid[0]};
+assign cl_sh_ddr_awaddr_2d  = '{s_axi4_cl_ddr_li.awaddr[2], s_axi4_cl_ddr_li.awaddr[1], s_axi4_cl_ddr_li.awaddr[0]};
+assign cl_sh_ddr_awlen_2d   = '{s_axi4_cl_ddr_li.awlen[2], s_axi4_cl_ddr_li.awlen[1], s_axi4_cl_ddr_li.awlen[0]};
+assign cl_sh_ddr_awsize_2d  = '{s_axi4_cl_ddr_li.awsize[2], s_axi4_cl_ddr_li.awsize[1], s_axi4_cl_ddr_li.awsize[0]};
+assign cl_sh_ddr_awvalid_2d = '{s_axi4_cl_ddr_li.awvalid[2], s_axi4_cl_ddr_li.awvalid[1], s_axi4_cl_ddr_li.awvalid[0]};
+assign cl_sh_ddr_awburst_2d = {s_axi4_cl_ddr_li.awburst[2], s_axi4_cl_ddr_li.awburst[1], s_axi4_cl_ddr_li.awburst[0]};
+assign {s_axi4_cl_ddr_lo.awready[2], s_axi4_cl_ddr_lo.awready[1], s_axi4_cl_ddr_lo.awready[0]} = sh_cl_ddr_awready_2d;
+
+// assign cl_sh_ddr_wid_2d = '{lcl_cl_sh_ddrd.wid, lcl_cl_sh_ddrb.wid, lcl_cl_sh_ddra.wid};
+assign cl_sh_ddr_wdata_2d  = '{s_axi4_cl_ddr_li.wdata[2], s_axi4_cl_ddr_li.wdata[1], s_axi4_cl_ddr_li.wdata[0]};
+assign cl_sh_ddr_wstrb_2d  = '{s_axi4_cl_ddr_li.wstrb[2], s_axi4_cl_ddr_li.wstrb[1], s_axi4_cl_ddr_li.wstrb[0]};
+assign cl_sh_ddr_wlast_2d  = {s_axi4_cl_ddr_li.wlast[2], s_axi4_cl_ddr_li.wlast[1], s_axi4_cl_ddr_li.wlast[0]};
+assign cl_sh_ddr_wvalid_2d = {s_axi4_cl_ddr_li.wvalid[2], s_axi4_cl_ddr_li.wvalid[1], s_axi4_cl_ddr_li.wvalid[0]};
+assign {s_axi4_cl_ddr_lo.wready[2], s_axi4_cl_ddr_lo.wready[1], s_axi4_cl_ddr_lo.wready[0]} = sh_cl_ddr_wready_2d;
+
+assign {s_axi4_cl_ddr_lo.bid[2], s_axi4_cl_ddr_lo.bid[1], s_axi4_cl_ddr_lo.bid[0]} = {sh_cl_ddr_bid_2d[2], sh_cl_ddr_bid_2d[1], sh_cl_ddr_bid_2d[0]};
+assign {s_axi4_cl_ddr_lo.bresp[2], s_axi4_cl_ddr_lo.bresp[1], s_axi4_cl_ddr_lo.bresp[0]} = {sh_cl_ddr_bresp_2d[2], sh_cl_ddr_bresp_2d[1], sh_cl_ddr_bresp_2d[0]};
+assign {s_axi4_cl_ddr_lo.bvalid[2], s_axi4_cl_ddr_lo.bvalid[1], s_axi4_cl_ddr_lo.bvalid[0]} = sh_cl_ddr_bvalid_2d;
+assign cl_sh_ddr_bready_2d = {s_axi4_cl_ddr_li.bready[2], s_axi4_cl_ddr_li.bready[1], s_axi4_cl_ddr_li.bready[0]};
+
+assign cl_sh_ddr_arid_2d    = '{s_axi4_cl_ddr_li.arid[2], s_axi4_cl_ddr_li.arid[1], s_axi4_cl_ddr_li.arid[0]};
+assign cl_sh_ddr_araddr_2d  = '{s_axi4_cl_ddr_li.araddr[2], s_axi4_cl_ddr_li.araddr[1], s_axi4_cl_ddr_li.araddr[0]};
+assign cl_sh_ddr_arlen_2d   = '{s_axi4_cl_ddr_li.arlen[2], s_axi4_cl_ddr_li.arlen[1], s_axi4_cl_ddr_li.arlen[0]};
+assign cl_sh_ddr_arsize_2d  = '{s_axi4_cl_ddr_li.arsize[2], s_axi4_cl_ddr_li.arsize[1], s_axi4_cl_ddr_li.arsize[0]};
+assign cl_sh_ddr_arvalid_2d = {s_axi4_cl_ddr_li.arvalid[2], s_axi4_cl_ddr_li.arvalid[1], s_axi4_cl_ddr_li.arvalid[0]};
+assign cl_sh_ddr_arburst_2d = {s_axi4_cl_ddr_li.arburst[2], s_axi4_cl_ddr_li.arburst[1], s_axi4_cl_ddr_li.arburst[0]};
+assign {s_axi4_cl_ddr_lo.arready[2], s_axi4_cl_ddr_lo.arready[1], s_axi4_cl_ddr_lo.arready[0]} = sh_cl_ddr_arready_2d;
+
+assign {s_axi4_cl_ddr_lo.rid[2], s_axi4_cl_ddr_lo.rid[1], s_axi4_cl_ddr_lo.rid[0]} = {sh_cl_ddr_rid_2d[2], sh_cl_ddr_rid_2d[1], sh_cl_ddr_rid_2d[0]};
+assign {s_axi4_cl_ddr_lo.rresp[2], s_axi4_cl_ddr_lo.rresp[1], s_axi4_cl_ddr_lo.rresp[0]} = {sh_cl_ddr_rresp_2d[2], sh_cl_ddr_rresp_2d[1], sh_cl_ddr_rresp_2d[0]};
+assign {s_axi4_cl_ddr_lo.rdata[2], s_axi4_cl_ddr_lo.rdata[1], s_axi4_cl_ddr_lo.rdata[0]} = {sh_cl_ddr_rdata_2d[2], sh_cl_ddr_rdata_2d[1], sh_cl_ddr_rdata_2d[0]};
+assign {s_axi4_cl_ddr_lo.rlast[2], s_axi4_cl_ddr_lo.rlast[1], s_axi4_cl_ddr_lo.rlast[0]} = sh_cl_ddr_rlast_2d;
+assign {s_axi4_cl_ddr_lo.rvalid[2], s_axi4_cl_ddr_lo.rvalid[1], s_axi4_cl_ddr_lo.rvalid[0]} = sh_cl_ddr_rvalid_2d;
+assign cl_sh_ddr_rready_2d = {s_axi4_cl_ddr_li.rready[2], s_axi4_cl_ddr_li.rready[1], s_axi4_cl_ddr_li.rready[0]};
+
+
+//-----------------------------------------
+// DDR controller instantiation
+//-----------------------------------------
+localparam NUM_CFG_STGS_CL_DDR_LP = 8;
+
+logic [ 7:0] sh_ddr_stat_addr_q [2:0];
+logic [ 2:0] sh_ddr_stat_wr_q        ;
+logic [ 2:0] sh_ddr_stat_rd_q        ;
+logic [31:0] sh_ddr_stat_wdata_q[2:0];
+logic [ 2:0] ddr_sh_stat_ack_q       ;
+logic [31:0] ddr_sh_stat_rdata_q[2:0];
+logic [ 7:0] ddr_sh_stat_int_q  [2:0];
+
+for (genvar i = 0; i < num_axi4_p; i++) begin : stat_buf
+
+  lib_pipe #(.WIDTH(1+1+8+32), .STAGES(NUM_CFG_STGS_CL_DDR_LP)) PIPE_DDR_STAT (
+    .clk    (clk_i                                                                                    ),
+    .rst_n  (~reset_i                                                                                 ),
+    .in_bus ({sh_ddr_stat_wr_i[i], sh_ddr_stat_rd_i[i], sh_ddr_stat_addr_i[i], sh_ddr_stat_wdata_i[i]}),
+    .out_bus({sh_ddr_stat_wr_q[i], sh_ddr_stat_rd_q[i], sh_ddr_stat_addr_q[i], sh_ddr_stat_wdata_q[i]})
+  );
+
+
+  lib_pipe #(.WIDTH(1+8+32), .STAGES(NUM_CFG_STGS_CL_DDR_LP)) PIPE_DDR_STAT_ACK (
+    .clk    (clk_i                                                               ),
+    .rst_n  (~reset_i                                                            ),
+    .in_bus ({ddr_sh_stat_ack_q[i], ddr_sh_stat_int_q[i], ddr_sh_stat_rdata_q[i]}),
+    .out_bus({ddr_sh_stat_ack_o[i], ddr_sh_stat_int_o[i], ddr_sh_stat_rdata_o[i]})
+  );
+
+end
+
+(* dont_touch = "true" *) logic sh_ddr_sync_rst_n;
+lib_pipe #(.WIDTH(1), .STAGES(4)) SH_DDR_SLC_RST_N (.clk(clk_i), .rst_n(1'b1), .in_bus(~reset_i), .out_bus(sh_ddr_sync_rst_n));
+sh_ddr #(
+  .DDR_A_PRESENT(`DDR_A_PRESENT),
+  .DDR_B_PRESENT(`DDR_B_PRESENT),
+  .DDR_D_PRESENT(`DDR_D_PRESENT)
+) SH_DDR (
+  .clk               (clk_i                 ),
+  .rst_n             (sh_ddr_sync_rst_n     ),
+
+  .stat_clk          (clk_i                 ),
+  .stat_rst_n        (sh_ddr_sync_rst_n     ),
+
+
+  .CLK_300M_DIMM0_DP (CLK_300M_DIMM0_DP     ),
+  .CLK_300M_DIMM0_DN (CLK_300M_DIMM0_DN     ),
+  .M_A_ACT_N         (M_A_ACT_N             ),
+  .M_A_MA            (M_A_MA                ),
+  .M_A_BA            (M_A_BA                ),
+  .M_A_BG            (M_A_BG                ),
+  .M_A_CKE           (M_A_CKE               ),
+  .M_A_ODT           (M_A_ODT               ),
+  .M_A_CS_N          (M_A_CS_N              ),
+  .M_A_CLK_DN        (M_A_CLK_DN            ),
+  .M_A_CLK_DP        (M_A_CLK_DP            ),
+  .M_A_PAR           (M_A_PAR               ),
+  .M_A_DQ            (M_A_DQ                ),
+  .M_A_ECC           (M_A_ECC               ),
+  .M_A_DQS_DP        (M_A_DQS_DP            ),
+  .M_A_DQS_DN        (M_A_DQS_DN            ),
+  .cl_RST_DIMM_A_N   (cl_RST_DIMM_A_N       ),
+
+
+  .CLK_300M_DIMM1_DP (CLK_300M_DIMM1_DP     ),
+  .CLK_300M_DIMM1_DN (CLK_300M_DIMM1_DN     ),
+  .M_B_ACT_N         (M_B_ACT_N             ),
+  .M_B_MA            (M_B_MA                ),
+  .M_B_BA            (M_B_BA                ),
+  .M_B_BG            (M_B_BG                ),
+  .M_B_CKE           (M_B_CKE               ),
+  .M_B_ODT           (M_B_ODT               ),
+  .M_B_CS_N          (M_B_CS_N              ),
+  .M_B_CLK_DN        (M_B_CLK_DN            ),
+  .M_B_CLK_DP        (M_B_CLK_DP            ),
+  .M_B_PAR           (M_B_PAR               ),
+  .M_B_DQ            (M_B_DQ                ),
+  .M_B_ECC           (M_B_ECC               ),
+  .M_B_DQS_DP        (M_B_DQS_DP            ),
+  .M_B_DQS_DN        (M_B_DQS_DN            ),
+  .cl_RST_DIMM_B_N   (cl_RST_DIMM_B_N       ),
+
+  .CLK_300M_DIMM3_DP (CLK_300M_DIMM3_DP     ),
+  .CLK_300M_DIMM3_DN (CLK_300M_DIMM3_DN     ),
+  .M_D_ACT_N         (M_D_ACT_N             ),
+  .M_D_MA            (M_D_MA                ),
+  .M_D_BA            (M_D_BA                ),
+  .M_D_BG            (M_D_BG                ),
+  .M_D_CKE           (M_D_CKE               ),
+  .M_D_ODT           (M_D_ODT               ),
+  .M_D_CS_N          (M_D_CS_N              ),
+  .M_D_CLK_DN        (M_D_CLK_DN            ),
+  .M_D_CLK_DP        (M_D_CLK_DP            ),
+  .M_D_PAR           (M_D_PAR               ),
+  .M_D_DQ            (M_D_DQ                ),
+  .M_D_ECC           (M_D_ECC               ),
+  .M_D_DQS_DP        (M_D_DQS_DP            ),
+  .M_D_DQS_DN        (M_D_DQS_DN            ),
+  .cl_RST_DIMM_D_N   (cl_RST_DIMM_D_N       ),
+
+  //------------------------------------------------------
+  // DDR-4 Interface from CL (AXI-4)
+  //------------------------------------------------------
+  .cl_sh_ddr_awid    (cl_sh_ddr_awid_2d     ),
+  .cl_sh_ddr_awaddr  (cl_sh_ddr_awaddr_2d   ),
+  .cl_sh_ddr_awlen   (cl_sh_ddr_awlen_2d    ),
+  .cl_sh_ddr_awsize  (cl_sh_ddr_awsize_2d   ),
+  .cl_sh_ddr_awvalid (cl_sh_ddr_awvalid_2d  ),
+  .cl_sh_ddr_awburst (cl_sh_ddr_awburst_2d  ),
+  .sh_cl_ddr_awready (sh_cl_ddr_awready_2d  ),
+
+  .cl_sh_ddr_wid     (cl_sh_ddr_wid_2d      ),
+  .cl_sh_ddr_wdata   (cl_sh_ddr_wdata_2d    ),
+  .cl_sh_ddr_wstrb   (cl_sh_ddr_wstrb_2d    ),
+  .cl_sh_ddr_wlast   (cl_sh_ddr_wlast_2d    ),
+  .cl_sh_ddr_wvalid  (cl_sh_ddr_wvalid_2d   ),
+  .sh_cl_ddr_wready  (sh_cl_ddr_wready_2d   ),
+
+  .sh_cl_ddr_bid     (sh_cl_ddr_bid_2d      ),
+  .sh_cl_ddr_bresp   (sh_cl_ddr_bresp_2d    ),
+  .sh_cl_ddr_bvalid  (sh_cl_ddr_bvalid_2d   ),
+  .cl_sh_ddr_bready  (cl_sh_ddr_bready_2d   ),
+
+  .cl_sh_ddr_arid    (cl_sh_ddr_arid_2d     ),
+  .cl_sh_ddr_araddr  (cl_sh_ddr_araddr_2d   ),
+  .cl_sh_ddr_arlen   (cl_sh_ddr_arlen_2d    ),
+  .cl_sh_ddr_arsize  (cl_sh_ddr_arsize_2d   ),
+  .cl_sh_ddr_arvalid (cl_sh_ddr_arvalid_2d  ),
+  .cl_sh_ddr_arburst (cl_sh_ddr_arburst_2d  ),
+  .sh_cl_ddr_arready (sh_cl_ddr_arready_2d  ),
+
+  .sh_cl_ddr_rid     (sh_cl_ddr_rid_2d      ),
+  .sh_cl_ddr_rdata   (sh_cl_ddr_rdata_2d    ),
+  .sh_cl_ddr_rresp   (sh_cl_ddr_rresp_2d    ),
+  .sh_cl_ddr_rlast   (sh_cl_ddr_rlast_2d    ),
+  .sh_cl_ddr_rvalid  (sh_cl_ddr_rvalid_2d   ),
+  .cl_sh_ddr_rready  (cl_sh_ddr_rready_2d   ),
+
+  .sh_cl_ddr_is_ready(lcl_sh_cl_ddr_is_ready),
+
+  .sh_ddr_stat_addr0 (sh_ddr_stat_addr_q[0] ),
+  .sh_ddr_stat_wr0   (sh_ddr_stat_wr_q[0]   ),
+  .sh_ddr_stat_rd0   (sh_ddr_stat_rd_q[0]   ),
+  .sh_ddr_stat_wdata0(sh_ddr_stat_wdata_q[0]),
+  .ddr_sh_stat_ack0  (ddr_sh_stat_ack_q[0]  ),
+  .ddr_sh_stat_rdata0(ddr_sh_stat_rdata_q[0]),
+  .ddr_sh_stat_int0  (ddr_sh_stat_int_q[0]  ),
+
+  .sh_ddr_stat_addr1 (sh_ddr_stat_addr_q[1] ),
+  .sh_ddr_stat_wr1   (sh_ddr_stat_wr_q[1]   ),
+  .sh_ddr_stat_rd1   (sh_ddr_stat_rd_q[1]   ),
+  .sh_ddr_stat_wdata1(sh_ddr_stat_wdata_q[1]),
+  .ddr_sh_stat_ack1  (ddr_sh_stat_ack_q[1]  ),
+  .ddr_sh_stat_rdata1(ddr_sh_stat_rdata_q[1]),
+  .ddr_sh_stat_int1  (ddr_sh_stat_int_q[1]  ),
+
+  .sh_ddr_stat_addr2 (sh_ddr_stat_addr_q[2] ),
+  .sh_ddr_stat_wr2   (sh_ddr_stat_wr_q[2]   ),
+  .sh_ddr_stat_rd2   (sh_ddr_stat_rd_q[2]   ),
+  .sh_ddr_stat_wdata2(sh_ddr_stat_wdata_q[2]),
+  .ddr_sh_stat_ack2  (ddr_sh_stat_ack_q[2]  ),
+  .ddr_sh_stat_rdata2(ddr_sh_stat_rdata_q[2]),
+  .ddr_sh_stat_int2  (ddr_sh_stat_int_q[2]  )
+);
+
+endmodule

--- a/hardware/hardware.mk
+++ b/hardware/hardware.mk
@@ -1,19 +1,19 @@
 # Copyright (c) 2019, University of Washington All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:
-# 
+#
 # Redistributions of source code must retain the above copyright notice, this list
 # of conditions and the following disclaimer.
-# 
+#
 # Redistributions in binary form must reproduce the above copyright notice, this
 # list of conditions and the following disclaimer in the documentation and/or
 # other materials provided with the distribution.
-# 
+#
 # Neither the name of the copyright holder nor the names of its contributors may
 # be used to endorse or promote products derived from this software without
 # specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -34,7 +34,7 @@
 
 # This file REQUIRES several variables to be set. They are typically
 # set by the Makefile that includes this makefile..
-# 
+#
 # CL_DIR: The path to the root of the BSG F1 Repository
 ifndef CL_DIR
 $(error $(shell echo -e "$(RED)BSG MAKE ERROR: CL_DIR is not defined$(NC)"))
@@ -99,6 +99,9 @@ VSOURCES += $(CL_DIR)/hardware/bsg_bladerunner_rom.v
 VSOURCES += $(CL_DIR)/hardware/axil_to_mcl.v
 VSOURCES += $(CL_DIR)/hardware/s_axil_mcl_adapter.v
 VSOURCES += $(CL_DIR)/hardware/axil_to_mem.sv
+VSOURCES += $(CL_DIR)/hardware/axi4_transpose_h2v.v
+VSOURCES += $(CL_DIR)/hardware/axi4_clock_converter.v
+VSOURCES += $(CL_DIR)/hardware/cl_sh_ddr_wrapper.v
 
 VHEADERS += $(HARDWARE_PATH)/f1_parameters.vh
 VHEADERS += $(HARDWARE_PATH)/axil_to_mcl.vh

--- a/testbenches/aws.vcs.f
+++ b/testbenches/aws.vcs.f
@@ -45,6 +45,7 @@ ${HDK_SHELL_DESIGN_DIR}/ip/axi_register_slice_light/hdl/axi_infrastructure_v1_1_
 ${HDK_SHELL_DESIGN_DIR}/ip/axi_clock_converter_0/hdl/axi_clock_converter_v2_1_vl_rfs.v
 ${HDK_SHELL_DESIGN_DIR}/ip/axi_clock_converter_0/hdl/fifo_generator_v13_2_rfs.v
 ${HDK_SHELL_DESIGN_DIR}/ip/axi_clock_converter_0/sim/axi_clock_converter_0.v
+${HDK_SHELL_DESIGN_DIR}/sh_ddr/sim/axi_mem_model.sv
 
 # Simulator-specific design files
 -f ${HDK_COMMON_DIR}/verif/tb/filelists/tb.vcs.f

--- a/testbenches/cosim_wrapper.sv
+++ b/testbenches/cosim_wrapper.sv
@@ -45,8 +45,7 @@ module cosim_wrapper();
 
       tb.power_up();
 
-      if (mem_cfg_p == e_vcache_blocking_axi4_f1_ddrx4 ||
-          mem_cfg_p == e_vcache_blocking_axi4_f1_ddr_modelx4) begin
+      if (mem_cfg_p == e_vcache_blocking_axi4_f1_ddrx4) begin
          // initialize the DDR
          $display("BSG COSIM: Starting DDR init...\n");
          tb.nsec_delay(500);

--- a/testbenches/cosim_wrapper.sv
+++ b/testbenches/cosim_wrapper.sv
@@ -27,6 +27,7 @@
 
 module cosim_wrapper();
    import cl_manycore_pkg::*;
+   import bsg_bladerunner_mem_cfg_pkg::*;
    initial begin
       int exit_code;
       string args;
@@ -43,6 +44,19 @@ module cosim_wrapper();
       $display("[INFO][TESTBENCH] BSG_MACHINE_MEM_CFG                  = %s", mem_cfg_p.name());
 
       tb.power_up();
+
+      if (mem_cfg_p == e_vcache_blocking_axi4_f1_ddrx4 ||
+          mem_cfg_p == e_vcache_blocking_axi4_f1_ddr_modelx4) begin
+         // initialize the DDR
+         $display("BSG COSIM: Starting DDR init...\n");
+         tb.nsec_delay(500);
+         tb.poke_stat(.addr(8'h0c), .ddr_idx(0), .data(32'h0000_0000));
+         tb.poke_stat(.addr(8'h0c), .ddr_idx(1), .data(32'h0000_0000));
+         tb.poke_stat(.addr(8'h0c), .ddr_idx(2), .data(32'h0000_0000));
+         // allow memory to initialize
+         tb.nsec_delay(27000);
+         $display("BSG COSIM: Done DDR init...\n");
+      end
 
       tb.cosim_main(exit_code, args);
       

--- a/testbenches/simlibs.mk
+++ b/testbenches/simlibs.mk
@@ -154,6 +154,15 @@ VDEFINES   += ECC_ADDR_HI=0
 VDEFINES   += RND_ECC_WEIGHT=0
 endif
 
+ifeq ($(CL_MANYCORE_MEM_CFG),e_vcache_blocking_axi4_f1_ddrx4_model)
+VDEFINES   += AXI_MEMORY_MODEL=1
+VDEFINES   += ECC_DIRECT_EN
+VDEFINES   += RND_ECC_EN
+VDEFINES   += ECC_ADDR_LO=0
+VDEFINES   += ECC_ADDR_HI=0
+VDEFINES   += RND_ECC_WEIGHT=0
+endif
+
 ifeq ($(EXTRA_TURBO), 1)
 VLOGAN_VFLAGS += -undef_vcs_macro
 endif


### PR DESCRIPTION
1) Added 2 additional memory configurations:
- e_vcache_blocking_axi4_f1_ddrx4_model
- e_vcache_blocking_axi4_f1_ddrx4

2) Update **bsg_axi_bus_pkg.vh** to support AXI interface transpose.

3) Add some wrappers to ease the wiring:
 - axi4_clock_converter
- axi4_transpose_h2v
- cl_sh_ddr_wrapper

4) Modify the **test_vcache_stride** test to check cache_axi_to_ddr functionality.

Depends on
bsg_manycore/feature_ddrx4_on_f1 **6b169d7**
basejump_stl/master **06d2fef**


