### PR TITLE
CUDA Malloc Bugfix in API

### DIFF
--- a/libraries/bsg_manycore_cuda.cpp
+++ b/libraries/bsg_manycore_cuda.cpp
@@ -642,6 +642,7 @@ static int hb_mc_tile_group_enqueue (hb_mc_device_t* device,
         tg->id = tg_id;
         tg->grid_id = grid_id;
         tg->grid_dim = grid_dim;
+        tg->argc = argc;
         tg->status = HB_MC_TILE_GROUP_STATUS_INITIALIZED;
 
         tg->map = (hb_mc_eva_map_t *) malloc (sizeof(hb_mc_eva_map_t)); 
@@ -748,6 +749,10 @@ static int hb_mc_tile_group_launch (hb_mc_device_t *device,
                 return HB_MC_NOMEM;
         }
 
+        // store the address of argv in the host, to free the 
+        // memory location in the device DRAM after tile group is executed
+        tg->argv_eva = args_eva;
+
         // transfer the arguments to dram
         error = hb_mc_device_memcpy(    device, reinterpret_cast<void *>(args_eva),
                                         (void *) &(tg->kernel->argv[0]),
@@ -827,6 +832,7 @@ static int hb_mc_tile_group_launch (hb_mc_device_t *device,
 
 /**
  * De-allocates all tiles in tile group, and resets their tile-group id and origin in the device book keeping.
+ * Also free's the memory location in device's DRAM that holds the list of argument for tile group's kernel.
  * @param[in]  device        Pointer to device
  * @parma[in]  tg            Pointer to tile group
  * @return HB_MC_SUCCESS if succesful. Otherwise an error code is returned.
@@ -854,6 +860,17 @@ static int hb_mc_tile_group_deallocate_tiles(hb_mc_device_t *device,
                    hb_mc_coordinate_get_x(tg->origin), hb_mc_coordinate_get_y(tg->origin));
         
         tg->status = HB_MC_TILE_GROUP_STATUS_FINISHED;
+
+        // Free the memory location in the device that holds the list of arguments of tile group's kernel
+        error = hb_mc_device_free(device, tg->argv_eva);
+        if (error != HB_MC_SUCCESS) { 
+                bsg_pr_err("%s: failed to free the argument list for grid %d tile group (%d,%d).\n", 
+                           __func__,
+                           tg->grid_id,
+                           hb_mc_coordinate_get_x (tg->id),
+                           hb_mc_coordinate_get_y (tg->id));
+                return error;
+        }
 
         return HB_MC_SUCCESS;
 }
@@ -1478,6 +1495,7 @@ static int hb_mc_device_wait_for_tile_group_finish_any(hb_mc_device_t *device) {
 /**
  * Iterates over all tile groups inside device, allocates those that fit in mesh and launches them. 
  * API remains in this function until all tile groups have successfully finished execution.
+ * Number of tile groups is reset to zero after all tile groups are executed.
  * @param[in]  device        Pointer to device
  * @return HB_MC_SUCCESS if succesful. Otherwise an error code is returned.
  */
@@ -1508,6 +1526,17 @@ int hb_mc_device_tile_groups_execute (hb_mc_device_t *device) {
                         return error;
                 }
 
+        }
+
+        // Reset number of tile groups to zero
+        // Reset the device's tile group capacity to 1
+        // Readjust the space needed for device's tile groups 
+        device->num_tile_groups = 0;
+        device->tile_group_capacity = 1;
+        device->tile_groups = (hb_mc_tile_group_t *) realloc (device->tile_groups, device->tile_group_capacity * sizeof(hb_mc_tile_group_t));
+        if (device->tile_groups == NULL) {
+                bsg_pr_err("%s: failed to reset the space for hb_mc_tile_group_t structs.\n", __func__);
+                return HB_MC_NOMEM;
         }
 
         return HB_MC_SUCCESS;

--- a/libraries/bsg_manycore_cuda.h
+++ b/libraries/bsg_manycore_cuda.h
@@ -92,6 +92,8 @@ extern "C" {
                 hb_mc_dimension_t dim;
                 hb_mc_eva_map_t *map;
                 hb_mc_kernel_t *kernel;
+                uint32_t argc;
+                hb_mc_eva_t argv_eva;
         } hb_mc_tile_group_t;
 
 

--- a/regression/cuda/test_memory_leak.cpp
+++ b/regression/cuda/test_memory_leak.cpp
@@ -1,0 +1,128 @@
+// Copyright (c) 2019, University of Washington All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// Redistributions of source code must retain the above copyright notice, this list
+// of conditions and the following disclaimer.
+//
+// Redistributions in binary form must reproduce the above copyright notice, this
+// list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// Neither the name of the copyright holder nor the names of its contributors may
+// be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "test_memory_leak.hpp"
+
+#define ALLOC_NAME "default_allocator"
+
+#define NUM_ITER 32
+#define WIDTH (1 << 24)
+/*!
+ * Makes sure CUDA-Lite API does not have any memory leaks.
+ * Runs an empty test multiple times while allocating large
+ * chunks of memory before every kernel call and freeing them after.
+ * If the CUDA API doesn't have memory leaks, the address of 
+ * allocated spaces should match every time.  
+*/
+
+int kernel_memory_leak (int argc, char **argv) {
+        char *bin_path, *test_name;
+        struct arguments_path args = {NULL, NULL};
+
+        argp_parse (&argp_path, argc, argv, 0, 0, &args);
+        bin_path = args.path;
+        test_name = args.name;
+
+        bsg_pr_test_info("Running the CUDA Malloc Free Kernel on a 4x4 tile group.\n");
+
+        srand(static_cast<unsigned>(time(0)));
+
+        /* Define path to binary. */
+        /* Initialize device, load binary and unfreeze tiles. */
+        hb_mc_dimension_t tg_dim = { .x = 2, .y = 2};
+        hb_mc_device_t device;
+        BSG_CUDA_CALL(hb_mc_device_init_custom_dimensions(&device, test_name, 0, tg_dim));
+
+        BSG_CUDA_CALL(hb_mc_device_program_init(&device, bin_path, ALLOC_NAME, 0));
+
+        /* Allocate memory on the device for A, B and C. */
+        constexpr size_t vsize = WIDTH * sizeof(uint32_t);
+
+        bool mismatch = false;
+
+        hb_mc_eva_t A_device, B_device, C_device;
+        hb_mc_eva_t A_prev = A_device;
+        hb_mc_eva_t B_prev = B_device;
+        hb_mc_eva_t C_prev = C_device;
+
+        for (int i = 0; i < NUM_ITER; i ++) {
+
+            // If the address of current allocation doesn't match the address of 
+            // previous allocation, we have a memory leak
+            if ((A_device != A_prev) || (B_device != B_prev) || (C_device != C_prev)) {
+                bsg_pr_err("Address Mismatch -- you have a memory leak!\n");
+                mismatch = true;
+                break;
+            }
+
+            BSG_CUDA_CALL(hb_mc_device_malloc(&device, vsize, &A_device)); 
+            BSG_CUDA_CALL(hb_mc_device_malloc(&device, vsize, &B_device)); 
+            BSG_CUDA_CALL(hb_mc_device_malloc(&device, vsize, &C_device)); 
+    
+            bsg_pr_test_info("iter %d\tA: 0x%x\tB: 0x%x\tC: 0x%x\n", i, A_device, B_device, C_device);
+    
+            /* Define tg_dim_x/y: number of tiles in each tile group */
+            /* Calculate grid_dim_x/y: number of tile groups needed based on block_size_x/y */
+            hb_mc_dimension_t grid_dim = { .x = 1, .y = 1};
+    
+            /* Prepare list of input arguments for kernel. */
+            uint32_t cuda_argv[3] = {A_device, B_device, C_device};
+    
+            /* Enqqueue grid of tile groups, pass in grid and tile group dimensions,
+               kernel name, number and list of input arguments */
+            BSG_CUDA_CALL(hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_memory_leak", 3, cuda_argv));
+    
+            /* Launch and execute all tile groups on device and wait for all to finish.  */
+            BSG_CUDA_CALL(hb_mc_device_tile_groups_execute(&device));
+    
+            BSG_CUDA_CALL(hb_mc_device_free(&device, A_device));
+            BSG_CUDA_CALL(hb_mc_device_free(&device, B_device));
+            BSG_CUDA_CALL(hb_mc_device_free(&device, C_device));
+
+            A_prev = A_device;
+            B_prev = B_device;
+            C_prev = C_device;
+        }
+
+
+        /* Freeze the tiles and memory manager cleanup.  */
+        BSG_CUDA_CALL(hb_mc_device_finish(&device));
+
+        return mismatch ? HB_MC_FAIL : HB_MC_SUCCESS;
+}
+
+#ifdef VCS
+int vcs_main(int argc, char ** argv) {
+#else
+int main(int argc, char ** argv) {
+#endif
+        bsg_pr_test_info("test_memory_leak Regression Test\n");
+        int rc = kernel_memory_leak(argc, argv);
+        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
+        return rc;
+}
+

--- a/regression/cuda/test_memory_leak.hpp
+++ b/regression/cuda/test_memory_leak.hpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2019, University of Washington All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// Redistributions of source code must retain the above copyright notice, this list
+// of conditions and the following disclaimer.
+//
+// Redistributions in binary form must reproduce the above copyright notice, this
+// list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// Neither the name of the copyright holder nor the names of its contributors may
+// be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef TEST_MEMORY_LEAK_H
+#define TEST_MEMORY_LEAK_H
+
+
+#include <stdio.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <string.h>
+#include <time.h>
+#include <stdlib.h>
+
+#include "cuda_tests.h"
+
+
+#endif

--- a/regression/cuda/tests.mk
+++ b/regression/cuda/tests.mk
@@ -49,6 +49,7 @@ INDEPENDENT_TESTS += test_empty_parallel
 INDEPENDENT_TESTS += test_multiple_binary_load
 INDEPENDENT_TESTS += test_host_memset
 INDEPENDENT_TESTS += test_stack_load
+INDEPENDENT_TESTS += test_memory_leak
 INDEPENDENT_TESTS += test_dram_load_store
 INDEPENDENT_TESTS += test_dram_host_allocated
 INDEPENDENT_TESTS += test_dram_device_allocated


### PR DESCRIPTION
1. API now resets the number of tile groups to zero in the host, after every hb_mc_tile_groups_execute call.
2. API allocates a space in device DRAM to store kernel arguments before tile group launch, it now frees that location after tile group is executed.
3. Adds a memory_leak regression test to make sure CUDA Lite API does not have memory leak on launching tile groups.

**merge with PR # 317 in bsg_manycore.**