### PR TITLE
Minor refactoring of the Endpoint-To-FIFO module

### DIFF
--- a/hardware/bsg_manycore_endpoint_to_fifos.v
+++ b/hardware/bsg_manycore_endpoint_to_fifos.v
@@ -33,20 +33,21 @@
 * Or cast the manycore packet to the rx_fifo data stream
 */
 
-
 module bsg_manycore_endpoint_to_fifos
-  import cl_manycore_pkg::*;
   import bsg_manycore_pkg::*;
-  import bsg_manycore_link_to_axil_pkg::*;
-  import bsg_manycore_addr_pkg::bsg_print_stat_epa_gp;
 #(
   parameter fifo_width_p = "inv"
   // these are endpoint parameters
   , parameter x_cord_width_p = "inv"
+  , localparam x_cord_width_pad_lp = `BSG_CDIV(x_cord_width_p,8)*8
   , parameter y_cord_width_p = "inv"
+  , localparam y_cord_width_pad_lp = `BSG_CDIV(y_cord_width_p,8)*8
   , parameter addr_width_p = "inv"
+  , localparam addr_width_pad_lp = `BSG_CDIV(addr_width_p,8)*8
   , parameter data_width_p = "inv"
+  , parameter data_width_pad_lp = `BSG_CDIV(data_width_p,8)*8
   , parameter max_out_credits_p = "inv"
+  , parameter ep_fifo_els_p = "inv"
   , parameter link_sif_width_lp = `bsg_manycore_link_sif_width(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p)
 ) (
   input                                      clk_i
@@ -77,13 +78,9 @@ module bsg_manycore_endpoint_to_fifos
 
   ,output [`BSG_WIDTH(max_out_credits_p)-1:0] out_credits_o
 
-
-  // print stat
-  ,output                                     print_stat_v_o
-  ,output [                 data_width_p-1:0] print_stat_tag_o
 );
 
-  `declare_bsg_manycore_link_fifo_s(fifo_width_p, mcl_addr_width_gp, mcl_data_width_gp, mcl_x_cord_width_gp, mcl_y_cord_width_gp);
+  `declare_bsg_manycore_link_fifo_s(fifo_width_p, addr_width_pad_lp, data_width_pad_lp, x_cord_width_pad_lp, y_cord_width_pad_lp);
 
   // host as master
   bsg_mcl_request_s  host_req_li_cast;
@@ -166,10 +163,10 @@ module bsg_manycore_endpoint_to_fifos
 
   assign mc_rsp_lo_cast.padding  = '0;
   assign mc_rsp_lo_cast.pkt_type = 8'(returned_pkt_type_r_lo);
-  assign mc_rsp_lo_cast.data     = mcl_data_width_gp'(returned_data_r_lo);
+  assign mc_rsp_lo_cast.data     = data_width_pad_lp'(returned_data_r_lo);
   assign mc_rsp_lo_cast.reg_id   = 8'(returned_reg_id_r_lo);
-  assign mc_rsp_lo_cast.y_cord   = mcl_y_cord_width_gp'(my_y_i);
-  assign mc_rsp_lo_cast.x_cord   = mcl_x_cord_width_gp'(my_x_i);
+  assign mc_rsp_lo_cast.y_cord   = y_cord_width_pad_lp'(my_y_i);
+  assign mc_rsp_lo_cast.x_cord   = x_cord_width_pad_lp'(my_x_i);
 
 
   // manycore request to host
@@ -178,14 +175,14 @@ module bsg_manycore_endpoint_to_fifos
   assign endpoint_in_yumi_li = mc_req_ready_i & mc_req_v_o;
 
   assign mc_req_lo_cast.padding      = '0;
-  assign mc_req_lo_cast.addr         = mcl_addr_width_gp'(endpoint_in_addr_lo);
+  assign mc_req_lo_cast.addr         = addr_width_pad_lp'(endpoint_in_addr_lo);
   assign mc_req_lo_cast.op           = 8'(endpoint_in_we_lo);
   assign mc_req_lo_cast.op_ex        = 8'(endpoint_in_mask_lo);
