### PR TITLE
Reuse CUDA init_custom_dimension in global init

### DIFF
--- a/libraries/bsg_manycore_cuda.cpp
+++ b/libraries/bsg_manycore_cuda.cpp
@@ -962,7 +962,7 @@ int hb_mc_device_init (hb_mc_device_t *device,
  * @param[in]  device        Pointer to device
  * @param[in]  name          Device name
  * @param[in]  id            Device id
- * @param[in]  dim           Tile pool (mesh) dimensions
+ * @param[in]  dim           Tile pool (mesh) dimensions. If (0,0) this method will initialize the whole array.
  * @return HB_MC_SUCCESS if succesful. Otherwise an error code is returned. 
  */
 int hb_mc_device_init_custom_dimensions (hb_mc_device_t *device,
@@ -983,6 +983,7 @@ int hb_mc_device_init_custom_dimensions (hb_mc_device_t *device,
                 return HB_MC_UNINITIALIZED;
         }
 
+        // If the input dimensions are (0,0) this will initialize the whole array.
         if(!dim.x && !dim.y){
                 dim = hb_mc_config_get_dimension_vcore(hb_mc_manycore_get_config(device->mc));
         }

--- a/libraries/bsg_manycore_cuda.cpp
+++ b/libraries/bsg_manycore_cuda.cpp
@@ -946,20 +946,14 @@ static int hb_mc_tile_group_kernel_exit (hb_mc_kernel_t *kernel) {
  * @param[in]  device        Pointer to device
  * @param[in]  name          Device name
  * @param[in]  id            Device id
- * @param[in]  dim           Tile pool (mesh) dimensions
  * @return HB_MC_SUCCESS if succesful. Otherwise an error code is returned. 
  */
 int hb_mc_device_init (hb_mc_device_t *device,
                        const char *name,
                        hb_mc_manycore_id_t id){
 
-        const hb_mc_config_t *config = hb_mc_manycore_get_config(device->mc);
-        hb_mc_dimension_t init_dim = hb_mc_config_get_dimension_vcore(config);
-        
-        return hb_mc_device_init_custom_dimensions(device, name, id, init_dim);
+        return hb_mc_device_init_custom_dimensions(device, name, id, {0, 0});
 }
-
-
 
 
 /**
@@ -968,6 +962,7 @@ int hb_mc_device_init (hb_mc_device_t *device,
  * @param[in]  device        Pointer to device
  * @param[in]  name          Device name
  * @param[in]  id            Device id
+ * @param[in]  dim           Tile pool (mesh) dimensions
  * @return HB_MC_SUCCESS if succesful. Otherwise an error code is returned. 
  */
 int hb_mc_device_init_custom_dimensions (hb_mc_device_t *device,
@@ -986,7 +981,11 @@ int hb_mc_device_init_custom_dimensions (hb_mc_device_t *device,
         if (error != HB_MC_SUCCESS) { 
                 bsg_pr_err("%s: failed to initialize manycore.\n", __func__);
                 return HB_MC_UNINITIALIZED;
-        } 
+        }
+
+        if(!dim.x && !dim.y){
+                dim = hb_mc_config_get_dimension_vcore(hb_mc_manycore_get_config(device->mc));
+        }
         
         error = hb_mc_device_mesh_init(device, dim);
         if (error != HB_MC_SUCCESS) {

--- a/libraries/bsg_manycore_cuda.cpp
+++ b/libraries/bsg_manycore_cuda.cpp
@@ -952,39 +952,11 @@ static int hb_mc_tile_group_kernel_exit (hb_mc_kernel_t *kernel) {
 int hb_mc_device_init (hb_mc_device_t *device,
                        const char *name,
                        hb_mc_manycore_id_t id){
-        device->mc = (hb_mc_manycore_t*) malloc (sizeof (hb_mc_manycore_t));
-        if (device->mc == NULL) { 
-                bsg_pr_err("%s: failed to allocate space on host for hb_mc_manycore_t.\n", __func__);
-                return HB_MC_NOMEM;
-        }
-        *(device->mc) = {0};
+
+        const hb_mc_config_t *config = hb_mc_manycore_get_config(device->mc);
+        hb_mc_dimension_t init_dim = hb_mc_config_get_dimension_vcore(config);
         
-        int error = hb_mc_manycore_init(device->mc, name, id); 
-        if (error != HB_MC_SUCCESS) { 
-                bsg_pr_err("%s: failed to initialize manycore.\n", __func__);
-                return HB_MC_UNINITIALIZED;
-        } 
-
-
-        const hb_mc_config_t *cfg = hb_mc_manycore_get_config(device->mc);
-        hb_mc_dimension_t max_dim = hb_mc_config_get_dimension_vcore(cfg);       
-
-        error = hb_mc_device_mesh_init(device, max_dim);
-        if (error != HB_MC_SUCCESS) {
-                bsg_pr_err("%s: failed to initialize mesh.\n", __func__);
-                return HB_MC_UNINITIALIZED;
-        }
-
-        error = hb_mc_device_tile_groups_init (device); 
-        if (error != HB_MC_SUCCESS) { 
-                bsg_pr_err("%s: failed to initialize device's tile group structure.\n", __func__);
-                return error; 
-        }
-
-        device->num_grids = 0;
-
-        return HB_MC_SUCCESS;
-
+        return hb_mc_device_init_custom_dimensions(device, name, id, init_dim);
 }
 
 
@@ -1016,7 +988,6 @@ int hb_mc_device_init_custom_dimensions (hb_mc_device_t *device,
                 return HB_MC_UNINITIALIZED;
         } 
         
-
         error = hb_mc_device_mesh_init(device, dim);
         if (error != HB_MC_SUCCESS) {
                 bsg_pr_err("%s: failed to initialize mesh.\n", __func__);

--- a/libraries/bsg_manycore_cuda.h
+++ b/libraries/bsg_manycore_cuda.h
@@ -41,7 +41,7 @@ extern "C" {
 #endif
 
 
-        // Kernel is not loaded into tile if kernel poitner equals this value.
+        // Kernel is not loaded into tile if kernel pointer equals this value.
 #define HB_MC_CUDA_KERNEL_NOT_LOADED_VAL        0x0001
         // The value that is written on to finish_signal_addr to show that tile group execution is done.
 #define HB_MC_CUDA_FINISH_SIGNAL_VAL            0x0001  
@@ -147,7 +147,8 @@ extern "C" {
         __attribute__((warn_unused_result))
         int hb_mc_device_init (hb_mc_device_t *device,
                                const char *name,
-                               hb_mc_manycore_id_t id);
+                               hb_mc_manycore_id_t id,
+                               hb_mc_dimension_t dim);
 
 
 

--- a/libraries/bsg_manycore_cuda.h
+++ b/libraries/bsg_manycore_cuda.h
@@ -41,7 +41,7 @@ extern "C" {
 #endif
 
 
-        // Kernel is not loaded into tile if kernel pointer equals this value.
+        // Kernel is not loaded into tile if kernel poitner equals this value.
 #define HB_MC_CUDA_KERNEL_NOT_LOADED_VAL        0x0001
         // The value that is written on to finish_signal_addr to show that tile group execution is done.
 #define HB_MC_CUDA_FINISH_SIGNAL_VAL            0x0001  
@@ -147,8 +147,7 @@ extern "C" {
         __attribute__((warn_unused_result))
         int hb_mc_device_init (hb_mc_device_t *device,
                                const char *name,
-                               hb_mc_manycore_id_t id,
-                               hb_mc_dimension_t dim);
+                               hb_mc_manycore_id_t id);
 
 
 


### PR DESCRIPTION
This is a PR from a long time ago. I increased code reuse.

It does rely on passing 0,0 to the initializer. If this controversial, let me know. I did comment it though