### PR TITLE
Simplified main/cosim main calling

### DIFF
--- a/libraries/bsg_manycore.cpp
+++ b/libraries/bsg_manycore.cpp
@@ -38,6 +38,7 @@
 #include <fpga_pci.h>
 #include <fpga_mgmt.h>
 #else
+#include <svdpi.h>
 #include <fpga_pci_sv.h>
 #include <utils/sh_dpi_tasks.h>
 #include <bsg_mem_dma.hpp>
@@ -108,6 +109,9 @@ static int  hb_mc_manycore_init_mmio(hb_mc_manycore_t *mc, hb_mc_manycore_id_t i
 static void hb_mc_manycore_cleanup_mmio(hb_mc_manycore_t *mc);
 static int  hb_mc_manycore_init_private_data(hb_mc_manycore_t *mc);
 static void hb_mc_manycore_cleanup_private_data(hb_mc_manycore_t *mc);
+
+static int hb_mc_manycore_init_dpi(hb_mc_manycore_t *mc);
+static void hb_mc_manycore_cleanup_dpi(hb_mc_manycore_t *mc);
 
 static int hb_mc_manycore_packet_tx_internal(hb_mc_manycore_t *mc,
                                              hb_mc_packet_t *packet,
@@ -253,6 +257,21 @@ static int hb_mc_manycore_rx_fifo_drain(hb_mc_manycore_t *mc, hb_mc_fifo_rx_t ty
 ///////////////////
 // Init/Exit API //
 ///////////////////
+
+#ifdef COSIM
+static int hb_mc_manycore_init_dpi(hb_mc_manycore_t *mc)
+{
+        svScope scope;
+        scope = svGetScopeFromName("tb");
+        svSetScope(scope);
+        return HB_MC_SUCCESS;
+}
+
+static void hb_mc_manycore_cleanup_dpi(hb_mc_manycore_t *mc)
+{
+        return;
+}
+#endif
 
 /* initialize manycore MMIO */
 static int hb_mc_manycore_init_mmio(hb_mc_manycore_t *mc, hb_mc_manycore_id_t id)
@@ -509,6 +528,12 @@ int  hb_mc_manycore_init(hb_mc_manycore_t *mc, const char *name, hb_mc_manycore_
         if ((err = hb_mc_manycore_init_private_data(mc)) != HB_MC_SUCCESS)
                 goto cleanup;
 
+#ifdef COSIM
+        // initialize simulation
+        if ((err = hb_mc_manycore_init_dpi(mc)) != HB_MC_SUCCESS)
+                goto cleanup;
+#endif
+
         // initialize manycore for MMIO
         if ((err = hb_mc_manycore_init_mmio(mc, id)) != HB_MC_SUCCESS)
                 goto cleanup;
@@ -536,6 +561,7 @@ int  hb_mc_manycore_init(hb_mc_manycore_t *mc, const char *name, hb_mc_manycore_
         r = err;
         hb_mc_manycore_cleanup_fifos(mc);
         hb_mc_manycore_cleanup_mmio(mc);
+        hb_mc_manycore_cleanup_dpi(mc);
         hb_mc_manycore_cleanup_private_data(mc);
         free((void*)mc->name);
 

--- a/libraries/bsg_manycore.cpp
+++ b/libraries/bsg_manycore.cpp
@@ -561,7 +561,9 @@ int  hb_mc_manycore_init(hb_mc_manycore_t *mc, const char *name, hb_mc_manycore_
         r = err;
         hb_mc_manycore_cleanup_fifos(mc);
         hb_mc_manycore_cleanup_mmio(mc);
+#ifdef COSIM
         hb_mc_manycore_cleanup_dpi(mc);
+#endif
         hb_mc_manycore_cleanup_private_data(mc);
         free((void*)mc->name);
 

--- a/machine.mk
+++ b/machine.mk
@@ -35,7 +35,7 @@ endif
 
 # To switch machines, simply switch the path of BSG_MACHINE_PATH to
 # another directory with a Makefile.machine.include file.
-BSG_MACHINE_PATH ?= $(BSG_F1_DIR)/machines/4x4_fast_n_fake/
+BSG_MACHINE_PATH ?= $(BSG_F1_DIR)/machines/4x4_fast_n_fake
 
 # Convert the machine path to an abspath
 override BSG_MACHINE_PATH := $(abspath $(BSG_MACHINE_PATH))

--- a/regression/cl_manycore_regression.h
+++ b/regression/cl_manycore_regression.h
@@ -51,9 +51,6 @@ using std::isnormal;
 #include <unistd.h>
 #include <argp.h>
 
-#ifdef VCS
-#include "svdpi.h"
-#endif
 #define BSG_RED(x) "\033[31m" x "\033[0m"
 #define BSG_GREEN(x) "\033[32m" x "\033[0m"
 #define BSG_YELLOW(x) "\033[33m" x "\033[0m"
@@ -385,5 +382,23 @@ static struct argp argp_name = {opts_name, parse_name, desc_name, doc};
 static struct argp argp_path = {opts_path, parse_path, desc_path, doc};
 static struct argp argp_path_py = {opts_path_py, parse_path_py, desc_path_py, doc};
 static struct argp argp_none = {opts_none, parse_none, desc_none, doc};
+
+#ifdef VCS
+int vcs_main(int argc, char **argv);
+void cosim_main(uint32_t *exit_code, char * args) {
+        // We aren't passed command line arguments directly so we parse them
+        // from *args. args is a string from VCS - to pass a string of arguments
+        // to args, pass c_args to VCS as follows: +c_args="<space separated
+        // list of args>"
+        int argc = get_argc(args);
+        char *argv[argc];
+        get_argv(args, argc, argv);
+
+        int rc = vcs_main(argc, argv);
+        *exit_code = rc;
+        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
+        return;
+}
+#endif
 
 #endif

--- a/regression/cuda/test_binary_load_buffer.c
+++ b/regression/cuda/test_binary_load_buffer.c
@@ -145,33 +145,15 @@ int kernel_binary_load_buffer(int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_binary_load_buffer Regression Test (COSIMULATION)\n");
-        int rc = kernel_binary_load_buffer(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_binary_load_buffer Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_binary_load_buffer Regression Test\n");
         int rc = kernel_binary_load_buffer(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_conv1d.c
+++ b/regression/cuda/test_conv1d.c
@@ -232,35 +232,14 @@ int kernel_conv1d(int argc, char **argv)
         return HB_MC_FAIL;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char *args)
-{
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_conv1d Regression Test (COSIMULATION)\n");
-        int rc = kernel_conv1d(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
-int main(int argc, char **argv)
-{
-        bsg_pr_test_info("test_conv1d Regression Test (F1)\n");
+int main(int argc, char ** argv) {
+#endif
+        bsg_pr_test_info("test_conv1d Regression Test \n");
         int rc = kernel_conv1d(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
 

--- a/regression/cuda/test_conv2d.c
+++ b/regression/cuda/test_conv2d.c
@@ -242,35 +242,15 @@ int kernel_conv2d(int argc, char **argv)
         return HB_MC_FAIL;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char *args)
-{
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_conv2d Regression Test (COSIMULATION)\n");
-        int rc = kernel_conv2d(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
-int main(int argc, char **argv)
-{
-        bsg_pr_test_info("test_conv2d Regression Test (F1)\n");
+int main(int argc, char ** argv) {
+#endif
+        bsg_pr_test_info("test_conv2d Regression Test\n");
         int rc = kernel_conv2d(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_device_memcpy.c
+++ b/regression/cuda/test_device_memcpy.c
@@ -203,33 +203,14 @@ int kernel_device_memcpy (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_device_memcpy Regression Test (COSIMULATION)\n");
-        int rc = kernel_device_memcpy(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_device_memcpy Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_device_memcpy Regression Test \n");
         int rc = kernel_device_memcpy(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
 

--- a/regression/cuda/test_device_memset.c
+++ b/regression/cuda/test_device_memset.c
@@ -175,33 +175,15 @@ int kernel_device_memset (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_device_memset Regression Test (COSIMULATION)\n");
-        int rc = kernel_device_memset(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_device_memset Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_device_memset Regression Test\n");
         int rc = kernel_device_memset(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_dram_device_allocated.c
+++ b/regression/cuda/test_dram_device_allocated.c
@@ -180,33 +180,14 @@ int kernel_dram_device_allocated (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_dram_device_allocated Regression Test (COSIMULATION)\n");
-        int rc = kernel_dram_device_allocated(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_dram_device_allocated Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_dram_device_allocated Regression Test \n");
         int rc = kernel_dram_device_allocated(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
 

--- a/regression/cuda/test_dram_host_allocated.c
+++ b/regression/cuda/test_dram_host_allocated.c
@@ -156,33 +156,15 @@ int kernel_dram_host_allocated (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_dram_host_allocated Regression Test (COSIMULATION)\n");
-        int rc = kernel_dram_host_allocated(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_dram_host_allocated Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_dram_host_allocated Regression Test\n");
         int rc = kernel_dram_host_allocated(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_dram_load_store.c
+++ b/regression/cuda/test_dram_load_store.c
@@ -151,33 +151,15 @@ int kernel_dram_load_store(int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_dram_load_store Regression Test (COSIMULATION)\n");
-        int rc = kernel_dram_load_store(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_dram_load_store Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_dram_load_store Regression Test \n");
         int rc = kernel_dram_load_store(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_empty_parallel.c
+++ b/regression/cuda/test_empty_parallel.c
@@ -112,33 +112,15 @@ int kernel_empty_parallel (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_empty_parallel Regression Test (COSIMULATION)\n");
-        int rc = kernel_empty_parallel(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_empty_parallel Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_empty_parallel Regression Test\n");
         int rc = kernel_empty_parallel(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_float_all_ops.c
+++ b/regression/cuda/test_float_all_ops.c
@@ -435,33 +435,15 @@ int kernel_float_all_ops (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_float_all_ops Regression Test (COSIMULATION)\n");
-        int rc = kernel_float_all_ops(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_float_all_ops Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_float_all_ops Regression Test \n");
         int rc = kernel_float_all_ops(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_float_matrix_mul.c
+++ b/regression/cuda/test_float_matrix_mul.c
@@ -268,33 +268,15 @@ int kernel_float_matrix_mul (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_float_matrix_mul Regression Test (COSIMULATION)\n");
-        int rc = kernel_float_matrix_mul(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_float_matrix_mul Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_float_matrix_mul Regression Test\n");
         int rc = kernel_float_matrix_mul(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_float_matrix_mul_shared_mem.c
+++ b/regression/cuda/test_float_matrix_mul_shared_mem.c
@@ -268,33 +268,15 @@ int kernel_float_matrix_mul_shared_mem (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_float_matrix_mul_shared_mem Regression Test (COSIMULATION)\n");
-        int rc = kernel_float_matrix_mul_shared_mem(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_float_matrix_mul_shared_mem Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_float_matrix_mul_shared_mem Regression Test \n");
         int rc = kernel_float_matrix_mul_shared_mem(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_float_vec_add.c
+++ b/regression/cuda/test_float_vec_add.c
@@ -246,33 +246,15 @@ int kernel_float_vec_add (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_float_vec_add Regression Test (COSIMULATION)\n");
-        int rc = kernel_float_vec_add(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_float_vec_add Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_float_vec_add Regression Test\n");
         int rc = kernel_float_vec_add(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_float_vec_add_shared_mem.c
+++ b/regression/cuda/test_float_vec_add_shared_mem.c
@@ -245,33 +245,14 @@ int kernel_float_vec_add_shared_mem (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_float_vec_add_shared_mem Regression Test (COSIMULATION)\n");
-        int rc = kernel_float_vec_add_shared_mem(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_float_vec_add_shared_mem Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_float_vec_add_shared_mem Regression Test \n");
         int rc = kernel_float_vec_add_shared_mem(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
 

--- a/regression/cuda/test_float_vec_div.c
+++ b/regression/cuda/test_float_vec_div.c
@@ -245,33 +245,15 @@ int kernel_float_vec_div (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_float_vec_div Regression Test (COSIMULATION)\n");
-        int rc = kernel_float_vec_div(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_float_vec_div Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_float_vec_div Regression Test\n");
         int rc = kernel_float_vec_div(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_float_vec_exp.c
+++ b/regression/cuda/test_float_vec_exp.c
@@ -227,33 +227,14 @@ int kernel_float_vec_exp (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_float_vec_exp Regression Test (COSIMULATION)\n");
-        int rc = kernel_float_vec_exp(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_float_vec_exp Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_float_vec_exp Regression Test \n");
         int rc = kernel_float_vec_exp(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
 

--- a/regression/cuda/test_float_vec_log.c
+++ b/regression/cuda/test_float_vec_log.c
@@ -230,33 +230,15 @@ int kernel_float_vec_log (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_float_vec_log Regression Test (COSIMULATION)\n");
-        int rc = kernel_float_vec_log(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_float_vec_log Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_float_vec_log Regression Test\n");
         int rc = kernel_float_vec_log(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_float_vec_mul.c
+++ b/regression/cuda/test_float_vec_mul.c
@@ -246,33 +246,13 @@ int kernel_float_vec_mul (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_float_vec_mul Regression Test (COSIMULATION)\n");
-        int rc = kernel_float_vec_mul(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_float_vec_mul Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_float_vec_mul Regression Test \n");
         int rc = kernel_float_vec_mul(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
-

--- a/regression/cuda/test_float_vec_sqrt.c
+++ b/regression/cuda/test_float_vec_sqrt.c
@@ -227,33 +227,15 @@ int kernel_float_vec_sqrt (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_float_vec_sqrt Regression Test (COSIMULATION)\n");
-        int rc = kernel_float_vec_sqrt(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_float_vec_sqrt Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_float_vec_sqrt Regression Test\n");
         int rc = kernel_float_vec_sqrt(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_hammer_cache.cpp
+++ b/regression/cuda/test_hammer_cache.cpp
@@ -101,33 +101,13 @@ int test_loader (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("Unified Main Regression Test (COSIMULATION)\n");
-        int rc = test_loader(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("Unified Main CUDA Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("Unified Main CUDA Regression Test \n");
         int rc = test_loader(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
-

--- a/regression/cuda/test_host_memset.c
+++ b/regression/cuda/test_host_memset.c
@@ -161,33 +161,15 @@ int kernel_host_memset (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_host_memset Regression Test (COSIMULATION)\n");
-        int rc = kernel_host_memset(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_host_memset Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_host_memset Regression Test \n");
         int rc = kernel_host_memset(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_loader.c
+++ b/regression/cuda/test_loader.c
@@ -145,33 +145,15 @@ int test_loader (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("Unified Main Regression Test (COSIMULATION)\n");
-        int rc = test_loader(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("Unified Main CUDA Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("Unified Main CUDA Regression Test\n");
         int rc = test_loader(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_log_softmax.c
+++ b/regression/cuda/test_log_softmax.c
@@ -168,35 +168,13 @@ int kernel_log_softmax(int argc, char **argv)
         return HB_MC_FAIL;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char *args)
-{
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_log_softmax Regression Test (COSIMULATION)\n");
-        int rc = kernel_log_softmax(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
-int main(int argc, char **argv)
-{
-        bsg_pr_test_info("test_log_softmax Regression Test (F1)\n");
+int main(int argc, char ** argv) {
+#endif
+        bsg_pr_test_info("test_log_softmax Regression Test \n");
         int rc = kernel_log_softmax(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
-

--- a/regression/cuda/test_matrix_mul.c
+++ b/regression/cuda/test_matrix_mul.c
@@ -245,33 +245,15 @@ int kernel_matrix_mul (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_matrix_mul Regression Test (COSIMULATION)\n");
-        int rc = kernel_matrix_mul(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_matrix_mul Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_matrix_mul Regression Test\n");
         int rc = kernel_matrix_mul(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_matrix_mul_shared_mem.c
+++ b/regression/cuda/test_matrix_mul_shared_mem.c
@@ -243,33 +243,13 @@ int kernel_matrix_mul_shared_mem (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_matrix_mul_shared_mem Regression Test (COSIMULATION)\n");
-        int rc = kernel_matrix_mul_shared_mem(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_matrix_mul_shared_mem Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_matrix_mul_shared_mem Regression Test \n");
         int rc = kernel_matrix_mul_shared_mem(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
-

--- a/regression/cuda/test_max_pool2d.c
+++ b/regression/cuda/test_max_pool2d.c
@@ -276,33 +276,15 @@ int kernel_max_pool2d(int argc, char **argv) {
 }
 
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_max_pool2d Regression Test (COSIMULATION)\n");
-        int rc = kernel_max_pool2d(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_max_pool2d Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_max_pool2d Regression Test\n");
         int rc = kernel_max_pool2d(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_multiple_binary_load.c
+++ b/regression/cuda/test_multiple_binary_load.c
@@ -181,33 +181,15 @@ int kernel_multiple_binary_load (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_multiple_binary_load Regression Test (COSIMULATION)\n");
-        int rc = kernel_multiple_binary_load(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_multiple_binary_load Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_multiple_binary_load Regression Test \n");
         int rc = kernel_multiple_binary_load(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_shared_mem.c
+++ b/regression/cuda/test_shared_mem.c
@@ -157,33 +157,15 @@ int kernel_shared_mem (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_shared_mem Regression Test (COSIMULATION)\n");
-        int rc = kernel_shared_mem(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_shared_mem Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_shared_mem Regression Test\n");
         int rc = kernel_shared_mem(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_shared_mem_load_store.c
+++ b/regression/cuda/test_shared_mem_load_store.c
@@ -193,33 +193,15 @@ int kernel_shared_mem_load_store (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_shared_mem_load_store Regression Test (COSIMULATION)\n");
-        int rc = kernel_shared_mem_load_store(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_shared_mem_load_store Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_shared_mem_load_store Regression Test \n");
         int rc = kernel_shared_mem_load_store(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_softmax.c
+++ b/regression/cuda/test_softmax.c
@@ -172,35 +172,15 @@ int kernel_softmax(int argc, char **argv)
         return HB_MC_FAIL;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char *args)
-{
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_softmax Regression Test (COSIMULATION)\n");
-        int rc = kernel_softmax(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
-int main(int argc, char **argv)
-{
-        bsg_pr_test_info("test_softmax Regression Test (F1)\n");
+int main(int argc, char ** argv) {
+#endif
+        bsg_pr_test_info("test_softmax Regression Test\n");
         int rc = kernel_softmax(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_stack_load.c
+++ b/regression/cuda/test_stack_load.c
@@ -159,34 +159,15 @@ int kernel_stack_load (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_stack_load Regression Test (COSIMULATION)\n");
-        int rc = kernel_stack_load(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_stack_load Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_stack_load Regression Test \n");
         int rc = kernel_stack_load(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_vec_add.c
+++ b/regression/cuda/test_vec_add.c
@@ -217,33 +217,15 @@ int kernel_vec_add (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_vec_add Regression Test (COSIMULATION)\n");
-        int rc = kernel_vec_add(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_vec_add Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_vec_add Regression Test\n");
         int rc = kernel_vec_add(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_vec_add_dma.cpp
+++ b/regression/cuda/test_vec_add_dma.cpp
@@ -177,32 +177,14 @@ int kernel_vec_add (int argc, char **argv) {
         return mismatch ? HB_MC_FAIL : HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_vec_add Regression Test (COSIMULATION)\n");
-        int rc = kernel_vec_add(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_vec_add Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_vec_add Regression Test\n");
         int rc = kernel_vec_add(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+

--- a/regression/cuda/test_vec_add_parallel.c
+++ b/regression/cuda/test_vec_add_parallel.c
@@ -217,33 +217,15 @@ int kernel_vec_add_parallel (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_vec_add_parallel Regression Test (COSIMULATION)\n");
-        int rc = kernel_vec_add_parallel(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_vec_add_parallel Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_vec_add_parallel Regression Test \n");
         int rc = kernel_vec_add_parallel(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_vec_add_parallel_multi_grid.c
+++ b/regression/cuda/test_vec_add_parallel_multi_grid.c
@@ -318,33 +318,15 @@ int kernel_vec_add_parallel_multi_grid (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_vec_add_parallel_multi_grid Regression Test (COSIMULATION)\n");
-        int rc = kernel_vec_add_parallel_multi_grid(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_vec_add_parallel_multi_grid Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_vec_add_parallel_multi_grid Regression Test\n");
         int rc = kernel_vec_add_parallel_multi_grid(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/cuda/test_vec_add_serial_multi_grid.c
+++ b/regression/cuda/test_vec_add_serial_multi_grid.c
@@ -334,33 +334,14 @@ int kernel_vec_add_serial_multi_grid (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_vec_add_serial_multi_grid Regression Test (COSIMULATION)\n");
-        int rc = kernel_vec_add_serial_multi_grid(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_vec_add_serial_multi_grid Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_vec_add_serial_multi_grid Regression Test \n");
         int rc = kernel_vec_add_serial_multi_grid(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
 

--- a/regression/cuda/test_vec_add_shared_mem.c
+++ b/regression/cuda/test_vec_add_shared_mem.c
@@ -216,33 +216,15 @@ int kernel_vec_add_shared_mem (int argc, char **argv) {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_vec_add_shared_mem Regression Test (COSIMULATION)\n");
-        int rc = kernel_vec_add_shared_mem(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_vec_add_shared_mem Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_vec_add_shared_mem Regression Test\n");
         int rc = kernel_vec_add_shared_mem(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/library/test_manycore_alignment.c
+++ b/regression/library/test_manycore_alignment.c
@@ -296,32 +296,15 @@ cleanup:
         return r;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info(TEST_NAME " Regression Test (COSIMULATION)\n");
-        int rc = test_manycore_alignment();
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info(TEST_NAME " Regression Test (F1)\n");
+#endif
+
+        bsg_pr_test_info(TEST_NAME " Regression Test \n");
         int rc = test_manycore_alignment();
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+

--- a/regression/library/test_manycore_compile.c
+++ b/regression/library/test_manycore_compile.c
@@ -62,32 +62,13 @@ int test_manycore_compile(void)
         print_config(&manycore);
         return 0;
 }
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_manycore_compile Regression Test (COSIMULATION)\n");
-        int rc = test_manycore_compile();
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_manycore_compile Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_manycore_compile Regression Test \n");
         int rc = test_manycore_compile();
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif

--- a/regression/library/test_manycore_credits.c
+++ b/regression/library/test_manycore_credits.c
@@ -110,32 +110,15 @@ cleanup:
         return rc;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info(TEST_NAME " Regression Test (COSIMULATION)\n");
-        int rc = test_manycore_credits();
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info(TEST_NAME " Regression Test (F1)\n");
+#endif
+
+        bsg_pr_test_info(TEST_NAME " Regression Test \n");
         int rc = test_manycore_credits();
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+

--- a/regression/library/test_manycore_dmem_read_write.cpp
+++ b/regression/library/test_manycore_dmem_read_write.cpp
@@ -182,32 +182,14 @@ cleanup:
         return r;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info(TEST_NAME " Regression Test (COSIMULATION)\n");
-        int rc = test_manycore_dmem_read_write();
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info(TEST_NAME " Regression Test (F1)\n");
+#endif
+
+        bsg_pr_test_info(TEST_NAME " Regression Test \n");
         int rc = test_manycore_dmem_read_write();
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif

--- a/regression/library/test_manycore_dram_read_write.c
+++ b/regression/library/test_manycore_dram_read_write.c
@@ -130,32 +130,15 @@ cleanup:
         return r;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info(TEST_NAME " Regression Test (COSIMULATION)\n");
-        int rc = test_manycore_dram_read_write();
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info(TEST_NAME " Regression Test (F1)\n");
+#endif
+
+        bsg_pr_test_info(TEST_NAME " Regression Test \n");
         int rc = test_manycore_dram_read_write();
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+

--- a/regression/library/test_manycore_eva.c
+++ b/regression/library/test_manycore_eva.c
@@ -221,33 +221,15 @@ int test_manycore_eva () {
         return fail ? HB_MC_FAIL : HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_manycore_eva Regression Test (COSIMULATION)\n");
-        int rc = test_manycore_eva();
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_manycore_eva Regression Test (F1)\n");
+#endif
+
+        bsg_pr_test_info("test_manycore_eva Regression Test \n");
         int rc = test_manycore_eva();
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
 

--- a/regression/library/test_manycore_eva_read_write.c
+++ b/regression/library/test_manycore_eva_read_write.c
@@ -332,32 +332,15 @@ cleanup:
         return r;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info(TEST_NAME " Regression Test (COSIMULATION)\n");
-        int rc = test_manycore_eva_read_write();
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info(TEST_NAME " Regression Test (F1)\n");
+#endif
+
+        bsg_pr_test_info(TEST_NAME " Regression Test \n");
         int rc = test_manycore_eva_read_write();
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+

--- a/regression/library/test_manycore_init.c
+++ b/regression/library/test_manycore_init.c
@@ -164,32 +164,15 @@ int test_manycore_init(void)
     
     return fail ? HB_MC_FAIL : HB_MC_SUCCESS;
 }
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info(TEST_NAME " Regression Test (COSIMULATION)\n");
-        int rc = test_manycore_init();
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info(TEST_NAME " Regression Test (F1)\n");
+#endif
+
+        bsg_pr_test_info(TEST_NAME " Regression Test \n");
         int rc = test_manycore_init();
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+

--- a/regression/library/test_manycore_packets.c
+++ b/regression/library/test_manycore_packets.c
@@ -178,33 +178,15 @@ int test_manycore_packets() {
         return HB_MC_SUCCESS;   
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("%s Regression Test (COSIMULATION)\n", basename(__FILE__));
-        int rc = test_manycore_packets();
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("%s Regression Test (F1)\n", basename(__FILE__));
+#endif
+
+        bsg_pr_test_info("%s Regression Test \n", basename(__FILE__));
         int rc = test_manycore_packets();
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
 

--- a/regression/library/test_manycore_vcache_sequence.c
+++ b/regression/library/test_manycore_vcache_sequence.c
@@ -130,32 +130,14 @@ cleanup:
         return r;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info(TEST_NAME " Regression Test (COSIMULATION)\n");
-        int rc = test_manycore_vcache_sequence();
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info(TEST_NAME " Regression Test (F1)\n");
+#endif
+
+        bsg_pr_test_info(TEST_NAME " Regression Test \n");
         int rc = test_manycore_vcache_sequence();
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif

--- a/regression/library/test_printing.c
+++ b/regression/library/test_printing.c
@@ -47,6 +47,15 @@
 #include "test_printing.h"
 static int test_printing(void)
 {
+        int rc;
+        hb_mc_manycore_t mc = {0};
+        rc = hb_mc_manycore_init(&mc, "manycore@test_rom", 0);
+        if(rc != HB_MC_SUCCESS){
+                bsg_pr_test_err("Failed to initialize manycore device: %s\n",
+                                hb_mc_strerror(rc));
+                return HB_MC_FAIL;
+        }
+
         bsg_pr_dbg("testing ");
         bsg_pr_dbg("1... ");
         bsg_pr_dbg("2... ");
@@ -62,34 +71,18 @@ static int test_printing(void)
         bsg_pr_warn("%d\n%d\n%s\n", 1, 2, "hello");
 
         bsg_pr_info("%s %s\n%s\n", "hello", "from", "info");
+        rc = hb_mc_manycore_exit(&mc);
+
         return 0;
 }
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
 
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_printing Regression Test (COSIMULATION)\n");
-        int rc = test_printing();
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_printing Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_printing Regression Test\n");
         int rc = test_printing();
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif

--- a/regression/library/test_printing.c
+++ b/regression/library/test_printing.c
@@ -47,6 +47,7 @@
 #include "test_printing.h"
 static int test_printing(void)
 {
+        int rc;
         hb_mc_manycore_t mc = {0};
         rc = hb_mc_manycore_init(&mc, "manycore@test_rom", 0);
         if(rc != HB_MC_SUCCESS){

--- a/regression/library/test_printing.c
+++ b/regression/library/test_printing.c
@@ -47,7 +47,6 @@
 #include "test_printing.h"
 static int test_printing(void)
 {
-        int rc;
         hb_mc_manycore_t mc = {0};
         rc = hb_mc_manycore_init(&mc, "manycore@test_rom", 0);
         if(rc != HB_MC_SUCCESS){

--- a/regression/library/test_read_mem_scatter_gather.c
+++ b/regression/library/test_read_mem_scatter_gather.c
@@ -155,33 +155,15 @@ done:
 
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info(TEST_NAME " Regression Test (COSIMULATION)\n");
-        int rc = run_tests();
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info(TEST_NAME " Regression Test (F1)\n");
+#endif
+
+        bsg_pr_test_info(TEST_NAME " Regression Test \n");
         int rc = run_tests();
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
 

--- a/regression/library/test_rom.c
+++ b/regression/library/test_rom.c
@@ -285,35 +285,14 @@ cleanup:
         return fail ? HB_MC_FAIL : HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc + 1];
-        get_argv(args, argc, argv);
-        argv[argc] = NULL;
-
 #ifdef VCS
-
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_rom Regression Test (COSIMULATION)\n");
-        int rc = test_rom(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
-int main(int argc, char **argv) {
-        bsg_pr_test_info("test_rom Regression Test (F1)\n");
+int main(int argc, char ** argv) {
+#endif
+
+        bsg_pr_test_info("test_rom Regression Test \n");
         int rc = test_rom(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
-

--- a/regression/library/test_struct_size.c
+++ b/regression/library/test_struct_size.c
@@ -37,32 +37,14 @@ int test_struct_size() {
         }
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_struct_size Regression Test (COSIMULATION)\n");
-        int rc = test_struct_size();
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_struct_size Regression Test (F1)\n");
+#endif
+
+        bsg_pr_test_info("test_struct_size Regression Test \n");
         int rc = test_struct_size();
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif

--- a/regression/library/test_unified_main.c
+++ b/regression/library/test_unified_main.c
@@ -27,33 +27,15 @@
 
 #include "test_unified_main.h"
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_unified_main Regression Test (COSIMULATION)\n");
-        int rc = HB_MC_SUCCESS;
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_unified_main Regression Test (F1)\n");
+#endif
+
+        bsg_pr_test_info("test_unified_main Regression Test \n");
         int rc = HB_MC_SUCCESS;
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
 

--- a/regression/library/test_vcache_flush.cpp
+++ b/regression/library/test_vcache_flush.cpp
@@ -226,32 +226,14 @@ int test_vcache_flush() {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_vcache_flush Regression Test (COSIMULATION)\n");
-        int rc = test_vcache_flush();
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_vcache_flush Regression Test (F1)\n");
+#endif
+
+        bsg_pr_test_info("test_vcache_flush Regression Test \n");
         int rc = test_vcache_flush();
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif

--- a/regression/library/test_vcache_sequence.c
+++ b/regression/library/test_vcache_sequence.c
@@ -99,32 +99,14 @@ int test_vcache_sequence() {
         return HB_MC_SUCCESS;           
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_vcache_sequence Regression Test (COSIMULATION)\n");
-        int rc = test_vcache_sequence();
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_vcache_sequence Regression Test (F1)\n");
+#endif
+
+        bsg_pr_test_info("test_vcache_sequence Regression Test \n");
         int rc = test_vcache_sequence();
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif

--- a/regression/library/test_vcache_simplified.c
+++ b/regression/library/test_vcache_simplified.c
@@ -138,32 +138,15 @@ cleanup:
         return r;               
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test vcache simplified Regression Test (COSIMULATION)\n");
-        int rc = test_vcache_simplified();
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test vcache simplified Regression Test (F1)\n");
+#endif
+
+        bsg_pr_test_info("test vcache simplified Regression Test \n");
         int rc = test_vcache_simplified();
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+

--- a/regression/library/test_vcache_stride.c
+++ b/regression/library/test_vcache_stride.c
@@ -124,32 +124,14 @@ int test_vcache_stride() {
         return HB_MC_SUCCESS;
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_vcache_stride Regression Test (COSIMULATION)\n");
-        int rc = test_vcache_stride();
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_vcache_stride Regression Test (F1)\n");
+#endif
+
+        bsg_pr_test_info("test_vcache_stride Regression Test \n");
         int rc = test_vcache_stride();
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif

--- a/regression/python/test_loader.c
+++ b/regression/python/test_loader.c
@@ -56,32 +56,13 @@ int test_python(int argc, char **argv) {
         return Py_Main(py_argc, py_argv);
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_python Regression Test (COSIMULATION)\n");
-        int rc = test_python(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
-int main(int argc, char **argv) {
-        bsg_pr_test_info("test_python Regression Test (F1)\n");
+int main(int argc, char ** argv) {
+#endif
+        bsg_pr_test_info("test_python Regression Test\n");
         int rc = test_python(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif

--- a/regression/pytorch/test_loader.c
+++ b/regression/pytorch/test_loader.c
@@ -56,32 +56,14 @@ int test_pytorch(int argc, char **argv) {
         return Py_Main(py_argc, py_argv);
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_pytorch Regression Test (COSIMULATION)\n");
-        int rc = test_pytorch(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
-int main(int argc, char **argv) {
-        bsg_pr_test_info("test_pytorch Regression Test (F1)\n");
+int main(int argc, char ** argv) {
+#endif
+        bsg_pr_test_info("test_pytorch Regression Test \n");
         int rc = test_pytorch(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+

--- a/regression/specint/test_loader.c
+++ b/regression/specint/test_loader.c
@@ -177,31 +177,13 @@ int test_loader (int argc, char **argv) {
         
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        int rc = test_loader(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
+#endif
         int rc = test_loader(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
 

--- a/regression/spmd/test_bsg_dram_loopback_cache.c
+++ b/regression/spmd/test_bsg_dram_loopback_cache.c
@@ -181,34 +181,15 @@ cleanup:
         return r;
 }
 
-
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_bsg_dram_loopback_cache Regression Test (COSIMULATION)\n");
-        int rc = test_loopback(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_bsg_dram_loopback_cache Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_bsg_dram_loopback_cache Regression Test \n");
         int rc = test_loopback(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/regression/spmd/test_bsg_loader_suite.c
+++ b/regression/spmd/test_bsg_loader_suite.c
@@ -623,34 +623,14 @@ int test_loader_suite (int argc, char **argv) {
         return err;
 }
 
-
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info(SUITE_NAME " Regression Test (COSIMULATION)\n");
-        int rc = test_loader_suite(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info(SUITE_NAME " Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info(SUITE_NAME " Regression Test \n");
         int rc = test_loader_suite(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
 

--- a/regression/spmd/test_bsg_scalar_print.c
+++ b/regression/spmd/test_bsg_scalar_print.c
@@ -269,34 +269,14 @@ cleanup:
         return r;
 }
 
-
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_bsg_scalar_print Regression Test (COSIMULATION)\n");
-        int rc = test_scalar_print(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_bsg_scalar_print Regression Test (F1)\n");
+#endif
+        bsg_pr_test_info("test_bsg_scalar_print Regression Test \n");
         int rc = test_scalar_print(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
 

--- a/regression/spmd/test_loader.c
+++ b/regression/spmd/test_loader.c
@@ -180,31 +180,13 @@ cleanup:
         
 }
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        int rc = test_loader(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
+#endif
         int rc = test_loader(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
 

--- a/regression/spmd/test_symbol_to_eva.c
+++ b/regression/spmd/test_symbol_to_eva.c
@@ -207,33 +207,16 @@ int test_symbol_to_eva (int argc, char **argv) {
 }
 
 
-#ifdef COSIM
-void cosim_main(uint32_t *exit_code, char * args) {
-        // We aren't passed command line arguments directly so we parse them
-        // from *args. args is a string from VCS - to pass a string of arguments
-        // to args, pass c_args to VCS as follows: +c_args="<space separated
-        // list of args>"
-        int argc = get_argc(args);
-        char *argv[argc];
-        get_argv(args, argc, argv);
-
 #ifdef VCS
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-#endif
-        bsg_pr_test_info("test_symbol_to_eva Regression Test (COSIMULATION)\n");
-        int rc = test_symbol_to_eva(argc, argv);
-        *exit_code = rc;
-        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
-        return;
-}
+int vcs_main(int argc, char ** argv) {
 #else
 int main(int argc, char ** argv) {
-        bsg_pr_test_info("test_symbol_to_eva Regression Test (F1)\n");
+#endif
+
+        bsg_pr_test_info("test_symbol_to_eva Regression Test \n");
         int rc = test_symbol_to_eva(argc, argv);
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return rc;
 }
-#endif
+
 

--- a/testbenches/cosimulation.mk
+++ b/testbenches/cosimulation.mk
@@ -50,7 +50,6 @@ endif
 
 # The bsg_manycore_runtime headers are in $(LIBRARIES_PATH) (for cosimulation)
 INCLUDES   += -I$(LIBRARIES_PATH) 
-INCLUDES   += -I$(VCS_HOME)/linux64/lib/
 
 # CSOURCES/HEADERS should probably go in some regression file list.
 CDEFINES   += -DCOSIM -DVCS

--- a/testbenches/simlibs.mk
+++ b/testbenches/simlibs.mk
@@ -201,6 +201,7 @@ $(LIB_OBJECTS): CXXFLAGS += -DCOSIM
 $(LIB_OBJECTS): CFLAGS   += -DCOSIM
 
 # libfpga_mgmt will be compiled in $(TESTBENCH_PATH), so direct the linker there
+$(LIB_OBJECTS): INCLUDES += -I$(VCS_HOME)/linux64/lib/
 $(LIBRARIES_PATH)/libbsg_manycore_runtime.so.1.0: LDFLAGS +=-L$(TESTBENCH_PATH) 
 $(LIBRARIES_PATH)/libbsg_manycore_runtime.so.1.0: LDFLAGS +=-Wl,-rpath=$(TESTBENCH_PATH)
 $(LIBRARIES_PATH)/libbsg_manycore_runtime.so.1.0: $(TESTBENCH_PATH)/libfpga_mgmt.so


### PR DESCRIPTION
* moved cosim_main to header file (which seems REALLY strange)
* Moved svScope VCS code into bsg_manycore_lib with macro guards

Passes regression on 4x4_fast_n_fake (except for test_symbol_to_eva)

This makes cosim_main VCS specific, not cosim specific (because Verilator uses main)