### PR TITLE
Fixed #532 - Rebuild CUDA Binaries at runtime.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-synopsys_sim.setup*
 *.wcfg
 *.swp
 *.str
@@ -8,9 +7,3 @@ synopsys_sim.setup*
 __pycache__
 .Xil
 
-
-f1_parameters.vh
-bsg_bladerunner_configuration.rom
-bsg_bladerunner_memsys.rom
-bsg_bladerunner_configuration.v
-bsg_bladerunner_rom_pkg.vh

--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,7 @@ regression:
 cosim: 
 	$(MAKE) -C testbenches regression
 
-reverse = $(if $(1),$(call reverse,$(wordlist 2,$(words $(1)),$(1)))) $(firstword $(1))
-__BSG_MACHINES := $(call reverse,$(wildcard machines/*))
+__BSG_MACHINES := $(wildcard machines/*)
 multiverse:
 	$(foreach m,$(__BSG_MACHINES),$(MAKE) -k -C testbenches regression BSG_MACHINE_PATH=`pwd`/$m && cp testbenches/regression.log $m &&) echo ;
 

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,8 @@ regression:
 cosim: 
 	$(MAKE) -C testbenches regression
 
-__BSG_MACHINES := $(wildcard machines/*)
+reverse = $(if $(1),$(call reverse,$(wordlist 2,$(words $(1)),$(1)))) $(firstword $(1))
+__BSG_MACHINES := $(call reverse,$(wildcard machines/*))
 multiverse:
 	$(foreach m,$(__BSG_MACHINES),$(MAKE) -k -C testbenches regression BSG_MACHINE_PATH=`pwd`/$m && cp testbenches/regression.log $m &&) echo ;
 

--- a/machines/.gitignore
+++ b/machines/.gitignore
@@ -1,4 +1,3 @@
-bsg_link.ld
 synopsys_sim.setup
 f1_parameters.vh
 bsg_bladerunner_configuration.rom

--- a/machines/.gitignore
+++ b/machines/.gitignore
@@ -1,0 +1,7 @@
+bsg_link.ld
+synopsys_sim.setup
+f1_parameters.vh
+bsg_bladerunner_configuration.rom
+bsg_bladerunner_memsys.rom
+bsg_bladerunner_configuration.v
+bsg_bladerunner_rom_pkg.vh

--- a/regression/cuda/rules.mk
+++ b/regression/cuda/rules.mk
@@ -30,7 +30,9 @@
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-.PHONY:
+.PHONY: test_%.clean test_%.rule
+
+.FORCE:
 
 $(USER_RULES): test_%.rule: $(CUDALITE_SRC_PATH)/%/main.riscv
 
@@ -43,7 +45,8 @@ $(USER_CLEAN_RULES):
 	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
 	$(MAKE) -C $(CUDALITE_SRC_PATH)/$(subst .clean,,$(subst test_,,$@)) clean
 
-$(CUDALITE_SRC_PATH)/%/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
+$(CUDALITE_SRC_PATH)/%/main.riscv: LINK_SCRIPT=$(BSG_MACHINE_PATH)/bsg_link.ld
+$(CUDALITE_SRC_PATH)/%/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include .FORCE
 	CL_DIR=$(CL_DIR) \
 	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
 	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \

--- a/regression/cuda/rules.mk
+++ b/regression/cuda/rules.mk
@@ -32,6 +32,8 @@ CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 .PHONY: test_%.clean test_%.rule
 
+# Force rebuild targets that depend on .FORCE, like the
+# Manycore/SPMD/CUDA Binaries
 .FORCE:
 
 $(USER_RULES): test_%.rule: $(CUDALITE_SRC_PATH)/%/main.riscv
@@ -45,7 +47,6 @@ $(USER_CLEAN_RULES):
 	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
 	$(MAKE) -C $(CUDALITE_SRC_PATH)/$(subst .clean,,$(subst test_,,$@)) clean
 
-$(CUDALITE_SRC_PATH)/%/main.riscv: LINK_SCRIPT=$(BSG_MACHINE_PATH)/bsg_link.ld
 $(CUDALITE_SRC_PATH)/%/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include .FORCE
 	CL_DIR=$(CL_DIR) \
 	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \

--- a/regression/specint/rules.mk
+++ b/regression/specint/rules.mk
@@ -32,6 +32,10 @@
 # Manycore. It contains makefiles to compile specint programs.
 SPECINT_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd/specint2000
 
+# Force rebuild targets that depend on .FORCE, like the
+# Manycore/SPMD/CUDA Binaries
+.FORCE:
+
 .PHONY: test_%.clean $(USER_RULES)
 
 $(USER_RULES): test_%.rule: $(SPECINT_SRC_PATH)/%.riscv

--- a/regression/spmd/rules.mk
+++ b/regression/spmd/rules.mk
@@ -32,12 +32,15 @@
 # Manycore. It contains directories with RISC-V programs.
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 
-.PHONY: test_%.clean $(USER_RULES)
+.PHONY: test_%.clean test_%.rule
+
+.FORCE:
 
 $(USER_RULES): test_%.rule: $(SPMD_SRC_PATH)/%/main.riscv
 
 $(USER_CLEAN_RULES): 
 	CL_DIR=$(CL_DIR) \
+	LINK_SCRIPT=$(LINK_SCRIPT) \
 	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
 	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
 	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
@@ -45,8 +48,10 @@ $(USER_CLEAN_RULES):
 	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
 	$(MAKE) -C $(SPMD_SRC_PATH)/$(subst .clean,,$(subst test_,,$@)) clean
 
-$(SPMD_SRC_PATH)/%/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
+$(SPMD_SRC_PATH)/%/main.riscv: LINK_SCRIPT=$(BSG_MACHINE_PATH)/bsg_link.ld
+$(SPMD_SRC_PATH)/%/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include .FORCE
 	CL_DIR=$(CL_DIR) \
+	LINK_SCRIPT=$(LINK_SCRIPT) \
 	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
 	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
 	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \

--- a/regression/spmd/rules.mk
+++ b/regression/spmd/rules.mk
@@ -34,13 +34,14 @@ SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 
 .PHONY: test_%.clean test_%.rule
 
+# Force rebuild targets that depend on .FORCE, like the
+# Manycore/SPMD/CUDA Binaries
 .FORCE:
 
 $(USER_RULES): test_%.rule: $(SPMD_SRC_PATH)/%/main.riscv
 
 $(USER_CLEAN_RULES): 
 	CL_DIR=$(CL_DIR) \
-	LINK_SCRIPT=$(LINK_SCRIPT) \
 	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
 	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
 	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
@@ -48,10 +49,8 @@ $(USER_CLEAN_RULES):
 	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
 	$(MAKE) -C $(SPMD_SRC_PATH)/$(subst .clean,,$(subst test_,,$@)) clean
 
-$(SPMD_SRC_PATH)/%/main.riscv: LINK_SCRIPT=$(BSG_MACHINE_PATH)/bsg_link.ld
 $(SPMD_SRC_PATH)/%/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include .FORCE
 	CL_DIR=$(CL_DIR) \
-	LINK_SCRIPT=$(LINK_SCRIPT) \
 	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
 	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
 	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \

--- a/testbenches/.gitignore
+++ b/testbenches/.gitignore
@@ -1,8 +1,9 @@
 vcs_simlibs
+synopsys_sim.setup
 .cxl.*
 .vlogan*
 AN.DB
-ucli.key
+ucli.keyOf
 csrc
 vc_hdrs.h
 *.jou

--- a/testbenches/.gitignore
+++ b/testbenches/.gitignore
@@ -3,7 +3,7 @@ synopsys_sim.setup
 .cxl.*
 .vlogan*
 AN.DB
-ucli.keyOf
+ucli.key
 csrc
 vc_hdrs.h
 *.jou


### PR DESCRIPTION
This PR simply solves #532, by forcing a rebuild whenever the relevant program is run (through the makefile)

It is a less heavy-handed change than before.

I also moved some .gitigore directives that were semi-relevant