### PR TITLE
Regression now produces runtime measurements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,14 +66,17 @@ regression:
 cosim: 
 	$(MAKE) -C testbenches regression
 
-__BSG_MACHINES := $(wildcard machines/*)
-__BSG_MACHINES := $(filter-out machines/README.md,$(__BSG_MACHINES))
-__BSG_MACHINES := $(filter-out machines/timing_v0_32_16,$(__BSG_MACHINES))
-__BSG_MACHINES := $(filter-out machines/timing_v0_64_32,$(__BSG_MACHINES))
-# F1 with realistic DRAM Takes forever, so we'll leave it out for now
-__BSG_MACHINES := $(filter-out machines/4x4_blocking_vcache_f1_dram,$(__BSG_MACHINES))
+__BSG_MACHINES += machines/16x8_fast_n_fake
+__BSG_MACHINES += machines/4x4_fast_n_fake
+__BSG_MACHINES += machines/4x4_blocking_dramsim3_hbm2_512mb
+__BSG_MACHINES += machines/8x4_blocking_dramsim3_hbm2_4gb
+__BSG_MACHINES += machines/4x4_blocking_vcache_f1_model
+__BSG_MACHINES += machines/timing_v0_8_4
+__BSG_MACHINES += machines/timing_v0_16_8
+#__BSG_MACHINES += machines/timing_v0_32_16
+#__BSG_MACHINES += machines/timing_v0_64_32  
 multiverse:
-	$(foreach m,$(__BSG_MACHINES),$(MAKE) -k -C testbenches regression BSG_MACHINE_PATH=`pwd`/$m && cp testbenches/regression.log $m &&) echo ;
+	$(foreach m,$(__BSG_MACHINES),$(MAKE) -k -C testbenches regression BSG_MACHINE_PATH=`pwd`/$m &&) echo ;
 
 clean:
 	$(MAKE) -C testbenches clean 

--- a/testbenches/Makefile
+++ b/testbenches/Makefile
@@ -65,7 +65,7 @@ $(BSG_MACHINE_PATH)/regression.log: regression.log
 regression.log: $(TARGETS)
 	@cat $(foreach tgt,$(TARGETS),$(tgt)/regression.log) | tee $@
 
-runtime.log: #$(BSG_MACHINE_PATH)/regression.log
+runtime.log: $(BSG_MACHINE_PATH)/regression.log
 	@grep -H "CPU Time:" */test_*.log > $@
 	@sed -i 's/:CPU Time:\s*\([0-9]*.[0-9]*\).*/,\1/' $@
 	@sed -i 's/.log//'  $@

--- a/testbenches/Makefile
+++ b/testbenches/Makefile
@@ -65,8 +65,15 @@ $(BSG_MACHINE_PATH)/regression.log: regression.log
 regression.log: $(TARGETS)
 	@cat $(foreach tgt,$(TARGETS),$(tgt)/regression.log) | tee $@
 
-$(BSG_MACHINE_PATH)/runtime.log: $(BSG_MACHINE_PATH)/regression.log
-	grep -H "CPU Time:" */test_*.log | sed 's/:CPU Time:\s*\([0-9]*.[0-9]*\).*/,\1 seconds/' > $@
+runtime.log: #$(BSG_MACHINE_PATH)/regression.log
+	@grep -H "CPU Time:" */test_*.log > $@
+	@sed -i 's/:CPU Time:\s*\([0-9]*.[0-9]*\).*/,\1/' $@
+	@sed -i 's/.log//'  $@
+	@sed -i 's/\//,/'  $@
+	@sed -i "s/^\(.*\)/$(CL_MANYCORE_DIM_X),$(CL_MANYCORE_DIM_Y),$(CL_MANYCORE_MEM_CFG),\1/" $@
+
+$(BSG_MACHINE_PATH)/runtime.log: runtime.log
+	cp $< $@
 
 $(TARGETS): $(SIMLIBS)
 	$(MAKE) -C $@ regression

--- a/testbenches/Makefile
+++ b/testbenches/Makefile
@@ -57,10 +57,16 @@ include simlibs.mk
 include $(REGRESSION_PATH)/targets.mk
 .PHONY: clean %.clean regression $(TARGETS)
 
-regression: regression.log
+regression: $(BSG_MACHINE_PATH)/regression.log $(BSG_MACHINE_PATH)/runtime.log
+
+$(BSG_MACHINE_PATH)/regression.log: regression.log
+	cp $< $@
 
 regression.log: $(TARGETS)
-	@cat $(foreach tgt,$(TARGETS),$(tgt)/regression.log) | tee regression.log
+	@cat $(foreach tgt,$(TARGETS),$(tgt)/regression.log) | tee $@
+
+$(BSG_MACHINE_PATH)/runtime.log: $(BSG_MACHINE_PATH)/regression.log
+	grep -H "CPU Time:" */test_*.log | sed 's/:CPU Time:\s*\([0-9]*.[0-9]*\).*/,\1 seconds/' > $@
 
 $(TARGETS): $(SIMLIBS)
 	$(MAKE) -C $@ regression


### PR DESCRIPTION
This is probably long overdue, but running regression from testbenches now produces a runtime.log file that records the execution time (as reported by VCS) of each testbench.

That runtime.log file is copied into BSG_MACHINE_PATH, so that running regression on multiple machines produces runtime.log files for each machine. 

Anything else that people want in this? @proftaylor 

For example, I might be able to report manycore core clock cycles. 