-  assign mc_req_lo_cast.payload.data = mcl_data_width_gp'(endpoint_in_data_lo);
-  assign mc_req_lo_cast.src_y_cord   = mcl_y_cord_width_gp'(in_src_y_cord_lo);
-  assign mc_req_lo_cast.src_x_cord   = mcl_x_cord_width_gp'(in_src_x_cord_lo);
-  assign mc_req_lo_cast.y_cord       = mcl_y_cord_width_gp'(my_y_i);
-  assign mc_req_lo_cast.x_cord       = mcl_x_cord_width_gp'(my_x_i);
+  assign mc_req_lo_cast.payload.data = data_width_p'(endpoint_in_data_lo);
+  assign mc_req_lo_cast.src_y_cord   = y_cord_width_pad_lp'(in_src_y_cord_lo);
+  assign mc_req_lo_cast.src_x_cord   = x_cord_width_pad_lp'(in_src_x_cord_lo);
+  assign mc_req_lo_cast.y_cord       = y_cord_width_pad_lp'(my_y_i);
+  assign mc_req_lo_cast.x_cord       = x_cord_width_pad_lp'(my_x_i);
 
 
   // host response to manycore
@@ -207,7 +204,7 @@ module bsg_manycore_endpoint_to_fifos
   bsg_manycore_endpoint_standard #(
     .x_cord_width_p   (x_cord_width_p      ),
     .y_cord_width_p   (y_cord_width_p      ),
-    .fifo_els_p       (mcl_edpt_fifo_els_gp),
+    .fifo_els_p       (ep_fifo_els_p       ),
     .addr_width_p     (addr_width_p        ),
     .data_width_p     (data_width_p        ),
     .max_out_credits_p(max_out_credits_p   )
@@ -250,9 +247,5 @@ module bsg_manycore_endpoint_to_fifos
     .my_x_i               (my_x_i                ),
     .my_y_i               (my_y_i                )
   );
