### PR TITLE
Split out machine-specific functionality into new file

### DIFF
--- a/libraries/bsg_manycore.cpp
+++ b/libraries/bsg_manycore.cpp
@@ -26,21 +26,15 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <bsg_manycore.h>
+#include <bsg_manycore_platform.h>
 #include <bsg_manycore_fifo.h>
-#include <bsg_manycore_mmio.h>
 #include <bsg_manycore_printing.h>
 #include <bsg_manycore_tile.h>
 #include <bsg_manycore_responder.h>
 #include <bsg_manycore_epa.h>
 #include <bsg_manycore_vcache.h>
 
-#ifndef COSIM
-#include <fpga_pci.h>
-#include <fpga_mgmt.h>
-#else
-#include <svdpi.h>
-#include <fpga_pci_sv.h>
-#include <utils/sh_dpi_tasks.h>
+#ifdef COSIM
 #include <bsg_mem_dma.hpp>
 #endif
 
@@ -89,274 +83,32 @@
         bsg_pr_info("%s: " fmt, mc->name, ##__VA_ARGS__)
 
 
-// #undef manycore_pr_err
-// #define manycore_pr_err(...)
+/////////////////////////////////
+/* Flow Control Help Functions */
+/////////////////////////////////
 
-typedef struct hb_mc_manycore_private {
-        pci_bar_handle_t handle;
-} hb_mc_manycore_private_t;
-
-
-static int  hb_mc_manycore_mmio_read_mmio(hb_mc_manycore_t *mc, uintptr_t offset,
-                                          void *vo, size_t sz);
-
-static int  hb_mc_manycore_mmio_read_pci(hb_mc_manycore_t *mc, uintptr_t offset,
-                                         void *vp, size_t sz);
-static int hb_mc_manycore_mmio_read(hb_mc_manycore_t *mc, uintptr_t offset,
-                                    void *vp, size_t sz);
-
-static int  hb_mc_manycore_init_mmio(hb_mc_manycore_t *mc, hb_mc_manycore_id_t id);
-static void hb_mc_manycore_cleanup_mmio(hb_mc_manycore_t *mc);
-static int  hb_mc_manycore_init_private_data(hb_mc_manycore_t *mc);
-static void hb_mc_manycore_cleanup_private_data(hb_mc_manycore_t *mc);
-
-static int hb_mc_manycore_init_dpi(hb_mc_manycore_t *mc);
-static void hb_mc_manycore_cleanup_dpi(hb_mc_manycore_t *mc);
-
-static int hb_mc_manycore_packet_tx_internal(hb_mc_manycore_t *mc,
-                                             hb_mc_packet_t *packet,
-                                             hb_mc_fifo_tx_t type,
-                                             long timeout);
-
-static int hb_mc_manycore_packet_rx_internal(hb_mc_manycore_t *mc,
-                                             hb_mc_packet_t *packet,
-                                             hb_mc_fifo_rx_t type,
-                                             long timeout);
-///////////////////////////
-// FIFO Helper Functions //
-///////////////////////////
-
-/* get the number of unread packets in a FIFO (rx only) */
-static int hb_mc_manycore_rx_fifo_get_occupancy(hb_mc_manycore_t *mc,
-                                                hb_mc_fifo_rx_t type,
-                                                uint32_t *occupancy)
+static int hb_mc_manycore_get_remote_load_cap(hb_mc_manycore_t *mc, unsigned *cap)
 {
-        uint32_t val, occ;
-        uintptr_t occupancy_addr = hb_mc_mmio_fifo_get_addr(type, HB_MC_MMIO_FIFO_RX_OCCUPANCY_OFFSET);
-        const char *typestr = hb_mc_fifo_rx_to_string(type);
-        int err;
-        if (type == HB_MC_FIFO_RX_RSP) {
-            manycore_pr_err(mc, "RX FIFO Occupancy register %s is disabled!\n", typestr);
-            occupancy = NULL;
-            return HB_MC_FAIL;
-        }
-        else {
-            err = hb_mc_manycore_mmio_read32(mc, occupancy_addr, &val);
-            if (err != HB_MC_SUCCESS) {
-                    manycore_pr_err(mc, "Failed to get %s occupancy\n", typestr);
-                    return err;
-            }
-
-            // All packets recieved packets should have an integral occupancy that
-            // is determined by the Packet Bit-Width / FIFO Bit-Width
-            occ = ((sizeof(hb_mc_packet_t) * 8))/HB_MC_MMIO_FIFO_DATA_WIDTH;
-            if((occ < ((sizeof(hb_mc_packet_t) * 8))/HB_MC_MMIO_FIFO_DATA_WIDTH) && (val % occ != 0)) {
-                    manycore_pr_err(mc, "Invalid occupancy: Non-integral packet"
-                                    " received from %s\n", typestr);
-                    return HB_MC_FAIL;
-            }
-
-            *occupancy = (val / occ);
-            return HB_MC_SUCCESS;
-        }
-
-}
-
-/* get the number of remaining packets in a host tx FIFO */
-static int hb_mc_manycore_tx_fifo_get_vacancy(hb_mc_manycore_t *mc,
-                                              hb_mc_fifo_tx_t type,
-                                              uint32_t *vacancy)
-{
-        uint32_t val, vac;
-        uintptr_t vacancy_addr = hb_mc_mmio_fifo_get_addr(type, HB_MC_MMIO_FIFO_TX_VACANCY_OFFSET);
-        const char *typestr = hb_mc_fifo_tx_to_string(type);
-        int err;
-        if (type == HB_MC_FIFO_TX_RSP) {
-            manycore_pr_err(mc, "TX FIFO Vacancy register %s is disabled!\n", typestr);
-            vacancy = NULL;
-            return HB_MC_FAIL;
-        }
-        else {
-            err = hb_mc_manycore_mmio_read32(mc, vacancy_addr, &val);
-            if (err != HB_MC_SUCCESS) {
-                    manycore_pr_err(mc, "Failed to get %s vacancy\n", typestr);
-                    return err;
-            }
-
-            // All packets recieved packets should have an integral vacancy that
-            // is determined by the Packet Bit-Width / FIFO Bit-Width
-            vac = ((sizeof(hb_mc_packet_t) * 8))/HB_MC_MMIO_FIFO_DATA_WIDTH;
-            if((vac < ((sizeof(hb_mc_packet_t) * 8))/HB_MC_MMIO_FIFO_DATA_WIDTH) && (val % vac != 0)) {
-                    manycore_pr_err(mc, "Invalid vacancy: Non-integral packet"
-                                    " received from %s\n", typestr);
-                    return HB_MC_FAIL;
-            }
-            *vacancy = (val / vac);
-            return HB_MC_SUCCESS;
-        }
-
-}
-
-/* read all unread packets from a fifo (rx only) */
-static int hb_mc_manycore_rx_fifo_drain(hb_mc_manycore_t *mc, hb_mc_fifo_rx_t type)
-{
-        const char *typestr = hb_mc_fifo_rx_to_string(type);
-        hb_mc_request_packet_t recv;
-        uint32_t occupancy;
-        int rc;
-
-        for (int drains = 0; drains < 20; drains++) {
-                /* first check how many unread packets are currently in the FIFO */
-                rc = hb_mc_manycore_rx_fifo_get_occupancy(mc, type, &occupancy);
-                if (rc != HB_MC_SUCCESS)
-                        return rc;
-
-                /* break if occupancy is zero */
-                if (occupancy == 0)
-                        break;
-
-                /* Read stale packets from fifo */
-                for (unsigned i = 0; i < occupancy; i++){
-                        rc = hb_mc_manycore_packet_rx_internal(mc, (hb_mc_packet_t*) &recv, type, -1);
-                        if (rc != HB_MC_SUCCESS) {
-                                manycore_pr_err(mc, "%s: Failed to read packet from %s fifo\n",
-                                                __func__, typestr);
-                                return HB_MC_FAIL;
-                        }
-
-                        manycore_pr_dbg(mc,
-                                        "%s: packet drained from %s fifo: "
-                                        "src (%d,%d), "
-                                        "dst (%d,%d), "
-                                        "addr: 0x%08x, "
-                                        "data: 0x%08x\n",
-                                        __func__, typestr,
-                                        recv.x_src, recv.y_src,
-                                        recv.x_dst, recv.y_dst,
-                                        recv.addr,
-                                        recv.data);
-                }
-        }
-
-        /* recheck occupancy to make sure all packets are drained. */
-        rc = hb_mc_manycore_rx_fifo_get_occupancy(mc, type, &occupancy);
-        if (rc != HB_MC_SUCCESS)
-                return HB_MC_FAIL;
-
-        /* fail if new packets have arrived */
-        if (occupancy > 0){
-                manycore_pr_err(mc, "%s: Failed to drain %s fifo: new packets generated\n",
-                                __func__, type);
-                return HB_MC_FAIL;
-        }
-
+        const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
+        *cap = hb_mc_config_get_io_remote_load_cap(cfg);
         return HB_MC_SUCCESS;
 }
 
+/**
+ * Stall until the all requests (and responses to the host) have reached their destination.
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in] timeout A timeout counter. Unused - set to -1 to wait forever.
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_manycore_host_request_fence(hb_mc_manycore_t *mc, long timeout)
+{
+        return hb_mc_platform_fence(mc, timeout);
+}
 
 ///////////////////
 // Init/Exit API //
 ///////////////////
 
-#ifdef COSIM
-static int hb_mc_manycore_init_dpi(hb_mc_manycore_t *mc)
-{
-        svScope scope;
-        scope = svGetScopeFromName("tb");
-        svSetScope(scope);
-        return HB_MC_SUCCESS;
-}
-
-static void hb_mc_manycore_cleanup_dpi(hb_mc_manycore_t *mc)
-{
-        return;
-}
-#endif
-
-/* initialize manycore MMIO */
-static int hb_mc_manycore_init_mmio(hb_mc_manycore_t *mc, hb_mc_manycore_id_t id)
-{
-        hb_mc_manycore_private_t *pdata = (hb_mc_manycore_private_t*)mc->private_data;
-        int pf_id = FPGA_APP_PF, write_combine = 0, bar_id = APP_PF_BAR0;
-        int r = HB_MC_FAIL, err;
-
-        // all IDs except 0 are unused at the moment
-        if (id != 0) {
-                manycore_pr_err(mc, "Failed to init MMIO: invalid ID\n");
-                return HB_MC_INVALID;
-        }
-
-        if ((err = fpga_pci_attach(id, pf_id, bar_id, write_combine, &pdata->handle)) != 0) {
-                manycore_pr_err(mc, "Failed to init MMIO: %s\n", FPGA_ERR2STR(err));
-                manycore_pr_err(mc, "Are you running with sudo?\n");
-                return r;
-        }
-
-#if !defined(COSIM) // on F1
-        // it is not clear to me where 0x4000 comes from...
-        // map in the base address register to our address space
-        if ((err = fpga_pci_get_address(pdata->handle, 0, 0x4000, (void**)&mc->mmio)) != 0) {
-                manycore_pr_err(mc, "Failed to init MMIO: %s\n", FPGA_ERR2STR(err));
-                goto cleanup;
-        }
-#else
-        mc->mmio = (uintptr_t)nullptr;
-#endif
-        mc->id = id;
-        r = HB_MC_SUCCESS;
-        manycore_pr_dbg(mc, "%s: mc->mmio = 0x%" PRIxPTR "\n", __func__, mc->mmio);
-        goto done;
-
- cleanup:
-        fpga_pci_detach(pdata->handle);
-        pdata->handle = PCI_BAR_HANDLE_INIT;
- done:
-        return r;
-}
-
-/* cleanup manycore MMIO */
-static void hb_mc_manycore_cleanup_mmio(hb_mc_manycore_t *mc)
-{
-        hb_mc_manycore_private_t *pdata = (hb_mc_manycore_private_t*)mc->private_data;
-        int err;
-
-        if (pdata->handle == PCI_BAR_HANDLE_INIT)
-                return;
-
-        if ((err = fpga_pci_detach(pdata->handle)) != 0)
-                manycore_pr_err(mc, "Failed to cleanup MMIO: %s\n", FPGA_ERR2STR(err));
-
-        pdata->handle = PCI_BAR_HANDLE_INIT;
-        mc->mmio = (uintptr_t)nullptr;
-        mc->id = 0;
-        return;
-}
-
-/* initialize manycore private data */
-static int hb_mc_manycore_init_private_data(hb_mc_manycore_t *mc)
-{
-        int r = HB_MC_FAIL, err;
-        hb_mc_manycore_private_t *pdata;
-
-        mc->private_data = nullptr;
-
-        pdata = (hb_mc_manycore_private_t*)calloc(sizeof(*pdata), 1);
-        if (!pdata) {
-                manycore_pr_err(mc, "%s failed: %m\n", __func__);
-                return HB_MC_NOMEM;
-        }
-
-        pdata->handle = PCI_BAR_HANDLE_INIT;
-        mc->private_data = pdata;
-
-        return HB_MC_SUCCESS;
-}
-
-/* cleanup manycore private data */
-static void hb_mc_manycore_cleanup_private_data(hb_mc_manycore_t *mc)
-{
-        free(mc->private_data);
-}
 
 /* initialize configuration */
 static int hb_mc_manycore_init_config(hb_mc_manycore_t *mc)
@@ -367,13 +119,10 @@ static int hb_mc_manycore_init_config(hb_mc_manycore_t *mc)
         hb_mc_config_raw_t config[HB_MC_CONFIG_MAX];
 
         for (idx = HB_MC_CONFIG_MIN; idx < HB_MC_CONFIG_MAX; idx++) {
-                addr = hb_mc_config_id_to_addr(HB_MC_MMIO_ROM_BASE,
-                                               (hb_mc_config_id_t) idx);
-
-                err = hb_mc_manycore_mmio_read32(mc, addr, &config[idx]);
-                if (err != HB_MC_SUCCESS) {
-                        manycore_pr_err(mc, "%s: Failed to read config word %d from ROM\n",
-                                        __func__, idx);
+                err = hb_mc_platform_get_config_at(mc, idx, &config[idx]);
+                if (err != HB_MC_SUCCESS){
+                        manycore_pr_err(mc, "%s: Failed to read configuration"
+                                        " index %d\n", __func__, idx);
                         return err;
                 }
         }
@@ -389,113 +138,6 @@ static int hb_mc_manycore_init_config(hb_mc_manycore_t *mc)
         manycore_pr_dbg(mc, "Initialized configuration from ROM\n");
 
         return HB_MC_SUCCESS;
-}
-
-
-/////////////////////////////////
-/* Flow Control Help Functions */
-/////////////////////////////////
-
-static int hb_mc_manycore_get_remote_load_cap(hb_mc_manycore_t *mc, unsigned *cap)
-{
-        const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
-        *cap = hb_mc_config_get_io_remote_load_cap(cfg);
-        return HB_MC_SUCCESS;
-}
-
-static int hb_mc_manycore_incr_host_requests(hb_mc_manycore_t*mc)
-{
-
-        mc->htod_requests++;
-        return HB_MC_SUCCESS;
-}
-
-static int hb_mc_manycore_decr_host_requests(hb_mc_manycore_t *mc)
-{
-        if (mc->htod_requests == 0) {
-                manycore_pr_err(mc, "%s: No outstanding requests!\n", __func__);
-                return HB_MC_FAIL;
-        }
-
-        mc->htod_requests--;
-        return HB_MC_SUCCESS;
-}
-
-static int hb_mc_manycore_host_request_fence(hb_mc_manycore_t *mc)
-{
-    unsigned cap;
-    unsigned max_credits;
-
-    uint32_t vacancy;
-    int ep_out_credits;
-    int err;
-
-    const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
-
-    cap = hb_mc_config_get_io_host_credits_cap(cfg);
-    max_credits = hb_mc_config_get_io_endpoint_max_out_credits(cfg);
-
-    // wait until out credts are fully resumed, and the tx fifo vacancy equals to host credits
-    while ((vacancy != cap) | (ep_out_credits != max_credits)) {
-        err = hb_mc_manycore_tx_fifo_get_vacancy(mc, HB_MC_FIFO_TX_REQ, &vacancy);
-        if (err != HB_MC_SUCCESS)
-                return err;
-        ep_out_credits = hb_mc_manycore_get_endpoint_out_credits(mc);
-    }
-
-    return HB_MC_SUCCESS;
-}
-
-static int hb_mc_manycore_update_requests(hb_mc_manycore_t *mc)
-{
-    unsigned threshold, cap;
-    uint32_t vacancy;
-    int err;
-
-    const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
-
-    threshold = hb_mc_config_get_io_credit_update_threshold(cfg);
-    cap = hb_mc_config_get_io_host_credits_cap(cfg);
-
-    while (mc->htod_requests >= threshold) {
-        err = hb_mc_manycore_tx_fifo_get_vacancy(mc, HB_MC_FIFO_TX_REQ, &vacancy);
-        if (err != HB_MC_SUCCESS)
-                return err;
-        mc->htod_requests = (cap - vacancy);
-    }
-
-    return HB_MC_SUCCESS;
-}
-
-static int hb_mc_manycore_host_requests_init(hb_mc_manycore_t *mc)
-{
-        mc->htod_requests = 0;
-        return HB_MC_SUCCESS;
-}
-
-
-
-static int hb_mc_manycore_init_fifos(hb_mc_manycore_t *mc)
-{
-        int rc;
-
-        /* Drain the Manycore-To-Host (RX) Request FIFO */
-        rc = hb_mc_manycore_rx_fifo_drain(mc, HB_MC_FIFO_RX_REQ);
-        if (rc != HB_MC_SUCCESS)
-                return rc;
-
-        /* initialize the outstanding request counter */
-        rc = hb_mc_manycore_host_requests_init(mc);
-        if (rc != HB_MC_SUCCESS)
-                return rc;
-
-        return HB_MC_SUCCESS;
-}
-
-static void hb_mc_manycore_cleanup_fifos(hb_mc_manycore_t *mc)
-{
-        /* Drain the Manycore-To-Host (RX) Request FIFO */
-        hb_mc_manycore_rx_fifo_drain(mc, HB_MC_FIFO_RX_REQ);
 }
 
 /**
@@ -514,7 +156,7 @@ int  hb_mc_manycore_init(hb_mc_manycore_t *mc, const char *name, hb_mc_manycore_
                 return HB_MC_INVALID;
 
         // check if mc is already initialized
-        if (mc->name || mc->private_data)
+        if (mc->name)
                 return HB_MC_INITIALIZED_TWICE;
 
         // copy name
@@ -524,51 +166,34 @@ int  hb_mc_manycore_init(hb_mc_manycore_t *mc, const char *name, hb_mc_manycore_
                 return r;
         }
 
-        // initialize private data
-        if ((err = hb_mc_manycore_init_private_data(mc)) != HB_MC_SUCCESS)
-                goto cleanup;
-
-#ifdef COSIM
-        // initialize simulation
-        if ((err = hb_mc_manycore_init_dpi(mc)) != HB_MC_SUCCESS)
-                goto cleanup;
-#endif
-
-        // initialize manycore for MMIO
-        if ((err = hb_mc_manycore_init_mmio(mc, id)) != HB_MC_SUCCESS)
-                goto cleanup;
+        // Initialize the underlying machine
+        if ((err = hb_mc_platform_init(mc, id)) != HB_MC_SUCCESS){
+                free((void*)mc->name);
+                return err;
+        }
 
         // read configuration
-        if ((err = hb_mc_manycore_init_config(mc)) != HB_MC_SUCCESS)
-                goto cleanup;
-
-        // initialize FIFOs
-        if ((err = hb_mc_manycore_init_fifos(mc)) != HB_MC_SUCCESS)
-                goto cleanup;
+        if ((err = hb_mc_manycore_init_config(mc)) != HB_MC_SUCCESS){
+                free((void*)mc->name);
+                hb_mc_platform_cleanup(mc);
+                return err;
+        }
 
         // initialize responders
-        if ((err = hb_mc_responders_init(mc)))
-                goto cleanup;
+        if ((err = hb_mc_responders_init(mc))){
+                hb_mc_platform_cleanup(mc);
+                free((void*)mc->name);
+                return err;
+        }
 
         // enable dram
-        if ((err = hb_mc_manycore_enable_dram(mc)) != HB_MC_SUCCESS)
-                goto cleanup;
+        if ((err = hb_mc_manycore_enable_dram(mc)) != HB_MC_SUCCESS){
+                hb_mc_platform_cleanup(mc);
+                free((void*)mc->name);
+                return err;
+        }
 
-        r = HB_MC_SUCCESS;
-        goto done;
-
- cleanup:
-        r = err;
-        hb_mc_manycore_cleanup_fifos(mc);
-        hb_mc_manycore_cleanup_mmio(mc);
-#ifdef COSIM
-        hb_mc_manycore_cleanup_dpi(mc);
-#endif
-        hb_mc_manycore_cleanup_private_data(mc);
-        free((void*)mc->name);
-
- done:
-        return r;
+        return HB_MC_SUCCESS;
 }
 
 /**
@@ -584,402 +209,14 @@ int hb_mc_manycore_exit(hb_mc_manycore_t *mc)
                            __func__, hb_mc_strerror(err));
                 return err;
         }
-        hb_mc_manycore_cleanup_fifos(mc);
-        hb_mc_manycore_cleanup_mmio(mc);
-        hb_mc_manycore_cleanup_private_data(mc);
+        hb_mc_platform_cleanup(mc);
         free((void*)mc->name);
         return HB_MC_SUCCESS;
 }
 
-/************/
-/* MMIO API */
-/************/
-/**
- * Reads data for MMIO by actualling doing loads
- */
-static int  hb_mc_manycore_mmio_read_mmio(hb_mc_manycore_t *mc, uintptr_t offset,
-                                          void *vp, size_t sz)
-{
-        unsigned char *addr = (unsigned char *)mc->mmio;
-        uint32_t tmp;
-
-        if (addr == nullptr) {
-                manycore_pr_err(mc, "%s: Failed: MMIO not initialized", __func__);
-                return HB_MC_UNINITIALIZED;
-        }
-
-        // check that the address is aligned to a four byte boundar
-        if (offset % 4) {
-                manycore_pr_err(mc, "%s: Failed: 0x%" PRIxPTR " "
-                                "is not aligned to 4 byte boundary\n",
-                                __func__, offset);
-                return HB_MC_UNALIGNED;
-        }
-
-        addr = &addr[offset];
-
-        tmp = *(volatile uint32_t *)addr;
-
-        switch (sz) {
-        case 4:
-                *(uint32_t*)vp = tmp;
-                break;
-        case 2:
-                *(uint16_t*)vp = tmp;
-                break;
-        case 1:
-                *(uint8_t*)vp  = tmp;
-                break;
-        default:
-                manycore_pr_err(mc, "%s: Failed: invalid load size (%zu)\n", __func__, sz);
-                return HB_MC_INVALID;
-        }
-
-        return HB_MC_SUCCESS;
-}
-/**
- * Reads data for MMIO instead by using PCI ops (used in COSIM)
- */
-static int  hb_mc_manycore_mmio_read_pci(hb_mc_manycore_t *mc, uintptr_t offset,
-                                         void *vp, size_t sz)
-{
-        hb_mc_manycore_private_t *pdata = (hb_mc_manycore_private_t*)mc->private_data;
-        uint32_t val;
-        int err;
-
-        if ((err = fpga_pci_peek(pdata->handle, offset, &val)) != 0) {
-                manycore_pr_err(mc, "%s: Failed: %s\n", __func__, FPGA_ERR2STR(err));
-                return HB_MC_FAIL;
-        }
-
-        switch (sz) {
-        case 4:
-                *(uint32_t*)vp = val;
-                break;
-        case 2:
-                *(uint16_t*)vp = val;
-                break;
-        case 1:
-                *(uint8_t *)vp = val;
-                break;
-        default:
-                manycore_pr_err(mc, "%s: Failed: invalid load size (%zu)\n", __func__, sz);
-                return HB_MC_INVALID;
-        }
-        return HB_MC_SUCCESS;
-}
-
-/**
- * Read the number of remaining available endpoint out credits
- * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
- * @return HB_MC_FAIL if an error occured. Number of remaining endpoint out credits otherwise
- */
-int hb_mc_manycore_get_endpoint_out_credits(hb_mc_manycore_t *mc)
-{
-        uint64_t addr;
-        uint32_t value;
-        int err;
-        addr = hb_mc_mmio_out_credits_get_addr();
-        err = hb_mc_manycore_mmio_read32(mc, addr, &value);
-        if (err != HB_MC_SUCCESS) {
-                manycore_pr_err(mc, "%s: Failed to read endpoint out credits: %s\n",
-                                __func__, hb_mc_strerror(err));
-                return err;
-        }
-        return value;
-}
-
-/**
- * Read the number of remaining credits of host
- * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
- * @return HB_MC_FAIL if an error occured. Number of remaining credits of host otherwise
- */
-int hb_mc_manycore_get_host_request_credits(hb_mc_manycore_t *mc)
-{
-        uint32_t value;
-        int err;
-        err = hb_mc_manycore_tx_fifo_get_vacancy(mc, HB_MC_FIFO_TX_REQ, &value);
-        if (err != HB_MC_SUCCESS) {
-                manycore_pr_err(mc, "%s: Failed to read Host Credits: %s\n",
-                                __func__, hb_mc_strerror(err));
-                return err;
-        }
-        return value;
-}
-
-
-static int hb_mc_manycore_mmio_read(hb_mc_manycore_t *mc, uintptr_t offset,
-                                    void *vp, size_t sz)
-{
-#if !defined(COSIM)
-        return hb_mc_manycore_mmio_read_mmio(mc, offset, vp, sz);
-#else
-        return hb_mc_manycore_mmio_read_pci(mc,  offset, vp, sz);
-#endif
-}
-
-/**
- * Writes data for MMIO by direct stores
- */
-static int hb_mc_manycore_mmio_write_mmio(hb_mc_manycore_t *mc, uintptr_t offset,
-                                          void *vp, size_t sz)
-{
-        unsigned char *addr = (unsigned char *)mc->mmio;
-        uint32_t tmp;
-
-        if (addr == nullptr) {
-                manycore_pr_err(mc, "%s: Failed: MMIO not initialized", __func__);
-                return HB_MC_UNINITIALIZED;
-        }
-
-        // check that the address is aligned to a four byte boundary
-        if (offset % 4) {
-                manycore_pr_err(mc, "%s: Failed: 0x%" PRIxPTR " "
-                                "is not aligned to 4 byte boundary\n",
-                                __func__, offset);
-                return HB_MC_UNALIGNED;
-        }
-
-        addr = &addr[offset];
-
-        switch (sz) {
-        case 4:
-                tmp = *(uint32_t *)vp;
-                break;
-        case 2:
-                tmp = *(uint16_t*)vp;
-                break;
-        case 1:
-                tmp = *(uint8_t*)vp;
-                break;
-        default:
-                manycore_pr_err(mc, "%s: Failed: invalid load size (%zu)\n", __func__, sz);
-                return HB_MC_INVALID;
-        }
-
-        *(volatile uint32_t *)addr = tmp;
-
-        return HB_MC_SUCCESS;
-}
-
-/**
- * Writes data for MMIO instead by  PCI ops (used in COSIM)
- */
-static int hb_mc_manycore_mmio_write_pci(hb_mc_manycore_t *mc, uintptr_t offset,
-                                         void *vp, size_t sz)
-{
-        hb_mc_manycore_private_t *pdata = (hb_mc_manycore_private_t*)mc->private_data;
-        uint32_t val;
-        int err;
-
-        switch (sz) {
-        case 4:
-                val = *(uint32_t*)vp;
-                break;
-        case 2:
-                val = *(uint16_t*)vp;
-                break;
-        case 1:
-                val = *(uint8_t*)vp;
-                break;
-        default:
-                manycore_pr_err(mc, "%s: Failed: invalid store size (%zu)\n", __func__, sz);
-                return HB_MC_INVALID;
-        }
-
-        err = fpga_pci_poke(pdata->handle, offset, val);
-        if (err != 0) {
-                manycore_pr_err(mc, "%s: Failed: %s\n", __func__, FPGA_ERR2STR(err));
-                return HB_MC_FAIL;
-        }
-        return HB_MC_SUCCESS;
-}
-
-static int hb_mc_manycore_mmio_write(hb_mc_manycore_t *mc, uintptr_t offset,
-                                     void *vp, size_t sz)
-{
-#if !defined(COSIM)
-        return hb_mc_manycore_mmio_write_mmio(mc, offset, vp, sz);
-#else
-        return hb_mc_manycore_mmio_write_pci(mc, offset, vp, sz);
-#endif
-}
-/**
- * Read one byte from manycore hardware at a given AXI Address
- * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
- * @param[in]  offset An  offset into the manycore's MMIO address space
- * @param[out] vp     A byte to be set to the data read
- * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
- */
-
-int hb_mc_manycore_mmio_read8(hb_mc_manycore_t *mc, uintptr_t offset, uint8_t *vp)
-{
-        return hb_mc_manycore_mmio_read(mc, offset, (void*)vp, 1);
-}
-
-/**
- * Read a 16-bit half-word from manycore hardware at a given AXI Address
- * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
- * @param[in]  offset An  offset into the manycore's MMIO address space
- * @param[out] vp     A half-word to be set to the data read
- * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
- */
-
-int hb_mc_manycore_mmio_read16(hb_mc_manycore_t *mc, uintptr_t offset, uint16_t *vp)
-{
-        return hb_mc_manycore_mmio_read(mc, offset, (void*)vp, 2);
-}
-
-/**
- * Read a 32-bit word from manycore hardware at a given AXI Address
- * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
- * @param[in]  offset An  offset into the manycore's MMIO address space
- * @param[out] vp     A word to be set to the data read
- * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
- */
-
-int hb_mc_manycore_mmio_read32(hb_mc_manycore_t *mc, uintptr_t offset, uint32_t *vp)
-{
-        return hb_mc_manycore_mmio_read(mc, offset, (void*)vp, 4);
-}
-
-/**
- * Write one byte to manycore hardware at a given AXI Address
- * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
- * @param[in]  offset An  offset into the manycore's MMIO address space
- * @param[in]  v      A byte value to be written out
- * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
- */
-
-int hb_mc_manycore_mmio_write8(hb_mc_manycore_t *mc, uintptr_t offset, uint8_t v)
-{
-        return hb_mc_manycore_mmio_write(mc, offset, (void*)&v, 1);
-}
-
-/**
- * Write a 16-bit half-word to manycore hardware at a given AXI Address
- * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
- * @param[in]  offset An  offset into the manycore's MMIO address space
- * @param[in]  v      A half-word value to be written out
- * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
- */
-
-int hb_mc_manycore_mmio_write16(hb_mc_manycore_t *mc, uintptr_t offset, uint16_t v)
-{
-        return hb_mc_manycore_mmio_write(mc, offset, (void*)&v, 2);
-}
-
-/**
- * Write a 32-bit word to manycore hardware at a given AXI Address
- * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
- * @param[in]  offset An  offset into the manycore's MMIO address space
- * @param[in]  v      A word value to be written out
- * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
- */
-
-int hb_mc_manycore_mmio_write32(hb_mc_manycore_t *mc, uintptr_t offset, uint32_t v)
-{
-        return hb_mc_manycore_mmio_write(mc, offset, (void*)&v, 4);
-}
-
-
-
 ////////////////
 // Packet API //
 ////////////////
-
-
-
-/**
- * Transmit a packet to manycore hardware
- * @param[in] mc      A manycore instance initialized with hb_mc_manycore_init()
- * @param[in] packet  A packet to transmit to manycore hardware
- * @param[in] type    Is this packet a request or response packet?
- * @param[in] timeout A timeout counter. Unused - set to -1 to wait forever.
- * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
- */
-
-static int hb_mc_manycore_packet_tx_internal(hb_mc_manycore_t *mc,
-                                             hb_mc_packet_t *packet,
-                                             hb_mc_fifo_tx_t type,
-                                             long timeout) {
-        const char *typestr = hb_mc_fifo_tx_to_string(type);
-        uintptr_t data_addr, len_addr;
-        int err;
-
-        if (timeout != -1) {
-                manycore_pr_err(mc, "%s: Only a timeout value of -1 is supported\n",
-                                __func__);
-                return HB_MC_INVALID;
-        }
-
-        // get the address of the transmit data register TDR
-        data_addr = hb_mc_mmio_fifo_get_addr(type, HB_MC_MMIO_FIFO_TX_DATA_OFFSET);
-
-        // transmit the data one word at a time
-        for (unsigned i = 0; i < array_size(packet->words); i++) {
-                err = hb_mc_manycore_mmio_write32(mc, data_addr, packet->words[i]);
-                if (err != HB_MC_SUCCESS) {
-                        manycore_pr_err(mc, "%s: Failed to transmit word %d via %s FIFO: %s\n",
-                                        __func__, i, typestr, hb_mc_strerror(err));
-                        return err;
-                }
-        }
-
-        return HB_MC_SUCCESS;
-}
-
-/**
- * Receive a packet from manycore hardware
- * @param[in] mc     A manycore instance initialized with hb_mc_manycore_init()
- * @param[out] packet A packet into which data should be read
- * @param[in] type   Is this packet a request or response packet?
- * @param[in] timeout A timeout counter. Unused - set to -1 to wait forever.
- * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
- */
-static int hb_mc_manycore_packet_rx_internal(hb_mc_manycore_t *mc,
-                                             hb_mc_packet_t *packet,
-                                             hb_mc_fifo_rx_t type,
-                                             long timeout)
-{
-        const char *typestr = hb_mc_fifo_rx_to_string(type);
-        uintptr_t data_addr;
-        uint32_t occupancy;
-        int err;
-
-        if (timeout != -1) {
-                manycore_pr_err(mc, "%s: Only a timeout value of -1 is supported\n",
-                                __func__);
-                return HB_MC_INVALID;
-        }
-
-        data_addr   = hb_mc_mmio_fifo_get_addr(type, HB_MC_MMIO_FIFO_RX_DATA_OFFSET);
-
-        if (type == HB_MC_FIFO_RX_REQ) {
-            /* wait for a packet */
-            do {
-                    err = hb_mc_manycore_rx_fifo_get_occupancy(mc, type, &occupancy);
-                    if (err != HB_MC_SUCCESS) {
-                            manycore_pr_err(mc, "%s: Failed to get %s FIFO occupancy while waiting for packet: %s\n",
-                                            __func__, typestr, hb_mc_strerror(err));
-                            return err;
-                    }
-
-            } while (occupancy < 1);  // this is packet occupancy, not word occupancy!
-        }
-
-        /* read in the packet one word at a time */
-        for (unsigned i = 0; i < array_size(packet->words); i++) {
-                err = hb_mc_manycore_mmio_read32(mc, data_addr, &packet->words[i]);
-                if (err != HB_MC_SUCCESS) {
-                        manycore_pr_err(mc, "%s: Failed read data from %s FIFO: %s\n",
-                                        __func__, typestr, hb_mc_strerror(err));
-                        return err;
-                }
-        }
-
-        return HB_MC_SUCCESS;
-}
 
 /**
  * Transmit a request packet to manycore hardware
@@ -992,18 +229,8 @@ int hb_mc_manycore_request_tx(hb_mc_manycore_t *mc,
                               hb_mc_request_packet_t *request,
                               long timeout)
 {
-        int err;
-
         /* send the request packet */
-        err = hb_mc_manycore_packet_tx_internal(mc, (hb_mc_packet_t*)request, HB_MC_FIFO_TX_REQ, timeout);
-        if (err != HB_MC_SUCCESS)
-                return err;
-
-        err = hb_mc_manycore_incr_host_requests(mc);
-        if (err != HB_MC_SUCCESS)
-                return err;
-
-        return HB_MC_SUCCESS;
+        return hb_mc_platform_transmit(mc, (hb_mc_packet_t*)request, HB_MC_FIFO_TX_REQ, timeout);
 }
 
 /**
@@ -1017,20 +244,8 @@ int hb_mc_manycore_response_rx(hb_mc_manycore_t *mc,
                                hb_mc_response_packet_t *response,
                                long timeout)
 {
-        int err;
-
         /* receive the response packet */
