### PR TITLE
Snooping vcache profiler's incoming print_stat_v signal

### DIFF
--- a/hardware/cl_manycore.sv
+++ b/hardware/cl_manycore.sv
@@ -548,8 +548,8 @@ module cl_manycore
     ) vcache_prof (
       .*
       ,.global_ctr_i($root.tb.card.fpga.CL.global_ctr)
-      ,.print_stat_v_i($root.tb.card.fpga.CL.print_stat_v_lo)
-      ,.print_stat_tag_i($root.tb.card.fpga.CL.print_stat_tag_lo)
+      ,.print_stat_v_i($root.tb.card.fpga.CL.print_stat_v)
+      ,.print_stat_tag_i($root.tb.card.fpga.CL.print_stat_tag)
       ,.trace_en_i($root.tb.card.fpga.CL.trace_en)
     );
     // synopsys translate_on


### PR DESCRIPTION
Due to varying frequencies of cosimulation during IO vs. compute, print_stat_v signal is not being detected by the vcache_profiler module and vcache stats are not being printed.  Switched the incoming stats profiler's signal to come from the snooping module, similar to the vanilla_core_profiler. 