-
-  assign print_stat_v_o = endpoint_in_v_lo & endpoint_in_we_lo
-    & ({endpoint_in_addr_lo[13:0], 2'b00} == bsg_print_stat_epa_gp);
-  assign print_stat_tag_o = endpoint_in_data_lo;
 
 endmodule

--- a/hardware/bsg_manycore_endpoint_to_fifos.v
+++ b/hardware/bsg_manycore_endpoint_to_fifos.v
@@ -45,7 +45,7 @@ module bsg_manycore_endpoint_to_fifos
   , parameter addr_width_p = "inv"
   , localparam addr_width_pad_lp = `BSG_CDIV(addr_width_p,8)*8
   , parameter data_width_p = "inv"
-  , parameter data_width_pad_lp = `BSG_CDIV(data_width_p,8)*8
+  , localparam data_width_pad_lp = `BSG_CDIV(data_width_p,8)*8
   , parameter max_out_credits_p = "inv"
   , parameter ep_fifo_els_p = "inv"
   , parameter link_sif_width_lp = `bsg_manycore_link_sif_width(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p)

--- a/hardware/bsg_manycore_endpoint_to_fifos_pkg.v
+++ b/hardware/bsg_manycore_endpoint_to_fifos_pkg.v
@@ -1,0 +1,48 @@
+`ifndef BSG_MANYCORE_ENDPOINT_TO_FIFOS_PKG_V
+`define BSG_MANYCORE_ENDPOINT_TO_FIFOS_PKG_V
+
+
+// To ease the programming, we slices the fields in the bsg_manycore_packet_s
+// struct, and cast the fileds into multiple of bytes.
+//
+// assume 8 >= bsg_manycore_reg_id_width_gp
+// assume 8 >= $bits(bsg_manycore_packet_op_e)
+// assume 8 >= $bits(bsg_manycore_packet_op_ex_u)
+// assume 8 >= $bits(bsg_manycore_return_packet_type_e)
+`define declare_bsg_manycore_link_fifo_s(fifo_width_mp,addr_width_mp,data_width_mp,x_cord_width_mp,y_cord_width_mp) \
+\
+  typedef struct packed { \
+    logic [fifo_width_mp-8-data_width_mp-8-y_cord_width_mp-x_cord_width_mp-1: \
+    0]                            padding ; \
+    logic [                8-1:0] pkt_type; \
+    logic [    data_width_mp-1:0] data    ; \
+    logic [                8-1:0] reg_id  ; \
+    logic [  y_cord_width_mp-1:0] y_cord  ; \
+    logic [  x_cord_width_mp-1:0] x_cord  ; \
+  } bsg_mcl_response_s; \
+\
+  typedef union packed { \
+    logic [data_width_mp-1:0] data     ; \
+    logic [data_width_mp-1:0] load_info; \
+  } bsg_mcl_packet_payload_u; \
+\
+  typedef struct packed { \
+    logic [fifo_width_mp-addr_width_mp-3*8-data_width_mp-2*y_cord_width_mp-2*x_cord_width_mp-1: \
+    0]                          padding   ; \
+    logic [  addr_width_mp-1:0] addr      ; \
+    logic [              8-1:0] op        ; \
+    logic [              8-1:0] op_ex     ; \
+    logic [              8-1:0] reg_id    ; \
+    bsg_mcl_packet_payload_u    payload   ; \
+    logic [y_cord_width_mp-1:0] src_y_cord; \
+    logic [x_cord_width_mp-1:0] src_x_cord; \
+    logic [y_cord_width_mp-1:0] y_cord    ; \
+    logic [x_cord_width_mp-1:0] x_cord    ; \
+  } bsg_mcl_request_s
+
+
+package bsg_manycore_endpoint_to_fifos_pkg;
+
+endpackage : bsg_manycore_endpoint_to_fifos_pkg
+
+`endif // BSG_MANYCORE_ENDPOINT_TO_FIFOS_PKG_V

--- a/hardware/bsg_manycore_link_to_axil.v
+++ b/hardware/bsg_manycore_link_to_axil.v
@@ -61,6 +61,7 @@ module bsg_manycore_link_to_axil
   , parameter addr_width_p = "inv"
   , parameter data_width_p = "inv"
   , parameter max_out_credits_p = "inv"
+  , localparam ep_fifo_els_lp = 4
   , localparam link_sif_width_lp = `bsg_manycore_link_sif_width(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p)
 ) (
   input                                clk_i
@@ -89,8 +90,6 @@ module bsg_manycore_link_to_axil
   ,input  [         x_cord_width_p-1:0] my_x_i
   ,input  [         y_cord_width_p-1:0] my_y_i
   // print stat
-  ,output                               print_stat_v_o
-  ,output [           data_width_p-1:0] print_stat_tag_o
 );
 
 
@@ -366,6 +365,7 @@ module bsg_manycore_link_to_axil
     .y_cord_width_p   (y_cord_width_p   ),
     .addr_width_p     (addr_width_p     ),
     .data_width_p     (data_width_p     ),
+    .ep_fifo_els_p    (ep_fifo_els_lp   ),
     .max_out_credits_p(max_out_credits_p)
   ) mc_ep_to_fifos (
     .clk_i           (clk_i            ),
@@ -389,10 +389,7 @@ module bsg_manycore_link_to_axil
     .link_sif_o      (link_sif_o       ),
     .my_x_i          (my_x_i           ),
     .my_y_i          (my_y_i           ),
-    .out_credits_o   (ep_out_credits_lo),
-    // stat log
-    .print_stat_v_o  (print_stat_v_o   ),
-    .print_stat_tag_o(print_stat_tag_o )
+    .out_credits_o   (ep_out_credits_lo)
   );
 
 endmodule

--- a/hardware/cl_manycore.sv
+++ b/hardware/cl_manycore.sv
@@ -1187,10 +1187,7 @@ module cl_manycore
     .link_sif_i      (axil_link_sif_li  ),
     .link_sif_o      (axil_link_sif_lo  ),
     .my_x_i          (mcl_x_cord_li     ),
-    .my_y_i          (mcl_y_cord_li     ),
-    // trace
-    .print_stat_v_o  (print_stat_v_lo   ),
-    .print_stat_tag_o(print_stat_tag_lo )
+    .my_y_i          (mcl_y_cord_li     )
   );
 
 `ifdef COSIM

--- a/hardware/hardware.mk
+++ b/hardware/hardware.mk
@@ -118,6 +118,7 @@ VSOURCES += $(BSG_MACHINE_PATH)/bsg_bladerunner_rom_pkg.vh
 VSOURCES += $(CL_DIR)/hardware/bsg_manycore_link_to_axil_pkg.v
 VSOURCES += $(CL_DIR)/hardware/bsg_mcl_axil_fifos_master.v
 VSOURCES += $(CL_DIR)/hardware/bsg_mcl_axil_fifos_slave.v
+VSOURCES += $(CL_DIR)/hardware/bsg_manycore_endpoint_to_fifos_pkg.v
 VSOURCES += $(CL_DIR)/hardware/bsg_manycore_endpoint_to_fifos.v
 VSOURCES += $(CL_DIR)/hardware/bsg_manycore_link_to_axil.v
 VSOURCES += $(BASEJUMP_STL_DIR)/bsg_dataflow/bsg_serial_in_parallel_out_full.v


### PR DESCRIPTION
Moving to Verilator, this module was slightly problematic. Several parameters had unnecessary global scope, and were included in a parameter file that was outside of the context of the endpoint-to-fifo module.

In addition, it seems like we had duplicate stat-print snoop logic. I removed that, as well.

* Removed some global parameters, that could be computed from local parameters (!!!)
* Removed Endpoint-To-FIFO dependence on AXI-L parameters
* Removed duplicate statistics snooping logic