-        err = hb_mc_manycore_packet_rx_internal(mc, (hb_mc_packet_t*)response, HB_MC_FIFO_RX_RSP, timeout);
-        if (err != HB_MC_SUCCESS)
-                return err;
-
-
-        /* update the outstanding requests */
-        err = hb_mc_manycore_decr_host_requests(mc);
-        if (err != HB_MC_SUCCESS)
-                return err;
-
-        return HB_MC_SUCCESS;
+        return hb_mc_platform_receive(mc, (hb_mc_packet_t*)response, HB_MC_FIFO_RX_RSP, timeout);
 }
 
 /**
@@ -1044,7 +259,7 @@ int hb_mc_manycore_response_tx(hb_mc_manycore_t *mc,
                                hb_mc_response_packet_t *response,
                                long timeout)
 {
-        return hb_mc_manycore_packet_tx_internal(mc, (hb_mc_packet_t*)response, HB_MC_FIFO_TX_RSP, timeout);
+        return hb_mc_platform_transmit(mc, (hb_mc_packet_t*)response, HB_MC_FIFO_TX_RSP, timeout);
 }
 
 /**
@@ -1059,7 +274,7 @@ int hb_mc_manycore_request_rx(hb_mc_manycore_t *mc,
                               long timeout)
 {
         int err;
-        err = hb_mc_manycore_packet_rx_internal(mc, (hb_mc_packet_t*)request, HB_MC_FIFO_RX_REQ, timeout);
+        err = hb_mc_platform_receive(mc, (hb_mc_packet_t*)request, HB_MC_FIFO_RX_REQ, timeout);
         if (err != HB_MC_SUCCESS)
                 return err;
 
@@ -2012,11 +1227,6 @@ int hb_mc_manycore_write_mem(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa,
         /* send store requests one word at a time */
         for (size_t i = 0; i < n_words; i++) {
 
-                /* do we have capacity for another request? */
-                err = hb_mc_manycore_update_requests(mc);
-                if (err != HB_MC_SUCCESS)
-                        return err;
-
                 err = hb_mc_manycore_write(mc, &addr, &words[i], 4);
                 if (err != HB_MC_SUCCESS) {
                         manycore_pr_err(mc, "%s: Failed to send write request: %s\n",
@@ -2024,15 +1234,11 @@ int hb_mc_manycore_write_mem(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa,
                         return err;
                 }
 
-                err = hb_mc_manycore_incr_host_requests(mc);
-                if (err != HB_MC_SUCCESS)
-                        return err;
-
                 // Increment EPA by 4:
                 hb_mc_npa_set_epa(&addr, hb_mc_npa_get_epa(&addr) + 4);
         }
 
-        err = hb_mc_manycore_host_request_fence(mc);
+        err = hb_mc_manycore_host_request_fence(mc, -1);
         if (err != HB_MC_SUCCESS)
                 return err;
 
@@ -2071,11 +1277,6 @@ int hb_mc_manycore_memset(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa,
         /* send store requests one word at a time */
         for (size_t i = 0; i < n_words; i++) {
 
-                /* do we have capacity for another request? */
-                err = hb_mc_manycore_update_requests(mc);
-                if (err != HB_MC_SUCCESS)
-                        return err;
-
                 err = hb_mc_manycore_write(mc, &addr, &word, 4);
                 if (err != HB_MC_SUCCESS) {
                         manycore_pr_err(mc, "%s: Failed to send write request: %s\n",
@@ -2083,15 +1284,11 @@ int hb_mc_manycore_memset(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa,
                         return err;
                 }
 
-                err = hb_mc_manycore_incr_host_requests(mc);
-                if (err != HB_MC_SUCCESS)
-                        return err;
-
                 // increment EPA by 1: (EPA's address words)
                 hb_mc_npa_set_epa(&addr, hb_mc_npa_get_epa(&addr) + sizeof(uint32_t));
         }
 
-        err = hb_mc_manycore_host_request_fence(mc);
+        err = hb_mc_manycore_host_request_fence(mc, -1);
         if (err != HB_MC_SUCCESS)
                 return err;
 
@@ -2123,15 +1320,14 @@ static int hb_mc_manycore_read_mem_internal(hb_mc_manycore_t *mc,
                                             NPA_OF_I_FUNCTION npa,
                                             UINTV & data, size_t cnt)
 {
+        const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
         size_t rsp_i = 0, rqst_i = 0;
         uint32_t occupancy;
         unsigned n_ids;
         int err;
 
         /* cap the number of load ids to the maximum number of pending requests */
-        err = hb_mc_manycore_get_remote_load_cap(mc, &n_ids);
-        if (err != HB_MC_SUCCESS)
-                return err;
+        n_ids = hb_mc_config_get_io_remote_load_cap(cfg);
 
 #ifdef COSIM
         sv_set_virtual_dip_switch(0, 1);

--- a/libraries/bsg_manycore.h
+++ b/libraries/bsg_manycore.h
@@ -55,13 +55,10 @@ extern "C" {
 #define HB_MC_MANYCORE_ID_ANY -1
 
         typedef struct hb_mc_manycore {
-                hb_mc_manycore_id_t id; //!< which manycore instance is this
-                const char    *name;     //!< the name of this manycore
-                uintptr_t      mmio;     //!< pointer to memory mapped io
-                hb_mc_config_t config;   //!< configuration of the manycore
-                void    *private_data;   //!< implementation private data
-                unsigned htod_requests;  //!< outstanding host requests
-                int dram_enabled;        //!< operating in no-dram mode?
+                const char *name;      //!< the name of this manycore
+                hb_mc_config_t config; //!< configuration of the manycore
+                void *platform;        //!< machine-specific data pointer
+                int dram_enabled;      //!< operating in no-dram mode?
         } hb_mc_manycore_t;
 
 #define HB_MC_MANYCORE_INIT {0}
@@ -582,20 +579,12 @@ extern "C" {
         }
 
         /**
-         * Read the number of remaining available endpoint out credits
+         * Stall until the all requests (and responses to the host) have reached their destination.
          * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
-         * @return HB_MC_FAIL if an error occured. Number of remaining endpoint out credits otherwise
+         * @param[in] timeout A timeout counter. Unused - set to -1 to wait forever.
+         * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
          */
-        int hb_mc_manycore_get_endpoint_out_credits(hb_mc_manycore_t *mc);
-
-        /**
-         * Read the number of remaining credits of host
-         * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
-         * @return HB_MC_FAIL if an error occured. Number of remaining credits of host otherwise
-         */
-        int hb_mc_manycore_get_host_request_credits(hb_mc_manycore_t *mc);
-
-
+        int hb_mc_manycore_host_request_fence(hb_mc_manycore_t *mc, long timeout);
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/bsg_manycore_config.h
+++ b/libraries/bsg_manycore_config.h
@@ -455,21 +455,9 @@ extern "C" {
          * @param[in] cfg A configuration initialized from the manycore ROM.
          * @return the host capacity for batching requests.
          */
-        static inline uint32_t hb_mc_config_get_io_host_credits_cap(const hb_mc_config_t *cfg)
+        static inline uint32_t hb_mc_config_get_transmit_vacancy_max(const hb_mc_config_t *cfg)
         {
                 return cfg->io_host_credits_cap;
-        }
-
-        /**
-         * Return the threshold for host to update its cached credits.
-         * @param[in] cfg A configuration initialized from the manycore ROM.
-         * @return the threshold for host to update its cached credits.
-         */
-        static inline uint32_t hb_mc_config_get_io_credit_update_threshold(const hb_mc_config_t *cfg)
-        {
-                return cfg->io_host_credits_cap;
-                // we can also set half of the max host credits.
-                // return cfg->io_host_credits_cap/2;
         }
 
         /**

--- a/libraries/bsg_manycore_platform.cpp
+++ b/libraries/bsg_manycore_platform.cpp
@@ -1,0 +1,818 @@
+#include <bsg_manycore_platform.h>
+#include <bsg_manycore_mmio.h>
+#include <bsg_manycore_config.h>
+#include <bsg_manycore_printing.h>
+
+#include <cstring>
+
+#ifndef COSIM
+#include <fpga_pci.h>
+#include <fpga_mgmt.h>
+#else
+#include <svdpi.h>
+#include <fpga_pci_sv.h>
+#include <utils/sh_dpi_tasks.h>
+#endif
+
+/* these are convenience macros that are only good for one line prints */
+#define platform_pr_dbg(m, fmt, ...)                    \
+        bsg_pr_dbg("%s: " fmt, m->name, ##__VA_ARGS__)
+
+#define platform_pr_err(m, fmt, ...)                    \
+        bsg_pr_err("%s: " fmt, m->name, ##__VA_ARGS__)
+
+#define platform_pr_warn(m, fmt, ...)                   \
+        bsg_pr_warn("%s: " fmt, m->name, ##__VA_ARGS__)
+
+#define platform_pr_info(m, fmt, ...)                   \
+        bsg_pr_info("%s: " fmt, m->name, ##__VA_ARGS__)
+
+#define array_size(x)                           \
+        (sizeof(x)/sizeof(x[0]))
+
+
+typedef struct hb_mc_platform_t {
+        const char *name;
+#ifdef COSIM
+        svScope scope;
+#endif
+        int transmit_vacancy;    //!< Software copy of the transmit vacancy register
+        pci_bar_handle_t handle; //!< pci bar handle
+        hb_mc_manycore_id_t id;  //!< which manycore instance is this
+        uintptr_t      mmio;     //!< pointer to memory mapped io (F1-specific)
+} hb_mc_platform_t;
+
+
+/* initialize manycore MMIO */
+static int hb_mc_platform_mmio_init(hb_mc_platform_t *pl,
+                                    hb_mc_manycore_id_t id)
+{
+
+        int pf_id = FPGA_APP_PF, write_combine = 0, bar_id = APP_PF_BAR0;
+        int r = HB_MC_FAIL, err;
+
+        // all IDs except 0 are unused at the moment
+        if (id != 0) {
+                platform_pr_err(pl, "Failed to init MMIO: invalid ID\n");
+                return HB_MC_INVALID;
+        }
+
+        if ((err = fpga_pci_attach(id, pf_id, bar_id, write_combine, &pl->handle)) != 0) {
+                platform_pr_err(pl, "Failed to init MMIO: %s\n", FPGA_ERR2STR(err));
+                platform_pr_err(pl, "Are you running with sudo?\n");
+                return r;
+        }
+
+#if !defined(COSIM) // on F1
+        // it is not clear to me where 0x4000 comes from...
+        // map in the base address register to our address space
+        if ((err = fpga_pci_get_address(pl->handle, 0, 0x4000, (void**)&pl->mmio)) != 0) {
+                platform_pr_err(pl, "Failed to init MMIO: %s\n", FPGA_ERR2STR(err));
+                goto cleanup;
+        }
+#else
+        pl->mmio = (uintptr_t)nullptr;
+#endif
+        pl->id = id;
+        r = HB_MC_SUCCESS;
+        platform_pr_dbg(pl, "%s: pl->mmio = 0x%" PRIxPTR "\n", __func__, pl->mmio);
+        goto done;
+
+ cleanup:
+        fpga_pci_detach(pl->handle);
+        pl->handle = PCI_BAR_HANDLE_INIT;
+ done:
+        return r;
+}
+
+/* cleanup manycore MMIO */
+static void hb_mc_platform_mmio_cleanup(hb_mc_platform_t *pl)
+{
+        int err;
+
+        if (pl->handle == PCI_BAR_HANDLE_INIT)
+                return;
+
+        if ((err = fpga_pci_detach(pl->handle)) != 0)
+                platform_pr_err(pl, "Failed to cleanup MMIO: %s\n", FPGA_ERR2STR(err));
+
+        pl->handle = PCI_BAR_HANDLE_INIT;
+        pl->mmio = (uintptr_t)nullptr;
+        pl->id = 0;
+        return;
+}
+
+/************/
+/* MMIO API */
+/************/
+/**
+ * Reads data for MMIO by actualling doing loads
+ */
+static int  hb_mc_platform_mmio_read_mmio(hb_mc_platform_t *pl, 
+                                          uintptr_t offset,
+                                          void *vp, size_t sz)
+{
+        unsigned char *addr = reinterpret_cast<unsigned char *>(pl->mmio);
+        uint32_t tmp;
+
+        if (addr == nullptr) {
+                platform_pr_err(pl, "%s: Failed: MMIO not initialized", __func__);
+                return HB_MC_UNINITIALIZED;
+        }
+
+        // check that the address is aligned to a four byte boundar
+        if (offset % 4) {
+                platform_pr_err(pl, "%s: Failed: 0x%" PRIxPTR " "
+                                "is not aligned to 4 byte boundary\n",
+                                __func__, offset);
+                return HB_MC_UNALIGNED;
+        }
+
+        addr = &addr[offset];
+
+        tmp = *(volatile uint32_t *)addr;
+
+        switch (sz) {
+        case 4:
+                *(uint32_t*)vp = tmp;
+                break;
+        case 2:
+                *(uint16_t*)vp = tmp;
+                break;
+        case 1:
+                *(uint8_t*)vp  = tmp;
+                break;
+        default:
+                platform_pr_err(pl, "%s: Failed: invalid load size (%zu)\n", __func__, sz);
+                return HB_MC_INVALID;
+        }
+
+        return HB_MC_SUCCESS;
+}
+/**
+ * Reads data for MMIO instead by using PCI ops (used in COSIM)
+ */
+static int hb_mc_platform_mmio_read_pci(hb_mc_platform_t *pl,
+                                        uintptr_t offset,
+                                        void *vp, size_t sz)
+{
+        uint32_t val;
+        int err;
+
+        if ((err = fpga_pci_peek(pl->handle, offset, &val)) != 0) {
+                platform_pr_err(pl, "%s: Failed: %s\n", __func__, FPGA_ERR2STR(err));
+                return HB_MC_FAIL;
+        }
+
+        switch (sz) {
+        case 4:
+                *(uint32_t*)vp = val;
+                break;
+        case 2:
+                *(uint16_t*)vp = val;
+                break;
+        case 1:
+                *(uint8_t *)vp = val;
+                break;
+        default:
+                platform_pr_err(pl, "%s: Failed: invalid load size (%zu)\n", __func__, sz);
+                return HB_MC_INVALID;
+        }
+        return HB_MC_SUCCESS;
+}
+
+/**
+ * Writes data for MMIO instead by  PCI ops (used in COSIM)
+ */
+static int hb_mc_platform_mmio_write_pci(hb_mc_platform_t *pl, uintptr_t offset,
+                                         void *vp, size_t sz)
+{
+        uint32_t val;
+        int err;
+
+        switch (sz) {
+        case 4:
+                val = *(uint32_t*)vp;
+                break;
+        case 2:
+                val = *(uint16_t*)vp;
+                break;
+        case 1:
+                val = *(uint8_t*)vp;
+                break;
+        default:
+                platform_pr_err(pl, "%s: Failed: invalid store size (%zu)\n", __func__, sz);
+                return HB_MC_INVALID;
+        }
+
+        err = fpga_pci_poke(pl->handle, offset, val);
+        if (err != 0) {
+                platform_pr_err(pl, "%s: Failed: %s\n", __func__, FPGA_ERR2STR(err));
+                return HB_MC_FAIL;
+        }
+        return HB_MC_SUCCESS;
+}
+
+
+static int hb_mc_platform_mmio_read(hb_mc_platform_t *pl, uintptr_t offset,
+                                    void *vp, size_t sz)
+{
+#if !defined(COSIM)
+        return hb_mc_platform_mmio_read_mmio(pl, offset, vp, sz);
+#else
+        return hb_mc_platform_mmio_read_pci(pl, offset, vp, sz);
+#endif
+}
+
+/**
+ * Writes data for MMIO by direct stores
+ */
+static int hb_mc_platform_mmio_write_mmio(hb_mc_platform_t *pl, uintptr_t offset,
+                                          void *vp, size_t sz)
+{
+        unsigned char *addr = reinterpret_cast<unsigned char *>(pl->mmio);
+        uint32_t tmp;
+
+        if (addr == nullptr) {
+                platform_pr_err(pl, "%s: Failed: MMIO not initialized", __func__);
+                return HB_MC_UNINITIALIZED;
+        }
+
+        // check that the address is aligned to a four byte boundary
+        if (offset % 4) {
+                platform_pr_err(pl, "%s: Failed: 0x%" PRIxPTR " "
+                                "is not aligned to 4 byte boundary\n",
+                                __func__, offset);
+                return HB_MC_UNALIGNED;
+        }
+
+        addr = &addr[offset];
+
+        switch (sz) {
+        case 4:
+                tmp = *(uint32_t *)vp;
+                break;
+        case 2:
+                tmp = *(uint16_t*)vp;
+                break;
+        case 1:
+                tmp = *(uint8_t*)vp;
+                break;
+        default:
+                platform_pr_err(pl, "%s: Failed: invalid load size (%zu)\n", __func__, sz);
+                return HB_MC_INVALID;
+        }
+
+        *(volatile uint32_t *)addr = tmp;
+
+        return HB_MC_SUCCESS;
+}
+ 
+static int hb_mc_platform_mmio_write(hb_mc_platform_t *pl, uintptr_t offset,
+                                     void *vp, size_t sz)
+{
+#if !defined(COSIM)
+        return hb_mc_platform_mmio_write_mmio(pl, offset, vp, sz);
+#else
+        return hb_mc_platform_mmio_write_pci(pl, offset, vp, sz);
+#endif
+}
+
+/**
+ * Read one byte from manycore hardware at a given AXI Address
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in]  offset An  offset into the manycore's MMIO address space
+ * @param[out] vp     A byte to be set to the data read
+ * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
+ */
+static int hb_mc_platform_mmio_read8(hb_mc_platform_t *pl, uintptr_t offset, uint8_t *vp)
+{
+        return hb_mc_platform_mmio_read(pl, offset, (void*)vp, 1);
+}
+
+/**
+ * Read a 16-bit half-word from manycore hardware at a given AXI Address
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in]  offset An  offset into the manycore's MMIO address space
+ * @param[out] vp     A half-word to be set to the data read
+ * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
+ */
+static int hb_mc_platform_mmio_read16(hb_mc_platform_t *pl, uintptr_t offset, uint16_t *vp)
+{
+        return hb_mc_platform_mmio_read(pl, offset, (void*)vp, 2);
+}
+
+/**
+ * Read a 32-bit word from manycore hardware at a given AXI Address
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in]  offset An  offset into the manycore's MMIO address space
+ * @param[out] vp     A word to be set to the data read
+ * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
+ */
+int hb_mc_platform_mmio_read32(hb_mc_platform_t *pl, uintptr_t offset, uint32_t *vp)
+{
+        return hb_mc_platform_mmio_read(pl, offset, (void*)vp, 4);
+}
+
+/**
+ * Write one byte to manycore hardware at a given AXI Address
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in]  offset An  offset into the manycore's MMIO address space
+ * @param[in]  v      A byte value to be written out
+ * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
+ */
+
+int hb_mc_platform_mmio_write8(hb_mc_platform_t *pl, uintptr_t offset, uint8_t v)
+{
+        return hb_mc_platform_mmio_write(pl, offset, (void*)&v, 1);
+}
+
+/**
+ * Write a 16-bit half-word to manycore hardware at a given AXI Address
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in]  offset An  offset into the manycore's MMIO address space
+ * @param[in]  v      A half-word value to be written out
+ * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
+ */
+
+int hb_mc_platform_mmio_write16(hb_mc_platform_t *pl, uintptr_t offset, uint16_t v)
+{
+        return hb_mc_platform_mmio_write(pl, offset, (void*)&v, 2);
+}
+
+/**
+ * Write a 32-bit word to manycore hardware at a given AXI Address
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in]  offset An  offset into the manycore's MMIO address space
+ * @param[in]  v      A word value to be written out
+ * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
+ */
+static int hb_mc_platform_mmio_write32(hb_mc_platform_t *pl, uintptr_t offset, uint32_t v)
+{
+        return hb_mc_platform_mmio_write(pl, offset, (void*)&v, 4);
+}
+
+// ****************************************************************************
+// FIFO INTERFACE
+// ****************************************************************************
+
+/* get the number of unread packets in a FIFO (rx only) */
+static int hb_mc_platform_rx_fifo_get_occupancy(hb_mc_platform_t *pl,
+                                                hb_mc_fifo_rx_t type,
+                                                uint32_t *occupancy)
+{
+        uint32_t val, occ;
+        uintptr_t occupancy_addr = hb_mc_mmio_fifo_get_addr(type, HB_MC_MMIO_FIFO_RX_OCCUPANCY_OFFSET);
+        const char *typestr = hb_mc_fifo_rx_to_string(type);
+        int err;
+        if (type == HB_MC_FIFO_RX_RSP) {
+                platform_pr_err(pl, "RX FIFO Occupancy register %s is disabled!\n", typestr);
+                occupancy = NULL;
+                return HB_MC_FAIL;
+        }
+        else {
+                err = hb_mc_platform_mmio_read32(pl, occupancy_addr, &val);
+                if (err != HB_MC_SUCCESS) {
+                        platform_pr_err(pl, "Failed to get %s occupancy\n", typestr);
+                        return err;
+                }
+
+                // All packets recieved packets should have an integral occupancy that
+                // is determined by the Packet Bit-Width / FIFO Bit-Width
+                occ = ((sizeof(hb_mc_packet_t) * 8))/HB_MC_MMIO_FIFO_DATA_WIDTH;
+                if((occ < ((sizeof(hb_mc_packet_t) * 8))/HB_MC_MMIO_FIFO_DATA_WIDTH) && (val % occ != 0)) {
+                        platform_pr_err(pl, "Invalid occupancy: Non-integral packet"
+                                        " received from %s\n", typestr);
+                        return HB_MC_FAIL;
+                }
+
+                *occupancy = (val / occ);
+                return HB_MC_SUCCESS;
+        }
+
+}
+
+/* read all unread packets from a fifo (rx only) */
+static int hb_mc_platform_drain(hb_mc_manycore_t *mc,
+                                hb_mc_platform_t *pl,
+                                hb_mc_fifo_rx_t type)
+{
+        const char *typestr = hb_mc_fifo_rx_to_string(type);
+        hb_mc_request_packet_t recv;
+        uint32_t occupancy;
+        int rc;
+
+        for (int drains = 0; drains < 20; drains++) {
+                /* first check how many unread packets are currently in the FIFO */
+                rc = hb_mc_platform_rx_fifo_get_occupancy(pl, type, &occupancy);
+                if (rc != HB_MC_SUCCESS)
+                        return rc;
+
+                /* break if occupancy is zero */
+                if (occupancy == 0)
+                        break;
+
+                /* Read stale packets from fifo */
+                for (unsigned i = 0; i < occupancy; i++){
+                        rc = hb_mc_platform_receive(mc, (hb_mc_packet_t*) &recv, type, -1);
+                        if (rc != HB_MC_SUCCESS) {
+                                platform_pr_err(pl, "%s: Failed to read packet from %s fifo\n",
+                                                __func__, typestr);
+                                return HB_MC_FAIL;
+                        }
+
+                        platform_pr_dbg(pl,
+                                        "%s: packet drained from %s fifo: "
+                                        "src (%d,%d), "
+                                        "dst (%d,%d), "
+                                        "addr: 0x%08x, "
+                                        "data: 0x%08x\n",
+                                        __func__, typestr,
+                                        recv.x_src, recv.y_src,
+                                        recv.x_dst, recv.y_dst,
+                                        recv.addr,
+                                        recv.data);
+                }
+        }
+
+        /* recheck occupancy to make sure all packets are drained. */
+        rc = hb_mc_platform_rx_fifo_get_occupancy(pl, type, &occupancy);
+        if (rc != HB_MC_SUCCESS)
+                return HB_MC_FAIL;
+
+        /* fail if new packets have arrived */
+        if (occupancy > 0){
+                platform_pr_err(pl, "%s: Failed to drain %s fifo: new packets generated\n",
+                                __func__, type);
+                return HB_MC_FAIL;
+        }
+
+        return HB_MC_SUCCESS;
+}
+
+#define HB_MC_FIFO_ELS_PER_PACKET (((sizeof(hb_mc_packet_t) * 8))/HB_MC_MMIO_FIFO_DATA_WIDTH)
+/* get the number of remaining packets in a host tx FIFO */
+static int hb_mc_platform_get_transmit_vacancy(hb_mc_manycore_t *mc,
+                                               hb_mc_fifo_tx_t type,
+                                               int *vacancy)
+{
+        hb_mc_platform_t *pl = reinterpret_cast<hb_mc_platform_t *>(mc->platform);
+
+        uint32_t vac;
+        uintptr_t vacancy_addr = hb_mc_mmio_fifo_get_addr(type, HB_MC_MMIO_FIFO_TX_VACANCY_OFFSET);
+        const char *typestr = hb_mc_fifo_tx_to_string(type);
+        int err;
+
+        if (type == HB_MC_FIFO_TX_RSP) {
+                platform_pr_err(pl, "TX Response Not Supported!\n", typestr);
+                return HB_MC_NOIMPL;
+        }
+        else {
+                err = hb_mc_platform_mmio_read32(pl, vacancy_addr, &vac);
+                if (err != HB_MC_SUCCESS) {
+                        platform_pr_err(pl, "Failed to get %s vacancy\n", typestr);
+                        return err;
+                }
+
+                // All packets recieved packets should have an integral vacancy that
+                // is determined by the Packet Bit-Width / FIFO Bit-Width
+                if(vac % HB_MC_FIFO_ELS_PER_PACKET) {
+                        platform_pr_err(pl, "Invalid vacancy: Non-integral packet"
+                                        " detected in %s\n", typestr);
+                        return HB_MC_FAIL;
+                }
+                *vacancy = (vac / HB_MC_FIFO_ELS_PER_PACKET);
+                if(*vacancy < 0){
+                        platform_pr_err(pl, "Invalid vacancy: Negative vacancy %d"
+                                        " detected in %s\n", vacancy, typestr);
+                        return HB_MC_FAIL;
+                }
+        }
+        return HB_MC_SUCCESS;
+}
+
+static int hb_mc_platform_fifos_init(hb_mc_manycore_t *mc,
+                                     hb_mc_platform_t *pl)
+{
+        int rc;
+
+        /* Drain the Manycore-To-Host (RX) Request FIFO */
+        rc = hb_mc_platform_drain(mc, pl, HB_MC_FIFO_RX_REQ);
+        if (rc != HB_MC_SUCCESS)
+                return rc;
+
+        // Initialize the transmit vacancy
+        rc = hb_mc_platform_get_transmit_vacancy(mc, HB_MC_FIFO_TX_REQ, &pl->transmit_vacancy);
+        if (rc != HB_MC_SUCCESS)
+                return rc;
+                
+        return HB_MC_SUCCESS;
+}
+
+static void hb_mc_platform_fifos_cleanup(hb_mc_manycore_t *mc, 
+                                         hb_mc_platform_t *pl)
+{
+        pl->transmit_vacancy = 0;
+
+        /* Drain the Manycore-To-Host (RX) Request FIFO */
+        hb_mc_platform_drain(mc, pl, HB_MC_FIFO_RX_REQ);
+}
+
+
+
+/**
+ * Transmit a request packet to manycore hardware
+ * @param[in] mc      A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in] request A request packet to transmit to manycore hardware
+ * @param[in] timeout A timeout counter. Unused - set to -1 to wait forever.
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_platform_transmit(hb_mc_manycore_t *mc,
+                                  hb_mc_packet_t *packet,
+                                  hb_mc_fifo_tx_t type,
+                                  long timeout){
+
+        hb_mc_platform_t *pl = reinterpret_cast<hb_mc_platform_t *>(mc->platform);
+
+        const char *typestr = hb_mc_fifo_tx_to_string(type);
+        uintptr_t data_addr;
+        int err;
+
+        if (timeout != -1) {
+                platform_pr_err(pl, "%s: Only a timeout value of -1 is supported\n",
+                                __func__);
+                return HB_MC_INVALID;
+        }
+
+        // get the address of the transmit data register TDR
+        data_addr = hb_mc_mmio_fifo_get_addr(type, HB_MC_MMIO_FIFO_TX_DATA_OFFSET);
+
+
+        while(pl->transmit_vacancy == 0){
+                hb_mc_platform_get_transmit_vacancy(mc, HB_MC_FIFO_TX_REQ, &pl->transmit_vacancy);
+        }
+
+        pl->transmit_vacancy--;
+
+        // transmit the data one word at a time
+        for (unsigned i = 0; i < array_size(packet->words); i++) {
+                err = hb_mc_platform_mmio_write32(pl, data_addr, packet->words[i]);
+                if (err != HB_MC_SUCCESS) {
+                        return err;
+                }
+        }
+
+        return HB_MC_SUCCESS;
+}
+
+/**
+ * Receive a packet from manycore hardware
+ * @param[in] mc       A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in] response A packet into which data should be read
+ * @param[in] timeout  A timeout counter. Unused - set to -1 to wait forever.
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_platform_receive(hb_mc_manycore_t *mc,
+                           hb_mc_packet_t *packet,
+                           hb_mc_fifo_rx_t type,
+                           long timeout){
+        hb_mc_platform_t *pl = reinterpret_cast<hb_mc_platform_t *>(mc->platform);
+
+        const char *typestr = hb_mc_fifo_rx_to_string(type);
+        uintptr_t data_addr;
+        uint32_t occupancy;
+        int err;
+
+        if (timeout != -1) {
+                platform_pr_err(pl, "%s: Only a timeout value of -1 is supported\n",
+                                __func__);
+                return HB_MC_INVALID;
+        }
+
+        data_addr = hb_mc_mmio_fifo_get_addr(type, HB_MC_MMIO_FIFO_RX_DATA_OFFSET);
+
+        if (type == HB_MC_FIFO_RX_REQ) {
+                /* wait for a packet */
+                do {
+                        err = hb_mc_platform_rx_fifo_get_occupancy(pl, type, &occupancy);
+                        if (err != HB_MC_SUCCESS) {
+                                platform_pr_err(pl, "%s: Failed to get %s FIFO occupancy while waiting for packet: %s\n",
+                                                __func__, typestr, hb_mc_strerror(err));
+                                return err;
+                        }
+
+                } while (occupancy < 1);  // this is packet occupancy, not word occupancy!
+        }
+
+        /* read in the packet one word at a time */
+        for (unsigned i = 0; i < array_size(packet->words); i++) {
+                err = hb_mc_platform_mmio_read32(pl, data_addr, &packet->words[i]);
+                if (err != HB_MC_SUCCESS) {
+                        platform_pr_err(pl, "%s: Failed read data from %s FIFO: %s\n",
+                                        __func__, typestr, hb_mc_strerror(err));
+                        return err;
+                }
+        }
+        return HB_MC_SUCCESS;
+}
+
+/**
+ * Read the configuration register at an index
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in]  idx    Configuration register index to access
+ * @param[out] config Configuration value at index
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_platform_get_config_at(hb_mc_manycore_t *mc, 
+                                 unsigned int idx,
+                                 hb_mc_config_raw_t *config)
+{
+        int err;
+        uintptr_t addr;
+        hb_mc_platform_t *pl = reinterpret_cast<hb_mc_platform_t *>(mc->platform); 
+
+        addr = hb_mc_config_id_to_addr(HB_MC_MMIO_ROM_BASE,
+                                       (hb_mc_config_id_t) idx);
+
+        if(idx >= HB_MC_CONFIG_MAX){
+                return HB_MC_INVALID;
+        }
+
+        err = hb_mc_platform_mmio_read32(pl, addr, config);
+        if (err != HB_MC_SUCCESS) {
+                platform_pr_err(pl, "%s: Failed to read config word %d from ROM\n",
+                                __func__, idx);
+                return err;
+        }
+
+        return HB_MC_SUCCESS;
+}
+
+/**
+ * Read the number of remaining manycore network credits
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[out] credits The number of remaining credits
+ * @param[in] timeout A timeout counter. Unused - set to -1 to wait forever.
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+static int hb_mc_platform_get_credits(hb_mc_manycore_t *mc, 
+                                      int *credits,
+                                      long timeout)
+{
+        uint64_t addr;
+        uint32_t val;
+        int err;
+        hb_mc_platform_t *pl = reinterpret_cast<hb_mc_platform_t *>(mc->platform); 
+
+        if (timeout != -1) {
+                platform_pr_err(pl, "%s: Only a timeout value of -1 is supported\n",
+                                __func__);
+                return HB_MC_NOIMPL;
+        }
+
+        addr = hb_mc_mmio_out_credits_get_addr();
+        err = hb_mc_platform_mmio_read32(pl, addr, &val);
+        if (err != HB_MC_SUCCESS) {
+                platform_pr_err(pl, "%s: Failed to read endpoint out credits: %s\n",
+                                __func__, hb_mc_strerror(err));
+                return err;
+        }
+        *credits = val;
+        return HB_MC_SUCCESS;
+}
+
+
+
+static int hb_mc_platform_dpi_init(hb_mc_platform_t *pl)
+{
+#ifdef COSIM
+        svScope scope;
+        scope = svGetScopeFromName("tb");
+        svSetScope(scope);
+        pl->scope = scope;
+#endif
+        return HB_MC_SUCCESS;
+}
+
+static void hb_mc_platform_dpi_cleanup(hb_mc_platform_t *pl)
+{
+#ifdef COSIM
+        pl->scope = nullptr;
+#endif
+        return;
+}
+
+/**
+ * Clean up the runtime platform
+ * @param[in] mc    A manycore to clean up
+ */
+void hb_mc_platform_cleanup(hb_mc_manycore_t *mc)
+{
+        hb_mc_platform_t *pl = reinterpret_cast<hb_mc_platform_t *>(mc->platform); 
+
+        hb_mc_platform_fifos_cleanup(mc, pl);
+
+        hb_mc_platform_mmio_cleanup(pl);
+
+        hb_mc_platform_dpi_cleanup(pl);
+
+        pl->name = nullptr;
+
+        delete pl;
+
+        mc->platform = nullptr;
+
+        return;
+}
+
+/**
+ * Initialize the runtime platform
+ * @param[in] mc    A manycore to initialize
+ * @param[in] id    ID which selects the physical hardware from which this manycore is configured
+ * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
+ */
+int hb_mc_platform_init(hb_mc_manycore_t *mc,
+                        hb_mc_manycore_id_t id){
+        // check if platform is already initialized
+        if (mc->platform)
+                return HB_MC_INITIALIZED_TWICE;
+
+        int r = HB_MC_FAIL, err;
+
+        hb_mc_platform_t *pl = new hb_mc_platform_t();
+
+        if (!pl) {
+                platform_pr_err(pl, "%s failed: %m\n", __func__);
+                return HB_MC_NOMEM;
+        }
+
+        pl->name = mc->name;
+
+        // initialize simulation
+        if ((err = hb_mc_platform_dpi_init(pl)) != HB_MC_SUCCESS) {
+                delete pl;
+                return err;
+        }
+
+        // initialize manycore for MMIO
+        if ((err = hb_mc_platform_mmio_init(pl, id)) != HB_MC_SUCCESS){
+                hb_mc_platform_dpi_cleanup(pl);
+                delete pl;
+                return err;
+        }
+
+        mc->platform = pl;
+
+        // initialize FIFOs
+        if ((err = hb_mc_platform_fifos_init(mc, pl)) != HB_MC_SUCCESS){
+                mc->platform = nullptr;
+                hb_mc_platform_mmio_cleanup(pl);
+                hb_mc_platform_dpi_cleanup(pl);
+                delete pl;
+                return err;
+        }
+
+        return HB_MC_SUCCESS;
+}
+
+
+/**
+ * Stall until the all requests (and responses) have reached their destination.
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in] timeout A timeout counter. Unused - set to -1 to wait forever.
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_platform_fence(hb_mc_manycore_t *mc,
+                         long timeout)
+{
+        uint32_t max_vacancy;
+        uint32_t max_credits;
+
+        int vacancy;
+        int credits;
+        int err;
+
+        const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
+        const hb_mc_platform_t *pl = reinterpret_cast<hb_mc_platform_t *>(mc->platform); 
+
+        if (timeout != -1) {
+                platform_pr_err(pl, "%s: Only a timeout value of -1 is supported\n",
+                                __func__);
+                return HB_MC_NOIMPL;
+        }
+
+        max_vacancy = hb_mc_config_get_transmit_vacancy_max(cfg);
+        max_credits = hb_mc_config_get_io_endpoint_max_out_credits(cfg);
+
+        // wait until out credts are fully resumed, and the tx fifo vacancy equals to host credits
+        while ((vacancy != max_vacancy) | (credits != max_credits)) {
+                err = hb_mc_platform_get_transmit_vacancy(mc, HB_MC_FIFO_TX_REQ, &vacancy);
+                if (err != HB_MC_SUCCESS)
+                        return err;
+                err = hb_mc_platform_get_credits(mc, &credits, -1);
+                if (err != HB_MC_SUCCESS)
+                        return err;
+        }
+
+        return HB_MC_SUCCESS;
+}

--- a/libraries/bsg_manycore_platform.h
+++ b/libraries/bsg_manycore_platform.h
@@ -1,0 +1,78 @@
+#ifndef __BSG_MANYCORE_PLATFORM_HPP
+#define __BSG_MANYCORE_PLATFORM_HPP
+#include <bsg_manycore.h>
+
+/**
+ * This file defines the interface that runtime platforms provide to
+ * BSG Manycore and CUDA Lite Runtime libraries. This interface
+ * provides methods for initialization and cleanup, transmit and
+ * receive, fence, and configuration.
+ *
+ * To support a new platform, define these functions in a new
+ * bsg_manycore_platform.cpp file. 
+ * 
+ * Editing this file should be VERY rare. Do not add methods to this
+ * interface without SERIOUSLY considering the implications.
+ * 
+ */
+
+/**
+ * Clean up the runtime platform
+ * @param[in] mc    A manycore to clean up
+ */
+void hb_mc_platform_cleanup(hb_mc_manycore_t *mc);
+
+/**
+ * Initialize the runtime platform
+ * @param[in] mc    A manycore to initialize
+ * @param[in] id    ID which selects the physical hardware from which this manycore is configured
+ * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
+ */
+int hb_mc_platform_init(hb_mc_manycore_t *mc,
+                        hb_mc_manycore_id_t id);
+
+/**
+ * Transmit a request packet to manycore hardware
+ * @param[in] mc      A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in] request A request packet to transmit to manycore hardware
+ * @param[in] timeout A timeout counter. Unused - set to -1 to wait forever.
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_platform_transmit(hb_mc_manycore_t *mc,
+                            hb_mc_packet_t *packet,
+                            hb_mc_fifo_tx_t type,
+                            long timeout);
+
+/**
+ * Receive a packet from manycore hardware
+ * @param[in] mc       A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in] response A packet into which data should be read
+ * @param[in] timeout  A timeout counter. Unused - set to -1 to wait forever.
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_platform_receive(hb_mc_manycore_t *mc,
+                           hb_mc_packet_t *packet,
+                           hb_mc_fifo_rx_t type,
+                           long timeout);
+
+/**
+ * Read the configuration register at an index
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in]  idx    Configuration register index to access
+ * @param[out] config Configuration value at index
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_platform_get_config_at(hb_mc_manycore_t *mc, 
+                                 unsigned int idx,
+                                 hb_mc_config_raw_t *config);
+
+/**
+ * Stall until the all requests (and responses) have reached their destination.
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in] timeout A timeout counter. Unused - set to -1 to wait forever.
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_platform_fence(hb_mc_manycore_t *mc, 
+                         long timeout);
+
+#endif

--- a/libraries/libraries.mk
+++ b/libraries/libraries.mk
@@ -27,6 +27,7 @@
 
 LIB_CSOURCES   += 
 LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore.cpp
+LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_platform.cpp
 LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_bits.cpp
 LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_config.cpp
 LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_cuda.cpp

--- a/regression/library/test_rom.c
+++ b/regression/library/test_rom.c
@@ -60,49 +60,6 @@ int test_rom (int argc, char **argv) {
         config = hb_mc_manycore_get_config(&mc);
 
 
-        /* Check the flow control parameters in IO */
-        dim = hb_mc_config_get_dimension_vcore(config);
-        // check enough times to let the credit resume...
-        int max_trail_num = hb_mc_dimension_get_x(dim)*hb_mc_dimension_get_y(dim);
-        uint32_t matched = 0;
-
-        // out credits from manycore endpoint standard
-        expected = hb_mc_config_get_io_endpoint_max_out_credits(config);
-        bsg_pr_test_info("Checking that the expected endpoint out credits is %d\n", expected);
-        for (unsigned i = 0; i < max_trail_num; i++) {
-            result = hb_mc_manycore_get_endpoint_out_credits(&mc);
-            bsg_pr_test_info("Try No. %d: endpoint out credits is %d\n", i, result);
-            if(result == expected) {
-                matched = 1;
-                break;
-            }
-        }
-        if (!matched) {
-            bsg_pr_test_err("Incorrect number of out credits. Got: %d, expected %d\n", result, expected);
-            bsg_pr_test_err("Have you programed your FPGA fpga-load-local-image)\n");
-            fail = 1;
-            goto cleanup;
-        }
-
-        // max host credits
-        expected = hb_mc_config_get_io_host_credits_cap(config);
-        bsg_pr_test_info("Checking that the expected host request credits is %d\n", expected);
-        for (unsigned i = 0; i < max_trail_num; i++) {
-            result = hb_mc_manycore_get_host_request_credits(&mc);
-            bsg_pr_test_info("Try No. %d: host request credits is %d\n", i, result);
-            if(result == expected) {
-                matched = 1;
-                break;
-            }
-        }
-        if (!matched) {
-            bsg_pr_test_err("Incorrect number of out credits. Got: %d, expected %d\n", result, expected);
-            bsg_pr_test_err("Have you programed your FPGA fpga-load-local-image)\n");
-            fail = 1;
-            goto cleanup;
-        }
-
-
         /* Read configuration and test values */
 #ifdef COSIM
         bsg_pr_test_info("Checking that the COSIM Major Version Number is %d\n", expected);


### PR DESCRIPTION
I've introduced the idea of platforms. Platforms are the host medium for running a manycore, be it FPGA, VCS, or Verilator. This PR splits `bsg_manycore.cpp` into two files: 

`bsg_manycore.cpp`: Manycore API - data copy in/out, packet tx/rx
`bsg_manycore_platform.cpp`: platform-specific tx/rx, initialization

This should make supporting new machines easier. This work would have been needed eventually to support Black Parrot. It has probably already been done by Paul. It was definitely already done by me, for Verilator.

I also took the liberty of removing some old, outdated code. This simplifies the interface between manycore software and platform. 
