### PR TITLE
Split DMA into feature-specific files

### DIFF
--- a/hardware/hardware.mk
+++ b/hardware/hardware.mk
@@ -252,7 +252,9 @@ $(BSG_MACHINE_PATH)/bsg_bladerunner_pkg.v: $(BSG_MACHINE_PATH)/bsg_bladerunner_c
 	@echo "\`endif" >> $@
 
 
-.PHONY: hardware.clean
+.PHONY: hardware.clean hardware.bleach
+
+hardware.bleach:
 
 # The rm commands on the hardware path are legacy, but we keep them
 # because NOT cleaning those files can really F*** with running

--- a/libraries/bsg_manycore.cpp
+++ b/libraries/bsg_manycore.cpp
@@ -27,16 +27,13 @@
 
 #include <bsg_manycore.h>
 #include <bsg_manycore_platform.h>
+#include <bsg_manycore_dma.h>
 #include <bsg_manycore_fifo.h>
 #include <bsg_manycore_printing.h>
 #include <bsg_manycore_tile.h>
 #include <bsg_manycore_responder.h>
 #include <bsg_manycore_epa.h>
 #include <bsg_manycore_vcache.h>
-
-#ifdef COSIM
-#include <bsg_mem_dma.hpp>
-#endif
 
 #include <cinttypes>
 #include <cstdint>
@@ -296,6 +293,7 @@ int hb_mc_manycore_packet_tx(hb_mc_manycore_t *mc,
         case HB_MC_FIFO_TX_REQ:
                 return hb_mc_manycore_request_tx(mc, &packet->request, timeout);
         }
+        return HB_MC_FAIL;
 }
 
 /**
@@ -317,6 +315,7 @@ int hb_mc_manycore_packet_rx(hb_mc_manycore_t *mc,
         case HB_MC_FIFO_RX_REQ:
                 return hb_mc_manycore_request_rx(mc, &packet->request, timeout);
         }
+        return HB_MC_FAIL;
 }
 
 /////////////////////////////
@@ -630,317 +629,6 @@ int hb_mc_manycore_flush_vcache(hb_mc_manycore_t *mc)
         return HB_MC_SUCCESS;
 }
 
-
-/////////////
-// DMA API //
-/////////////
-
-/**
- * Check if NPA is in DRAM.
- * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
- * @param[in]  npa    A valid hb_mc_npa_t
- * @return One if the NPA maps to DRAM - Zero otherwise.
- */
-int hb_mc_manycore_npa_is_dram(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa)
-{
-    const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
-    return hb_mc_config_is_dram_y(cfg, hb_mc_npa_get_y(npa));
-}
-
-/**
- * Given an NPA that maps to DRAM, return a buffer that holds the data for that address.
- * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
- * @param[in]  npa    A valid hb_mc_npa_t - must be an L2 cache coordinate
- * @param[in]  sz     The number of bytes to write to manycore hardware - used for sanity check
- * @param[out] buffer The valid buffer
- * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
- */
-static int hb_mc_manycore_npa_to_buffer_cosim_only(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa, size_t sz,
-                                                   unsigned char **buffer)
-{
-#ifdef COSIM
-    using namespace bsg_mem_dma;
-
-    /*
-      Our system supports having multiple caches per memory channel.
-      Currently, we do this by splitting the channels evenly into even 'banks' for each cache.
-
-      IF THE ADDRESS MAPPING SCHEME FROM CACHES TO DRAM CHANGES THIS FUNCTION WILL BREAK!!!!!
-
-      As of the time of this writing we are in the process of designing the memory system.
-      So take note...
-     */
-
-    /*
-      Get system parameters for performing the address mapping
-     */
-    const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
-    unsigned long caches = hb_mc_vcache_num_caches(mc);
-    unsigned long channels = hb_mc_config_get_dram_channels(cfg);
-    unsigned long caches_per_channel = caches/channels;
-
-    manycore_pr_dbg(mc, "%s: caches = %lu, channels = %lu, caches_per_channel = %lu\n",
-                    __func__, caches, channels, caches_per_channel);
-
-    /*
-      Figure out which memory channel and bank this NPA maps to.
-     */
-    hb_mc_idx_t cache_id = hb_mc_config_get_dram_id(cfg, hb_mc_npa_get_xy(npa)); // which cache
-    parameter_t id = cache_id / caches_per_channel; // which channel
-    parameter_t bank = cache_id % caches_per_channel; // which bank within channel
-
-    /*
-      Use the backdoor to our non-synthesizable memory.
-     */
-    Memory *memory = bsg_mem_dma_get_memory(id);
-    parameter_t bank_size = memory->_data.size()/caches_per_channel;
-
-    hb_mc_epa_t epa = hb_mc_npa_get_epa(npa);
-    char npa_str[256];
-
-    if (memory == nullptr) {
-        manycore_pr_err(mc, " %s: Could not get the memory for endpoint at %s\n",
-                        __func__, hb_mc_npa_to_string(npa, npa_str, sizeof(npa_str)));
-
-        return HB_MC_FAIL;
-    }
-
-    // this is the address that comes out of cache_to_test_dram_tx
-    address_t cache_addr = bank*bank_size + epa;
-    address_t addr = hb_mc_memsys_map_to_physical_channel_address(&cfg->memsys, cache_addr);
-
-
-    manycore_pr_dbg(mc, "%s: Mapped %s to Channel %2lu, Address 0x%08lx\n",
-                    __func__, hb_mc_npa_to_string(npa, npa_str, sizeof(npa_str)), id, addr);
-
-    /*
-      Don't overflow memory if you can help it.
-    */
-    assert(addr + sz <= memory->_data.size());
-
-    *buffer = &memory->_data[addr];
-
-    return HB_MC_SUCCESS;
-#else
-    manycore_pr_err(mc, "%s: This function should only be called in simulation\n",
-                    __func__);
-    return HB_MC_NOIMPL;
-#endif
-}
-
-/**
- * Write memory out to manycore DRAM via C++ backdoor
- * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
- * @param[in]  npa    A valid hb_mc_npa_t - must be an L2 cache coordinate
- * @param[in]  data   A buffer to be written out manycore hardware
- * @param[in]  sz     The number of bytes to write to manycore hardware
- * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
- */
-static int hb_mc_manycore_write_dram_cosim_only(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa,
-                                                const void *data, size_t sz)
-{
-#ifdef COSIM
-    unsigned char *membuffer;
-    int err = hb_mc_manycore_npa_to_buffer_cosim_only(mc, npa, sz, &membuffer);
-    if (err != HB_MC_SUCCESS)
-        return err;
-
-    char npa_str[256];
-
-    manycore_pr_dbg(mc, "%s: Writing %3zu bytes to %s\n",
-                    __func__, sz, hb_mc_npa_to_string(npa, npa_str, sizeof(npa_str)));
-
-    memcpy(reinterpret_cast<void*>(membuffer), data, sz);
-
-    return HB_MC_SUCCESS;
-#else
-    manycore_pr_err(mc, "%s: This function should only be called in simulation\n",
-                    __func__);
-    return HB_MC_NOIMPL;
-#endif
-}
-
-
-/**
- * Read memory from manycore DRAM via C++ backdoor
- * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
- * @param[in]  npa    A valid hb_mc_npa_t - must be an L2 cache coordinate
- * @param[in]  data   A host buffer to be read into from manycore hardware
- * @param[in]  sz     The number of bytes to read from manycore hardware
- * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
- */
-static int hb_mc_manycore_read_dram_cosim_only(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa,
-                                               void *data, size_t sz)
-{
-#ifdef COSIM
-    unsigned char *membuffer;
-    int err = hb_mc_manycore_npa_to_buffer_cosim_only(mc, npa, sz, &membuffer);
-    if (err != HB_MC_SUCCESS)
-        return err;
-
-    char npa_str[256];
-
-    manycore_pr_dbg(mc, "%s: Reading %3zu bytes from %s\n",
-                    __func__, sz, hb_mc_npa_to_string(npa, npa_str, sizeof(npa_str)));
-
-    memcpy(data, reinterpret_cast<void*>(membuffer), sz);
-
-    return HB_MC_SUCCESS;
-#else
-    manycore_pr_err(mc, "%s: This function should only be called in simulation\n",
-                    __func__);
-    return HB_MC_NOIMPL;
-#endif
-}
-
-
-/**
- * Check if DMA writing is supported.
- * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
- * @return One if DMA writing is supported - Zero otherwise.
- */
-int hb_mc_manycore_supports_dma_write(const hb_mc_manycore *mc)
-{
-        return hb_mc_config_memsys_feature_dma(hb_mc_manycore_get_config(mc)) == 1;
-}
-
-/**
- * Check if DMA reading is supported.
- * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
- * @return One if DMA reading is supported - Zero otherwise.
- */
-int hb_mc_manycore_supports_dma_read(const hb_mc_manycore *mc)
-{
-        return hb_mc_config_memsys_feature_dma(hb_mc_manycore_get_config(mc)) == 1;
-}
-
-/**
- * Write memory via DMA to manycore DRAM starting at a given NPA
- * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
- * @param[in]  npa    A valid hb_mc_npa_t (must map to DRAM)
- * @param[in]  data   A buffer to be written out manycore hardware
- * @param[in]  sz     The number of bytes to write to manycore hardware
- * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
- *
- * This function is used to write to HammerBlade DRAM directly via DMA.
- * Any data in the cache that becomes stale will be invalidated - this function is 'safe' in that respect.
- *
- * However, invalidating every address might be expensive - and perhaps unnecessary if you 'know'
- * that the memory being written is guaranteed to be un-cached.
- * See hb_mc_manycore_dma_write_no_cache_ainv() for an unsafe version of this function.
- *
- * This function is not supported on all HammerBlade platforms.
- * Please check the return code for HB_MC_NOIMPL.
- */
-int hb_mc_manycore_dma_write(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa,
-                             const void *data, size_t sz)
-{
-        int err;
-        if (!hb_mc_manycore_supports_dma_write(mc))
-                return HB_MC_INVALID;
-
-        err = hb_mc_manycore_dma_write_no_cache_ainv(mc, npa, data, sz);
-        if (err != HB_MC_SUCCESS)
-                return err;
-
-        return hb_mc_manycore_vcache_invalidate_npa_range(mc, npa, sz);
-}
-
-/**
- * Write memory via DMA to manycore DRAM starting at a given NPA - unsafe
- * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
- * @param[in]  npa    A valid hb_mc_npa_t (must map to DRAM)
- * @param[in]  data   A buffer to be written out manycore hardware
- * @param[in]  sz     The number of bytes to write to manycore hardware
- * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
- *
- * This function is used to write to HammerBlade DRAM directly via DMA.
- * Stale data may remain in the cache - this function is unsafe in that respect.
- * This function is not supported on all HammerBlade platforms.
- * Please check the return code for HB_MC_NOIMPL.
- */
-int hb_mc_manycore_dma_write_no_cache_ainv(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa,
-                                           const void *data, size_t sz)
-{
-        int err;
-        if (!hb_mc_manycore_supports_dma_write(mc))
-                return HB_MC_NOIMPL;
-
-        // is dram?
-        if (!hb_mc_manycore_npa_is_dram(mc, npa))
-                return HB_MC_INVALID;
-
-
-        err = hb_mc_manycore_write_dram_cosim_only(mc, npa, data, sz);
-        if (err != HB_MC_SUCCESS)
-                return err;
-
-        return HB_MC_SUCCESS;
-}
-
-
-/**
- * Read memory via DMA from manycore DRAM starting at a given NPA - unsafe
- * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
- * @param[in]  npa    A valid hb_mc_npa_t (must map to DRAM)
- * @param[in]  data   A buffer into which data will be read
- * @param[in]  sz     The number of bytes to read from manycore hardware
- * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
- *
- * This function is used to read from HammerBlade DRAM directly via DMA.
- * Cached data for this memory range migth not be flushed - this function is 'unsafe' in that respect.
- *
- * This function is not supported on all HammerBlade platforms.
- * Please check the return code for HB_MC_NOIMPL.
- */
-int hb_mc_manycore_dma_read_no_cache_afl(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa,
-                                         void *data, size_t sz)
-{
-        int err;
-        if (!hb_mc_manycore_supports_dma_read(mc))
-                return HB_MC_NOIMPL;
-
-        // is dram?
-        if (!hb_mc_manycore_npa_is_dram(mc, npa))
-                return HB_MC_INVALID;
-
-        return hb_mc_manycore_read_dram_cosim_only(mc, npa, data, sz);
-}
-
-/**
- * Read memory via DMA from manycore DRAM starting at a given NPA
- * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
- * @param[in]  npa    A valid hb_mc_npa_t (must map to DRAM)
- * @param[in]  data   A buffer into which data will be read
- * @param[in]  sz     The number of bytes to read from manycore hardware
- * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
- *
- * This function is used to read from HammerBlade DRAM directly via DMA.
- * Any cached data for this memory range will be flushed - this function is 'safe' in that respect.
- *
- * However, sending a flush packet for every address in this range might be expensive -
- * and perhaps unnecessary if you 'know'  the data is uncached.
- * See hb_mc_manycore_dma_read_no_cache_afl() for an unsafe alternative to this function.
- *
- * This function is not supported on all HammerBlade platforms.
- * Please check the return code for HB_MC_NOIMPL.
- */
-int hb_mc_manycore_dma_read(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa,
-                            void *data, size_t sz)
-{
-        int err;
-        if (!hb_mc_manycore_supports_dma_read(mc))
-                return HB_MC_NOIMPL;
-
-        if (!hb_mc_manycore_npa_is_dram(mc, npa))
-                return HB_MC_INVALID;
-
-        err = hb_mc_manycore_vcache_flush_npa_range(mc, npa, sz);
-        if (err != HB_MC_SUCCESS)
-                return err;
-
-        return hb_mc_manycore_dma_read_no_cache_afl(mc, npa, data, sz);
-}
 
 ////////////////
 // Memory API //
@@ -1571,4 +1259,158 @@ int hb_mc_manycore_disable_dram(hb_mc_manycore_t *mc)
         }
         mc->dram_enabled = 0;
         return HB_MC_SUCCESS;
+}
+
+
+/**
+ * Check if DMA writing is supported.
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @return One if DMA writing is supported - Zero otherwise.
+ */
+int hb_mc_manycore_supports_dma_write(const hb_mc_manycore_t *mc)
+{
+        return hb_mc_dma_supports_write(mc);
+}
+
+/**
+ * Check if DMA reading is supported.
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @return One if DMA reading is supported - Zero otherwise.
+ */
+ int hb_mc_manycore_supports_dma_read(const hb_mc_manycore_t *mc)
+{
+        return hb_mc_dma_supports_read(mc);
+}
+
+/**
+ * Write memory via DMA to manycore DRAM starting at a given NPA
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in]  npa    A valid hb_mc_npa_t (must map to DRAM)
+ * @param[in]  data   A buffer to be written out manycore hardware
+ * @param[in]  sz     The number of bytes to write to manycore hardware
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ *
+ * This function is used to write to HammerBlade DRAM directly via DMA.
+ * Any data in the cache that becomes stale will be invalidated - this function is 'safe' in that respect.
+ *
+ * However, invalidating every address might be expensive - and perhaps unnecessary if you 'know'
+ * that the memory being written is guaranteed to be un-cached.
+ * See hb_mc_manycore_dma_write_no_cache_ainv() for an unsafe version of this function.
+ *
+ * This function is not supported on all HammerBlade platforms.
+ * Please check the return code for HB_MC_NOIMPL.
+ */
+int hb_mc_manycore_dma_write(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa,
+                             const void *data, size_t sz)
+{
+        int err;
+        if (!hb_mc_manycore_supports_dma_write(mc))
+                return HB_MC_INVALID;
+
+        err = hb_mc_manycore_dma_write_no_cache_ainv(mc, npa, data, sz);
+        if (err != HB_MC_SUCCESS)
+                return err;
+
+        return hb_mc_manycore_vcache_invalidate_npa_range(mc, npa, sz);
+}
+
+/**
+ * Write memory via DMA to manycore DRAM starting at a given NPA - unsafe
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in]  npa    A valid hb_mc_npa_t (must map to DRAM)
+ * @param[in]  data   A buffer to be written out manycore hardware
+ * @param[in]  sz     The number of bytes to write to manycore hardware
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ *
+ * This function is used to write to HammerBlade DRAM directly via DMA.
+ * Stale data may remain in the cache - this function is unsafe in that respect.
+ * This function is not supported on all HammerBlade platforms.
+ * Please check the return code for HB_MC_NOIMPL.
+ */
+int hb_mc_manycore_dma_write_no_cache_ainv(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa,
+                                           const void *data, size_t sz)
+{
+        int err;
+        if (!hb_mc_manycore_supports_dma_write(mc))
+                return HB_MC_NOIMPL;
+
+        // is dram?
+        if (!hb_mc_manycore_npa_is_dram(mc, npa))
+                return HB_MC_INVALID;
+
+        err = hb_mc_dma_write(mc, npa, data, sz);
+        if (err != HB_MC_SUCCESS)
+                return err;
+
+        return HB_MC_SUCCESS;
+}
+
+
+/**
+ * Read memory via DMA from manycore DRAM starting at a given NPA - unsafe
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in]  npa    A valid hb_mc_npa_t (must map to DRAM)
+ * @param[in]  data   A buffer into which data will be read
+ * @param[in]  sz     The number of bytes to read from manycore hardware
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ *
+ * This function is used to read from HammerBlade DRAM directly via DMA.
+ * Cached data for this memory range might not be flushed - this function is 'unsafe' in that respect.
+ *
+ * This function is not supported on all HammerBlade platforms.
+ * Please check the return code for HB_MC_NOIMPL.
+ */
+int hb_mc_manycore_dma_read_no_cache_afl(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa,
+                                         void *data, size_t sz)
+{
+        int err;
+        if (!hb_mc_manycore_supports_dma_read(mc))
+                return HB_MC_NOIMPL;
+
+        if (!hb_mc_manycore_dram_is_enabled(mc))
+                return HB_MC_FAIL;
+
+        // is dram?
+        if (!hb_mc_manycore_npa_is_dram(mc, npa))
+                return HB_MC_INVALID;
+
+        return hb_mc_dma_read(mc, npa, data, sz);
+}
+
+/**
+ * Read memory via DMA from manycore DRAM starting at a given NPA
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in]  npa    A valid hb_mc_npa_t (must map to DRAM)
+ * @param[in]  data   A buffer into which data will be read
+ * @param[in]  sz     The number of bytes to read from manycore hardware
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ *
+ * This function is used to read from HammerBlade DRAM directly via DMA.
+ * Any cached data for this memory range will be flushed - this function is 'safe' in that respect.
+ *
+ * However, sending a flush packet for every address in this range might be expensive -
+ * and perhaps unnecessary if you 'know'  the data is uncached.
+ * See hb_mc_manycore_dma_read_no_cache_afl() for an unsafe alternative to this function.
+ *
+ * This function is not supported on all HammerBlade platforms.
+ * Please check the return code for HB_MC_NOIMPL.
+ */
+int hb_mc_manycore_dma_read(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa,
+                            void *data, size_t sz)
+{
+        int err;
+        if (!hb_mc_manycore_supports_dma_read(mc))
+                return HB_MC_NOIMPL;
+
+        if (!hb_mc_manycore_dram_is_enabled(mc))
+                return HB_MC_FAIL;
+
+        if (!hb_mc_manycore_npa_is_dram(mc, npa))
+                return HB_MC_INVALID;
+
+        err = hb_mc_manycore_vcache_flush_npa_range(mc, npa, sz);
+        if (err != HB_MC_SUCCESS)
+                return err;
+
+        return hb_mc_manycore_dma_read_no_cache_afl(mc, npa, data, sz);
 }

--- a/libraries/bsg_manycore.cpp
+++ b/libraries/bsg_manycore.cpp
@@ -1261,6 +1261,18 @@ int hb_mc_manycore_disable_dram(hb_mc_manycore_t *mc)
         return HB_MC_SUCCESS;
 }
 
+/**
+ * Check if NPA is in DRAM.
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in]  npa    A valid hb_mc_npa_t
+ * @return One if the NPA maps to DRAM - Zero otherwise.
+ */
+static inline int hb_mc_manycore_npa_is_dram(hb_mc_manycore_t *mc,
+                                             const hb_mc_npa_t *npa)
+{
+        const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
+        return hb_mc_config_is_dram_y(cfg, hb_mc_npa_get_y(npa));
+}
 
 /**
  * Check if DMA writing is supported.
@@ -1307,6 +1319,9 @@ int hb_mc_manycore_dma_write(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa,
         if (!hb_mc_manycore_supports_dma_write(mc))
                 return HB_MC_INVALID;
 
+        if (!hb_mc_manycore_dram_is_enabled(mc))
+                return HB_MC_FAIL;
+
         err = hb_mc_manycore_dma_write_no_cache_ainv(mc, npa, data, sz);
         if (err != HB_MC_SUCCESS)
                 return err;
@@ -1333,6 +1348,9 @@ int hb_mc_manycore_dma_write_no_cache_ainv(hb_mc_manycore_t *mc, const hb_mc_npa
         int err;
         if (!hb_mc_manycore_supports_dma_write(mc))
                 return HB_MC_NOIMPL;
+
+        if (!hb_mc_manycore_dram_is_enabled(mc))
+                return HB_MC_FAIL;
 
         // is dram?
         if (!hb_mc_manycore_npa_is_dram(mc, npa))

--- a/libraries/bsg_manycore.h
+++ b/libraries/bsg_manycore.h
@@ -475,15 +475,6 @@ extern "C" {
          */
         int hb_mc_manycore_disable_dram(hb_mc_manycore_t *mc);
 
-
-        /**
-         * Check if NPA is in DRAM.
-         * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
-         * @param[in]  npa    A valid hb_mc_npa_t
-         * @return One if the NPA maps to DRAM - Zero otherwise.
-         */
-        int hb_mc_manycore_npa_is_dram(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa);
-
         /**
          * Get the max size of program text.
          */

--- a/libraries/bsg_manycore_config.h
+++ b/libraries/bsg_manycore_config.h
@@ -481,7 +481,7 @@ extern "C" {
         }
 
         /**
-         * Return the number of DRAM channels in the system.
+         * Return a the configuration value for the DMA feature
          * @param[in] cfg A configuration initialized from the manycore ROM.
          * @return 1 if DMA is a supported memory system feature, 0 otherwise.
          */
@@ -491,7 +491,7 @@ extern "C" {
         }
 
         /**
-         * Return the number of DRAM channels in the system.
+         * Return a the configuration value for the cache feature of the memory system.
          * @param[in] cfg A configuration initialized from the manycore ROM.
          * @return 1 if cache is a supported memory system feature, 0 otherwise.
          */
@@ -501,9 +501,9 @@ extern "C" {
         }
 
         /**
-         * Return the number of DRAM channels in the system.
+         * Returns an identifier for the memory system type
          * @param[in] cfg A configuration initialized from the manycore ROM.
-         * @return 1 if cache is a supported memory system feature, 0 otherwise.
+         * @return An enum value from hb_mc_memsys_id_t defining the memory type
          */
         static inline hb_mc_memsys_id_t hb_mc_config_memsys_id(const hb_mc_config_t *cfg)
         {

--- a/libraries/bsg_manycore_platform.h
+++ b/libraries/bsg_manycore_platform.h
@@ -106,6 +106,7 @@ extern "C" {
          * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
          */
         int hb_mc_platform_finish_bulk_transfer(hb_mc_manycore_t *mc);
+#ifdef __cplusplus
 }
-
+#endif
 #endif

--- a/libraries/features/README.md
+++ b/libraries/features/README.md
@@ -1,0 +1,15 @@
+# Platform Features
+
+This directory contains optional platform features that provide a similar API. 
+
+For example: DMA. DMA is implemented in simulation using a "magic"
+back-door to load data directly into simulated DRAM when using
+C++-based memory models. The DMA driver for simulation is in the
+[dma/simulation](dma/simulation) directory, and the API is in the
+[dma](dma) directory.
+
+However, some platforms do not implement these features. In this case,
+each feature should provide a **noimpl** "driver" that simply returns
+`HB_MC_NO_IMPL` for every API function call. For example, the
+`aws-fpga` platform does not currently support DMA, so it reuses the
+files in [dma/noimpl](dma/noimpl).

--- a/libraries/features/dma/bsg_manycore_dma.h
+++ b/libraries/features/dma/bsg_manycore_dma.h
@@ -29,20 +29,6 @@ extern "C" {
                 return hb_mc_config_memsys_feature_dma(hb_mc_manycore_get_config(mc)) == 1;
         }
 
-        // I don't think this should go here, but what do I know
-        /**
-         * Check if NPA is in DRAM.
-         * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
-         * @param[in]  npa    A valid hb_mc_npa_t
-         * @return One if the NPA maps to DRAM - Zero otherwise.
-         */
-        static inline int hb_mc_manycore_npa_is_dram(hb_mc_manycore_t *mc,
-                                                     const hb_mc_npa_t *npa)
-        {
-                const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
-                return hb_mc_config_is_dram_y(cfg, hb_mc_npa_get_y(npa));
-        }
-
         /**
          * Read memory from manycore DRAM via C++ backdoor
          * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()

--- a/libraries/features/dma/bsg_manycore_dma.h
+++ b/libraries/features/dma/bsg_manycore_dma.h
@@ -5,55 +5,48 @@
 #include <bsg_manycore_npa.h>
 #include <bsg_manycore_config.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-        /**
-         * Check if DMA writing is supported.
-         * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
-         * @return One if DMA writing is supported - Zero otherwise.
-         */
-        static inline int hb_mc_dma_supports_write(const hb_mc_manycore_t *mc)
-        {
-                return hb_mc_config_memsys_feature_dma(hb_mc_manycore_get_config(mc)) == 1;
-        }
-
-        /**
-         * Check if DMA reading is supported.
-         * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
-         * @return One if DMA reading is supported - Zero otherwise.
-         */
-        static inline int hb_mc_dma_supports_read(const hb_mc_manycore_t *mc)
-        {
-                return hb_mc_config_memsys_feature_dma(hb_mc_manycore_get_config(mc)) == 1;
-        }
-
-        /**
-         * Read memory from manycore DRAM via C++ backdoor
-         * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
-         * @param[in]  npa    A valid hb_mc_npa_t - must be an L2 cache coordinate
-         * @param[in]  data   A host buffer to be read into from manycore hardware
-         * @param[in]  sz     The number of bytes to read from manycore hardware
-         * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
-         */
-        int hb_mc_dma_read(hb_mc_manycore_t *mc,
-                           const hb_mc_npa_t *npa,
-                           void *data, size_t sz);
-
-        /**
-         * Write memory out to manycore DRAM via C++ backdoor
-         * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
-         * @param[in]  npa    A valid hb_mc_npa_t - must be an L2 cache coordinate
-         * @param[in]  data   A buffer to be written out manycore hardware
-         * @param[in]  sz     The number of bytes to write to manycore hardware
-         * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
-         */
-        int hb_mc_dma_write(hb_mc_manycore_t *mc,
-                            const hb_mc_npa_t *npa,
-                            const void *data, size_t sz);
-#ifdef __cplusplus
+/**
+ * Check if DMA writing is supported.
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @return One if DMA writing is supported - Zero otherwise.
+ */
+static inline int hb_mc_dma_supports_write(const hb_mc_manycore_t *mc)
+{
+        return hb_mc_config_memsys_feature_dma(hb_mc_manycore_get_config(mc)) == 1;
 }
-#endif
+
+/**
+ * Check if DMA reading is supported.
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @return One if DMA reading is supported - Zero otherwise.
+ */
+static inline int hb_mc_dma_supports_read(const hb_mc_manycore_t *mc)
+{
+        return hb_mc_config_memsys_feature_dma(hb_mc_manycore_get_config(mc)) == 1;
+}
+
+/**
+ * Read memory from manycore DRAM via C++ backdoor
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in]  npa    A valid hb_mc_npa_t - must be an L2 cache coordinate
+ * @param[in]  data   A host buffer to be read into from manycore hardware
+ * @param[in]  sz     The number of bytes to read from manycore hardware
+ * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
+ */
+int hb_mc_dma_read(hb_mc_manycore_t *mc,
+                   const hb_mc_npa_t *npa,
+                   void *data, size_t sz);
+
+/**
+ * Write memory out to manycore DRAM via C++ backdoor
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in]  npa    A valid hb_mc_npa_t - must be an L2 cache coordinate
+ * @param[in]  data   A buffer to be written out manycore hardware
+ * @param[in]  sz     The number of bytes to write to manycore hardware
+ * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
+ */
+int hb_mc_dma_write(hb_mc_manycore_t *mc,
+                    const hb_mc_npa_t *npa,
+                    const void *data, size_t sz);
 
 #endif

--- a/libraries/features/dma/bsg_manycore_dma.h
+++ b/libraries/features/dma/bsg_manycore_dma.h
@@ -1,0 +1,73 @@
+#ifndef __BSG_MANYCORE_DMA_HPP
+#define __BSG_MANYCORE_DMA_HPP
+
+#include <bsg_manycore.h>
+#include <bsg_manycore_npa.h>
+#include <bsg_manycore_config.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+        /**
+         * Check if DMA writing is supported.
+         * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+         * @return One if DMA writing is supported - Zero otherwise.
+         */
+        static inline int hb_mc_dma_supports_write(const hb_mc_manycore_t *mc)
+        {
+                return hb_mc_config_memsys_feature_dma(hb_mc_manycore_get_config(mc)) == 1;
+        }
+
+        /**
+         * Check if DMA reading is supported.
+         * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+         * @return One if DMA reading is supported - Zero otherwise.
+         */
+        static inline int hb_mc_dma_supports_read(const hb_mc_manycore_t *mc)
+        {
+                return hb_mc_config_memsys_feature_dma(hb_mc_manycore_get_config(mc)) == 1;
+        }
+
+        // I don't think this should go here, but what do I know
+        /**
+         * Check if NPA is in DRAM.
+         * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+         * @param[in]  npa    A valid hb_mc_npa_t
+         * @return One if the NPA maps to DRAM - Zero otherwise.
+         */
+        static inline int hb_mc_manycore_npa_is_dram(hb_mc_manycore_t *mc,
+                                                     const hb_mc_npa_t *npa)
+        {
+                const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
+                return hb_mc_config_is_dram_y(cfg, hb_mc_npa_get_y(npa));
+        }
+
+        /**
+         * Read memory from manycore DRAM via C++ backdoor
+         * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+         * @param[in]  npa    A valid hb_mc_npa_t - must be an L2 cache coordinate
+         * @param[in]  data   A host buffer to be read into from manycore hardware
+         * @param[in]  sz     The number of bytes to read from manycore hardware
+         * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
+         */
+        int hb_mc_dma_read(hb_mc_manycore_t *mc,
+                           const hb_mc_npa_t *npa,
+                           void *data, size_t sz);
+
+        /**
+         * Write memory out to manycore DRAM via C++ backdoor
+         * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+         * @param[in]  npa    A valid hb_mc_npa_t - must be an L2 cache coordinate
+         * @param[in]  data   A buffer to be written out manycore hardware
+         * @param[in]  sz     The number of bytes to write to manycore hardware
+         * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
+         */
+        int hb_mc_dma_write(hb_mc_manycore_t *mc,
+                            const hb_mc_npa_t *npa,
+                            const void *data, size_t sz);
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libraries/features/dma/noimpl/bsg_manycore_dma.cpp
+++ b/libraries/features/dma/noimpl/bsg_manycore_dma.cpp
@@ -1,0 +1,34 @@
+/**
+ * Write memory out to manycore DRAM via DMA
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in]  npa    A valid hb_mc_npa_t - must be an L2 cache coordinate
+ * @param[in]  data   A buffer to be written out manycore hardware
+ * @param[in]  sz     The number of bytes to write to manycore hardware
+ * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
+ */
+int hb_mc_dma_write(hb_mc_manycore_t *mc,
+                    const hb_mc_npa_t *npa,
+                    const void *data, size_t sz)
+{
+        manycore_pr_err(mc, "%s: This function is not supported on this platform\n",
+                        __func__);
+        return HB_MC_NOIMPL;
+}
+
+
+/**
+ * Read memory from manycore DRAM via DMA
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in]  npa    A valid hb_mc_npa_t - must be an L2 cache coordinate
+ * @param[in]  data   A host buffer to be read into from manycore hardware
+ * @param[in]  sz     The number of bytes to read from manycore hardware
+ * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
+ */
+int hb_mc_dma_read(hb_mc_manycore_t *mc, 
+                   const hb_mc_npa_t *npa,
+                   void *data, size_t sz)
+{
+        manycore_pr_err(mc, "%s: This function is not supported on this platform\n",
+                        __func__);
+        return HB_MC_NOIMPL;
+}

--- a/libraries/features/dma/noimpl/bsg_manycore_dma.cpp
+++ b/libraries/features/dma/noimpl/bsg_manycore_dma.cpp
@@ -1,16 +1,37 @@
+#include <bsg_manycore_dma.h>
+#include <bsg_manycore.h>
+#include <bsg_manycore_printing.h>
+/* these are convenience macros that are only good for one line prints */
+#define dma_pr_dbg(mc, fmt, ...)                   \
+        bsg_pr_dbg("%s: " fmt, mc->name, ##__VA_ARGS__)
+
+#define dma_pr_err(mc, fmt, ...)                   \
+        bsg_pr_err("%s: " fmt, mc->name, ##__VA_ARGS__)
+
+#define dma_pr_warn(mc, fmt, ...)                          \
+        bsg_pr_warn("%s: " fmt, mc->name, ##__VA_ARGS__)
+
+#define dma_pr_info(mc, fmt, ...)                          \
+        bsg_pr_info("%s: " fmt, mc->name, ##__VA_ARGS__)
+
 /**
  * Write memory out to manycore DRAM via DMA
+ * 
+ * NOTE: This method is declared with __attribute__((weak)) so that a
+ * platform can define write OR read in its own bsg_manycore_dma.cpp
+ * implementation, but does not need to declare both.
+ *
  * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
  * @param[in]  npa    A valid hb_mc_npa_t - must be an L2 cache coordinate
  * @param[in]  data   A buffer to be written out manycore hardware
  * @param[in]  sz     The number of bytes to write to manycore hardware
  * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
  */
-int hb_mc_dma_write(hb_mc_manycore_t *mc,
+int __attribute__((weak)) hb_mc_dma_write(hb_mc_manycore_t *mc,
                     const hb_mc_npa_t *npa,
                     const void *data, size_t sz)
 {
-        manycore_pr_err(mc, "%s: This function is not supported on this platform\n",
+        dma_pr_err(mc, "%s: This function is not supported on this platform\n",
                         __func__);
         return HB_MC_NOIMPL;
 }
@@ -18,17 +39,22 @@ int hb_mc_dma_write(hb_mc_manycore_t *mc,
 
 /**
  * Read memory from manycore DRAM via DMA
+ * 
+ * NOTE: This method is declared with __attribute__((weak)) so that a
+ * platform can define write OR read in its own bsg_manycore_dma.cpp
+ * implementation, but does not need to declare both.
+ *
  * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
  * @param[in]  npa    A valid hb_mc_npa_t - must be an L2 cache coordinate
  * @param[in]  data   A host buffer to be read into from manycore hardware
  * @param[in]  sz     The number of bytes to read from manycore hardware
  * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
  */
-int hb_mc_dma_read(hb_mc_manycore_t *mc, 
+int __attribute__((weak)) hb_mc_dma_read(hb_mc_manycore_t *mc, 
                    const hb_mc_npa_t *npa,
                    void *data, size_t sz)
 {
-        manycore_pr_err(mc, "%s: This function is not supported on this platform\n",
+        dma_pr_err(mc, "%s: This function is not supported on this platform\n",
                         __func__);
         return HB_MC_NOIMPL;
 }

--- a/libraries/features/dma/noimpl/feature.mk
+++ b/libraries/features/dma/noimpl/feature.mk
@@ -1,0 +1,47 @@
+# Copyright (c) 2019, University of Washington All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+# 
+# Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+# 
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+# 
+# Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# aws-fpga does not provide a DMA feature. Therefore, we compile
+# features/dma/noimpl/bsg_manycore_dma.cpp that simply returns
+# HB_MC_NO_IMPL for each function call.
+PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/features/features/dma/noimpl/bsg_manycore_dma.cpp
+
+DMA_FEATURE_OBJECTS += $(patsubst %cpp,%o,$(DMA_FEATURE_CXXSOURCES))
+DMA_FEATURE_OBJECTS += $(patsubst %c,%o,$(DMA_FEATURE_CSOURCES))
+
+$(DMA_FEATURE_OBJECTS): INCLUDES := -I$(LIBRARIES_PATH)
+$(DMA_FEATURE_OBJECTS): INCLUDES += -I$(LIBRARIES_PATH)/features/dma
+$(DMA_FEATURE_OBJECTS): CFLAGS   := -std=c11 -fPIC -D_GNU_SOURCE $(INCLUDES)
+$(DMA_FEATURE_OBJECTS): CXXFLAGS := -std=c++11 -fPIC -D_GNU_SOURCE $(INCLUDES)
+
+$(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so.1.0: $(DMA_FEATURE_OBJECTS)
+
+.PHONY: dma_feature.clean
+dma_feature.clean:
+	rm -f $(DMA_FEATURE_OBJECTS)
+
+platform.clean: dma_feature.clean

--- a/libraries/features/dma/noimpl/feature.mk
+++ b/libraries/features/dma/noimpl/feature.mk
@@ -28,7 +28,7 @@
 # aws-fpga does not provide a DMA feature. Therefore, we compile
 # features/dma/noimpl/bsg_manycore_dma.cpp that simply returns
 # HB_MC_NO_IMPL for each function call.
-PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/features/features/dma/noimpl/bsg_manycore_dma.cpp
+DMA_FEATURE_CXXSOURCES += $(LIBRARIES_PATH)/features/dma/noimpl/bsg_manycore_dma.cpp
 
 DMA_FEATURE_OBJECTS += $(patsubst %cpp,%o,$(DMA_FEATURE_CXXSOURCES))
 DMA_FEATURE_OBJECTS += $(patsubst %c,%o,$(DMA_FEATURE_CSOURCES))

--- a/libraries/features/dma/simulation/bsg_manycore_dma.cpp
+++ b/libraries/features/dma/simulation/bsg_manycore_dma.cpp
@@ -1,4 +1,4 @@
-#include <bsg_manycore_dma.h>
+#include <bsg_manycore.h>
 #include <bsg_mem_dma.hpp>
 #include <bsg_manycore_vcache.h>
 #include <bsg_manycore_printing.h>

--- a/libraries/features/dma/simulation/bsg_manycore_dma.cpp
+++ b/libraries/features/dma/simulation/bsg_manycore_dma.cpp
@@ -1,0 +1,147 @@
+#include <bsg_manycore_dma.h>
+#include <bsg_mem_dma.hpp>
+#include <bsg_manycore_vcache.h>
+#include <bsg_manycore_printing.h>
+/* these are convenience macros that are only good for one line prints */
+#define dma_pr_dbg(mc, fmt, ...)                   \
+        bsg_pr_dbg("%s: " fmt, mc->name, ##__VA_ARGS__)
+
+#define dma_pr_err(mc, fmt, ...)                   \
+        bsg_pr_err("%s: " fmt, mc->name, ##__VA_ARGS__)
+
+#define dma_pr_warn(mc, fmt, ...)                          \
+        bsg_pr_warn("%s: " fmt, mc->name, ##__VA_ARGS__)
+
+#define dma_pr_info(mc, fmt, ...)                          \
+        bsg_pr_info("%s: " fmt, mc->name, ##__VA_ARGS__)
+
+using namespace bsg_mem_dma;
+
+/**
+ * Given an NPA that maps to DRAM, return a buffer that holds the data for that address.
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in]  npa    A valid hb_mc_npa_t - must be an L2 cache coordinate
+ * @param[in]  sz     The number of bytes to write to manycore hardware - used for sanity check
+ * @param[out] buffer The valid buffer
+ * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
+ */
+static int hb_mc_dma_npa_to_buffer(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa, size_t sz,
+                                        unsigned char **buffer)
+{
+        /*
+          Our system supports having multiple caches per memory channel.
+          Currently, we do this by splitting the channels evenly into even 'banks' for each cache.
+
+          IF THE ADDRESS MAPPING SCHEME FROM CACHES TO DRAM CHANGES THIS FUNCTION WILL BREAK!!!!!
+
+          As of the time of this writing we are in the process of designing the memory system.
+          So take note...
+        */
+
+        /*
+          Get system parameters for performing the address mapping
+        */
+        const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
+        unsigned long caches = hb_mc_vcache_num_caches(mc);
+        unsigned long channels = hb_mc_config_get_dram_channels(cfg);
+        unsigned long caches_per_channel = caches/channels;
+
+        dma_pr_dbg(mc, "%s: caches = %lu, channels = %lu, caches_per_channel = %lu\n",
+                        __func__, caches, channels, caches_per_channel);
+
+        /*
+          Figure out which memory channel and bank this NPA maps to.
+        */
+        hb_mc_idx_t cache_id = hb_mc_config_get_dram_id(cfg, hb_mc_npa_get_xy(npa)); // which cache
+        parameter_t id = cache_id / caches_per_channel; // which channel
+        parameter_t bank = cache_id % caches_per_channel; // which bank within channel
+
+        /*
+          Use the backdoor to our non-synthesizable memory.
+        */
+        Memory *memory = bsg_mem_dma_get_memory(id);
+        parameter_t bank_size = memory->_data.size()/caches_per_channel;
+
+        hb_mc_epa_t epa = hb_mc_npa_get_epa(npa);
+        char npa_str[256];
+
+        if (memory == nullptr) {
+                dma_pr_err(mc, " %s: Could not get the memory for endpoint at %s\n",
+                                __func__, hb_mc_npa_to_string(npa, npa_str, sizeof(npa_str)));
+
+                return HB_MC_FAIL;
+        }
+
+        // this is the address that comes out of cache_to_test_dram_tx
+        address_t cache_addr = bank*bank_size + epa;
+        address_t addr = hb_mc_memsys_map_to_physical_channel_address(&cfg->memsys, cache_addr);
+
+
+        dma_pr_dbg(mc, "%s: Mapped %s to Channel %2lu, Address 0x%08lx\n",
+                        __func__, hb_mc_npa_to_string(npa, npa_str, sizeof(npa_str)), id, addr);
+
+        /*
+          Don't overflow memory if you can help it.
+        */
+        assert(addr + sz <= memory->_data.size());
+
+        *buffer = &memory->_data[addr];
+
+        return HB_MC_SUCCESS;
+}
+
+/**
+ * Write memory out to manycore DRAM via C++ backdoor
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in]  npa    A valid hb_mc_npa_t - must be an L2 cache coordinate
+ * @param[in]  data   A buffer to be written out manycore hardware
+ * @param[in]  sz     The number of bytes to write to manycore hardware
+ * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
+ */
+int hb_mc_dma_write(hb_mc_manycore_t *mc,
+                    const hb_mc_npa_t *npa,
+                    const void *data, size_t sz)
+{
+        unsigned char *membuffer;
+        int err = hb_mc_dma_npa_to_buffer(mc, npa, sz, &membuffer);
+        if (err != HB_MC_SUCCESS)
+                return err;
+
+        char npa_str[256];
+
+        dma_pr_dbg(mc, "%s: Writing %3zu bytes to %s\n",
+                        __func__, sz, hb_mc_npa_to_string(npa, npa_str, sizeof(npa_str)));
+
+        memcpy(reinterpret_cast<void*>(membuffer), data, sz);
+
+        return HB_MC_SUCCESS;
+}
+
+
+/**
+ * Read memory from manycore DRAM via C++ backdoor
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[in]  npa    A valid hb_mc_npa_t - must be an L2 cache coordinate
+ * @param[in]  data   A host buffer to be read into from manycore hardware
+ * @param[in]  sz     The number of bytes to read from manycore hardware
+ * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
+ */
+int hb_mc_dma_read(hb_mc_manycore_t *mc, 
+                   const hb_mc_npa_t *npa,
+                   void *data, size_t sz)
+{
+        unsigned char *membuffer;
+        int err = hb_mc_dma_npa_to_buffer(mc, npa, sz, &membuffer);
+        if (err != HB_MC_SUCCESS)
+                return err;
+
+        char npa_str[256];
+
+        dma_pr_dbg(mc, "%s: Reading %3zu bytes from %s\n",
+                        __func__, sz, hb_mc_npa_to_string(npa, npa_str, sizeof(npa_str)));
+
+        memcpy(data, reinterpret_cast<void*>(membuffer), sz);
+
+        return HB_MC_SUCCESS;
+}
+

--- a/libraries/features/dma/simulation/dramsim3.mk
+++ b/libraries/features/dma/simulation/dramsim3.mk
@@ -63,7 +63,7 @@ _BSG_F1_TESTBENCHES_DRAMSIM3_MK := 1
 ifneq ($(filter dramsim3, $(subst _, ,$(CL_MANYCORE_MEM_CFG))),)
 
 # Library for DMA-able memory
-include $(TESTBENCH_PATH)/libdmamem.mk
+include $(LIBRARIES_PATH)/features/dma/simulation/libdmamem.mk
 
 # Define USING_DRAMSIM3 for host library
 $(LIB_OBJECTS): CXXFLAGS += -DUSING_DRAMSIM3=1
@@ -71,36 +71,36 @@ $(LIB_OBJECTS): CXXFLAGS += -DUSING_DRAMSIM3=1
 # Add a clean rule
 .PHONY: dramsim3.clean
 
-$(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so.1.0: LDFLAGS += -L$(TESTBENCH_PATH) -Wl,-rpath=$(TESTBENCH_PATH) -ldramsim3
-$(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so.1.0: $(TESTBENCH_PATH)/libdramsim3.so
+$(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so.1.0: LDFLAGS += -L$(LIBRARIES_PATH)/features/dma/simulation -Wl,-rpath=$(LIBRARIES_PATH)/features/dma/simulation -ldramsim3
+$(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so.1.0: $(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so
 
 # Rules for building dramsim3 library
-$(TESTBENCH_PATH)/libdramsim3.so: CXXFLAGS += -std=c++11 -D_GNU_SOURCE -Wall -fPIC -shared
-$(TESTBENCH_PATH)/libdramsim3.so: CXXFLAGS += -I$(BASEJUMP_STL_DIR)/imports/DRAMSim3/src
-$(TESTBENCH_PATH)/libdramsim3.so: CXXFLAGS += -I$(BASEJUMP_STL_DIR)/imports/DRAMSim3/ext/headers
-$(TESTBENCH_PATH)/libdramsim3.so: CXXFLAGS += -I$(BASEJUMP_STL_DIR)/imports/DRAMSim3/ext/fmt/include
-$(TESTBENCH_PATH)/libdramsim3.so: CXXFLAGS += -DFMT_HEADER_ONLY=1
-$(TESTBENCH_PATH)/libdramsim3.so: CXXFLAGS += -DBASEJUMP_STL_DIR="$(BASEJUMP_STL_DIR)"
-$(TESTBENCH_PATH)/libdramsim3.so: CXX=g++
+$(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: CXXFLAGS += -std=c++11 -D_GNU_SOURCE -Wall -fPIC -shared
+$(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: CXXFLAGS += -I$(BASEJUMP_STL_DIR)/imports/DRAMSim3/src
+$(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: CXXFLAGS += -I$(BASEJUMP_STL_DIR)/imports/DRAMSim3/ext/headers
+$(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: CXXFLAGS += -I$(BASEJUMP_STL_DIR)/imports/DRAMSim3/ext/fmt/include
+$(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: CXXFLAGS += -DFMT_HEADER_ONLY=1
+$(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: CXXFLAGS += -DBASEJUMP_STL_DIR="$(BASEJUMP_STL_DIR)"
+$(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: CXX=g++
 
-$(TESTBENCH_PATH)/libdramsim3.so: $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/bankstate.cc
-$(TESTBENCH_PATH)/libdramsim3.so: $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/channel_state.cc
-$(TESTBENCH_PATH)/libdramsim3.so: $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/command_queue.cc
-$(TESTBENCH_PATH)/libdramsim3.so: $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/common.cc
-$(TESTBENCH_PATH)/libdramsim3.so: $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/configuration.cc
-$(TESTBENCH_PATH)/libdramsim3.so: $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/controller.cc
-$(TESTBENCH_PATH)/libdramsim3.so: $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/dram_system.cc
-$(TESTBENCH_PATH)/libdramsim3.so: $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/hmc.cc
-$(TESTBENCH_PATH)/libdramsim3.so: $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/memory_system.cc
-$(TESTBENCH_PATH)/libdramsim3.so: $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/refresh.cc
-$(TESTBENCH_PATH)/libdramsim3.so: $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/simple_stats.cc
-$(TESTBENCH_PATH)/libdramsim3.so: $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/timing.cc
-$(TESTBENCH_PATH)/libdramsim3.so: $(BASEJUMP_STL_DIR)/bsg_test/bsg_dramsim3.cpp
+$(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/bankstate.cc
+$(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/channel_state.cc
+$(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/command_queue.cc
+$(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/common.cc
+$(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/configuration.cc
+$(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/controller.cc
+$(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/dram_system.cc
+$(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/hmc.cc
+$(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/memory_system.cc
+$(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/refresh.cc
+$(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/simple_stats.cc
+$(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: $(BASEJUMP_STL_DIR)/imports/DRAMSim3/src/timing.cc
+$(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: $(BASEJUMP_STL_DIR)/bsg_test/bsg_dramsim3.cpp
 	$(CXX) $(CXXFLAGS) $(INCLUDES) $^ -Wl,-soname,$(notdir $@) -o $@
 
 endif # ifneq ($(filter dramsim3, $(subst _, ,$(CL_MANYCORE_MEM_CFG))),)
 dramsim3.clean:
-	rm -f $(TESTBENCH_PATH)/libdramsim3.so
+	rm -f $(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so
 
 # Add as a subrule to simlibs.clean
 libraries.clean: dramsim3.clean

--- a/libraries/features/dma/simulation/feature.mk
+++ b/libraries/features/dma/simulation/feature.mk
@@ -27,13 +27,13 @@
 
 # C/C++ memory system libraries. These will add dependencies to
 # $(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so.1.0.
-include $(TESTBENCH_PATH)/dramsim3.mk
-include $(TESTBENCH_PATH)/infmem.mk
-include $(TESTBENCH_PATH)/libdmamem.mk
+include $(LIBRARIES_PATH)/features/dma/simulation/dramsim3.mk
+include $(LIBRARIES_PATH)/features/dma/simulation/infmem.mk
+include $(LIBRARIES_PATH)/features/dma/simulation/libdmamem.mk
 
 # Simulation uses "Magic" DMA to reduce runtime so we compile
 # features/dma/simulation/bsg_manycore_dma.cpp.
-DMA_FEATURE_CXXSOURCES := $(BSG_F1_DIR)/libraries/features/dma/simulation/bsg_manycore_dma.cpp
+DMA_FEATURE_CXXSOURCES := $(LIBRARIES_PATH)/features/dma/simulation/bsg_manycore_dma.cpp
 
 DMA_FEATURE_OBJECTS += $(patsubst %cpp,%o,$(DMA_FEATURE_CXXSOURCES))
 DMA_FEATURE_OBJECTS += $(patsubst %c,%o,$(DMA_FEATURE_CSOURCES))

--- a/libraries/features/dma/simulation/feature.mk
+++ b/libraries/features/dma/simulation/feature.mk
@@ -1,0 +1,54 @@
+# Copyright (c) 2019, University of Washington All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+# 
+# Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+# 
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+# 
+# Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# C/C++ memory system libraries. These will add dependencies to
+# $(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so.1.0.
+include $(TESTBENCH_PATH)/dramsim3.mk
+include $(TESTBENCH_PATH)/infmem.mk
+include $(TESTBENCH_PATH)/libdmamem.mk
+
+# Simulation uses "Magic" DMA to reduce runtime so we compile
+# features/dma/simulation/bsg_manycore_dma.cpp.
+DMA_FEATURE_CXXSOURCES := $(BSG_F1_DIR)/libraries/features/dma/simulation/bsg_manycore_dma.cpp
+
+DMA_FEATURE_OBJECTS += $(patsubst %cpp,%o,$(DMA_FEATURE_CXXSOURCES))
+DMA_FEATURE_OBJECTS += $(patsubst %c,%o,$(DMA_FEATURE_CSOURCES))
+
+$(DMA_FEATURE_OBJECTS): INCLUDES := -I$(LIBRARIES_PATH)
+$(DMA_FEATURE_OBJECTS): INCLUDES += -I$(BASEJUMP_STL_DIR)/bsg_mem
+$(DMA_FEATURE_OBJECTS): INCLUDES += -I$(LIBRARIES_PATH)/features/dma
+$(DMA_FEATURE_OBJECTS): CFLAGS   := -std=c11 -fPIC -D_GNU_SOURCE $(INCLUDES)
+$(DMA_FEATURE_OBJECTS): CXXFLAGS := -std=c++11 -fPIC -D_GNU_SOURCE $(INCLUDES)
+
+$(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so.1.0: $(DMA_FEATURE_OBJECTS)
+
+
+.PHONY: dma_feature.clean
+dma_feature.clean:
+	rm -f $(DMA_FEATURE_OBJECTS)
+
+platform.clean: dma_feature.clean

--- a/libraries/features/dma/simulation/infmem.mk
+++ b/libraries/features/dma/simulation/infmem.mk
@@ -25,8 +25,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# This Makefile fragment is for building the simulation "DMA Engine"
-# library for cosimulation
+# This Makefile fragment is for building the infinite memory
+# simulation library for cosimulation
 ORANGE=\033[0;33m
 RED=\033[0;31m
 NC=\033[0m
@@ -35,36 +35,21 @@ NC=\033[0m
 # set by the Makefile that includes this makefile..
 #
 
-# TESTBENCH_PATH: The path to the testbenches folder in BSG F1
-ifndef TESTBENCH_PATH
-$(error $(shell echo -e "$(RED)BSG MAKE ERROR: TESTBENCH_PATH is not defined$(NC)"))
-endif
-
-ifndef BASEJUMP_STL_DIR
-$(error $(shell echo -e "$(RED)BSG MAKE ERROR: BASEJUMP_STL_DIR is not defined$(NC)"))
+# LIBRARIES_PATH: The path to the libraries folder in BSG F1
+ifndef LIBRARIES_PATH
+$(error $(shell echo -e "$(RED)BSG MAKE ERROR: LIBRARIES_PATH is not defined$(NC)"))
 endif
 
 # Don't include more than once
-ifndef (_BSG_F1_TESTBENCHES_LIB_DMA_MEM_MK)
-_BSG_F1_TESTBENCHES_LIB_DMA_MEM_MK := 1
+ifndef (_BSG_F1_TESTBENCHES_INFINITE_MEM_MK)
+_BSG_F1_TESTBENCHES_INFINITE_MEM_MK := 1
+_INFINITE_MEM_CFGS := e_infinite_mem
 
-$(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so.1.0: LDFLAGS += -L$(TESTBENCH_PATH) -Wl,-rpath=$(TESTBENCH_PATH) -ldmamem
-$(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so.1.0: $(TESTBENCH_PATH)/libdmamem.so
+# Check if Infinite Memory is the memory model for this design
+ifneq ($(filter $(_INFINITE_MEM_CFGS), $(CL_MANYCORE_MEM_CFG)),)
 
-# Add a clean rule
-.PHONY: dmamem.clean
-dmamem.clean:
-	rm -f $(TESTBENCH_PATH)/libdmamem.so
+# Library for DMA-able memory
+include $(LIBRARIES_PATH)/features/dma/simulation/libdmamem.mk
 
-# Add as a subrule to simlibs.clean
-libraries.clean: dmamem.clean
-
-# Rules for building Simulation "DMA library"
-$(TESTBENCH_PATH)/libdmamem.so: CXXFLAGS += -std=c++11 -D_GNU_SOURCE -Wall -fPIC -shared
-$(TESTBENCH_PATH)/libdmamem.so: CXXFLAGS += -I$(BASEJUMP_STL_DIR)/bsg_mem
-$(TESTBENCH_PATH)/libdmamem.so: CXXFLAGS += -DBASEJUMP_STL_DIR="$(BASEJUMP_STL_DIR)"
-$(TESTBENCH_PATH)/libdmamem.so: CXX=g++
-$(TESTBENCH_PATH)/libdmamem.so: $(BASEJUMP_STL_DIR)/bsg_mem/bsg_mem_dma.cpp
-	$(CXX) $(CXXFLAGS) $(INCLUDES) $^ -Wl,-soname,$(notdir $@) -o $@
-
-endif # ifndef(_BSG_F1_TESTBENCHES_LIB_DMA_MEM_MK)
+endif # ifneq ($(filter $(_INFINITE_MEM_CFGS), $(CL_MANYCORE_MEM_CFG)),)
+endif # ifndef(_BSG_F1_TESTBENCHES_INFINITE_MEM_MK)

--- a/libraries/features/dma/simulation/libdmamem.mk
+++ b/libraries/features/dma/simulation/libdmamem.mk
@@ -25,8 +25,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# This Makefile fragment is for building the infinite memory
-# simulation library for cosimulation
+# This Makefile fragment is for building the simulation "DMA Engine"
+# library for cosimulation
 ORANGE=\033[0;33m
 RED=\033[0;31m
 NC=\033[0m
@@ -35,21 +35,36 @@ NC=\033[0m
 # set by the Makefile that includes this makefile..
 #
 
-# TESTBENCH_PATH: The path to the testbenches folder in BSG F1
-ifndef TESTBENCH_PATH
-$(error $(shell echo -e "$(RED)BSG MAKE ERROR: TESTBENCH_PATH is not defined$(NC)"))
+# LIBRARIES_PATH: The path to the libraries folder in F1
+ifndef LIBRARIES_PATH
+$(error $(shell echo -e "$(RED)BSG MAKE ERROR: LIBRARIES_PATH is not defined$(NC)"))
+endif
+
+ifndef BASEJUMP_STL_DIR
+$(error $(shell echo -e "$(RED)BSG MAKE ERROR: BASEJUMP_STL_DIR is not defined$(NC)"))
 endif
 
 # Don't include more than once
-ifndef (_BSG_F1_TESTBENCHES_INFINITE_MEM_MK)
-_BSG_F1_TESTBENCHES_INFINITE_MEM_MK := 1
-_INFINITE_MEM_CFGS := e_infinite_mem
+ifndef (_BSG_F1_TESTBENCHES_LIB_DMA_MEM_MK)
+_BSG_F1_TESTBENCHES_LIB_DMA_MEM_MK := 1
 
-# Check if Infinite Memory is the memory model for this design
-ifneq ($(filter $(_INFINITE_MEM_CFGS), $(CL_MANYCORE_MEM_CFG)),)
+$(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so.1.0: LDFLAGS += -L$(LIBRARIES_PATH)/features/dma/simulation -Wl,-rpath=$(LIBRARIES_PATH)/features/dma/simulation -ldmamem
+$(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so.1.0: $(LIBRARIES_PATH)/features/dma/simulation/libdmamem.so
 
-# Library for DMA-able memory
-include $(TESTBENCH_PATH)/libdmamem.mk
+# Add a clean rule
+.PHONY: dmamem.clean
+dmamem.clean:
+	rm -f $(LIBRARIES_PATH)/features/dma/simulation/libdmamem.so
 
-endif # ifneq ($(filter $(_INFINITE_MEM_CFGS), $(CL_MANYCORE_MEM_CFG)),)
-endif # ifndef(_BSG_F1_TESTBENCHES_INFINITE_MEM_MK)
+# Add as a subrule to simlibs.clean
+libraries.clean: dmamem.clean
+
+# Rules for building Simulation "DMA library"
+$(LIBRARIES_PATH)/features/dma/simulation/libdmamem.so: CXXFLAGS += -std=c++11 -D_GNU_SOURCE -Wall -fPIC -shared
+$(LIBRARIES_PATH)/features/dma/simulation/libdmamem.so: CXXFLAGS += -I$(BASEJUMP_STL_DIR)/bsg_mem
+$(LIBRARIES_PATH)/features/dma/simulation/libdmamem.so: CXXFLAGS += -DBASEJUMP_STL_DIR="$(BASEJUMP_STL_DIR)"
+$(LIBRARIES_PATH)/features/dma/simulation/libdmamem.so: CXX=g++
+$(LIBRARIES_PATH)/features/dma/simulation/libdmamem.so: $(BASEJUMP_STL_DIR)/bsg_mem/bsg_mem_dma.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDES) $^ -Wl,-soname,$(notdir $@) -o $@
+
+endif # ifndef(_BSG_F1_TESTBENCHES_LIB_DMA_MEM_MK)

--- a/libraries/libraries.mk
+++ b/libraries/libraries.mk
@@ -95,12 +95,12 @@ $(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so.1.0: INCLUDES :=
 include $(BSG_PLATFORM_PATH)/library.mk
 
 
-$(LIB_OBJECTS): INCLUDES  := -I$(LIBRARIES_PATH)
-$(LIB_OBJECTS): INCLUDES  += -I$(BASEJUMP_STL_DIR)/bsg_mem
+$(LIB_OBJECTS): INCLUDES := -I$(LIBRARIES_PATH)
+$(LIB_OBJECTS): INCLUDES += -I$(LIBRARIES_PATH)/features/dma
 # We should move this from AWS (and keep the license)
-$(LIB_OBJECTS): INCLUDES  += -I$(AWS_FPGA_REPO_DIR)/SDAccel/userspace/include
-$(LIB_OBJECTS) $(PLATFORM_OBJECTS): CFLAGS    += -std=c11 -fPIC -D_GNU_SOURCE $(INCLUDES)
-$(LIB_OBJECTS) $(PLATFORM_OBJECTS): CXXFLAGS  += -std=c++11 -fPIC -D_GNU_SOURCE $(INCLUDES)
+$(LIB_OBJECTS): INCLUDES += -I$(AWS_FPGA_REPO_DIR)/SDAccel/userspace/include
+$(LIB_OBJECTS): CFLAGS    += -std=c11 -fPIC -D_GNU_SOURCE $(INCLUDES)
+$(LIB_OBJECTS): CXXFLAGS  += -std=c++11 -fPIC -D_GNU_SOURCE $(INCLUDES)
 # Need to move this, eventually
 #$(LIB_OBJECTS) $(PLATFORM_OBJECTS): $(BSG_MACHINE_PATH)/bsg_manycore_machine.h
 
@@ -112,7 +112,7 @@ $(LIB_STRICT_OBJECTS): CXXFLAGS += -Wno-unused-function
 $(LIB_STRICT_OBJECTS): CXXFLAGS += -Wno-unused-but-set-variable
 
 $(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so.1.0: LD = $(CXX)
-$(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so.1.0: $(LIB_OBJECTS) $(PLATFORM_OBJECTS)
+$(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so.1.0: $(LIB_OBJECTS)
 	$(LD) -shared -Wl,-soname,$(basename $(notdir $@)) -o $@ $^ $(LDFLAGS)
 
 .PHONY: libraries.clean

--- a/libraries/platforms/aws-fpga/library.mk
+++ b/libraries/platforms/aws-fpga/library.mk
@@ -35,7 +35,7 @@ PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/platforms/aws-fpga/bsg_manycore_platfor
 # aws-fpga does not provide a DMA feature. Therefore, we use the fragment in 
 # features/dma/noimpl/feature.mk that simply returns
 # HB_MC_NO_IMPL for each function call.
-include $(LIBRARIES_PATH)/features/dma/simulation/feature.mk
+include $(LIBRARIES_PATH)/features/dma/noimpl/feature.mk
 
 PLATFORM_OBJECTS += $(patsubst %cpp,%o,$(PLATFORM_CXXSOURCES))
 PLATFORM_OBJECTS += $(patsubst %c,%o,$(PLATFORM_CSOURCES))

--- a/libraries/platforms/aws-fpga/library.mk
+++ b/libraries/platforms/aws-fpga/library.mk
@@ -25,19 +25,33 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-PLATFORM_CXXSOURCES += $(BSG_F1_DIR)/libraries/platforms/aws-fpga/bsg_manycore_mmio.cpp
-PLATFORM_CXXSOURCES += $(BSG_F1_DIR)/libraries/platforms/aws-fpga/bsg_manycore_platform.cpp
+# aws-fpga and aws-vcs are identical, EXCEPT for the MMIO layer. The
+# reuse the bsg_manycore_platform.cpp file between the two platforms
+# aws-fpga, but provide our own bsg_manycore_mmio.cpp file that
+# handles PCIE-based MMIO.
+PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/platforms/aws-fpga/bsg_manycore_mmio.cpp
+PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/platforms/aws-fpga/bsg_manycore_platform.cpp
+
+# aws-fpga does not provide a DMA feature. Therefore, we use the fragment in 
+# features/dma/noimpl/feature.mk that simply returns
+# HB_MC_NO_IMPL for each function call.
+include $(LIBRARIES_PATH)/features/dma/simulation/feature.mk
 
 PLATFORM_OBJECTS += $(patsubst %cpp,%o,$(PLATFORM_CXXSOURCES))
 PLATFORM_OBJECTS += $(patsubst %c,%o,$(PLATFORM_CSOURCES))
 
 # -DCOSIM is still necessary, for now
 $(PLATFORM_OBJECTS): INCLUDES := -I$(LIBRARIES_PATH)
-$(PLATFORM_OBJECTS): INCLUDES += -I$(BSG_F1_DIR)/libraries/platforms/aws-fpga
+$(PLATFORM_OBJECTS): INCLUDES += -I$(LIBRARIES_PATH)/platforms/aws-fpga
+$(PLATFORM_OBJECTS): INCLUDES += -I$(LIBRARIES_PATH)/features/dma
 # not sure if these are still necessary for AWS, if fpga_mgmt is installed
 $(PLATFORM_OBJECTS): INCLUDES += -I$(SDK_DIR)/userspace/include
-#$(PLATFORM_OBJECTS): INCLUDES += -I$(HDK_DIR)/common/software/include
+$(PLATFORM_OBJECTS): CFLAGS   := -std=c11 -fPIC -D_GNU_SOURCE $(INCLUDES)
+$(PLATFORM_OBJECTS): CXXFLAGS := -std=c++11 -fPIC -D_GNU_SOURCE $(INCLUDES)
 
+$(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so.1.0: $(PLATFORM_OBJECTS)
+
+# libfpga_mgmt is the platform library provided by AWS.
 $(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so.1.0: LDFLAGS += -lfpga_mgmt
 
 _DOCSTRING := "Rules from aws-fpga/library.mk\n"

--- a/libraries/platforms/aws-vcs/hardware.mk
+++ b/libraries/platforms/aws-vcs/hardware.mk
@@ -209,7 +209,13 @@ $(BSG_PLATFORM_PATH)/vcs_simlibs/$(BSG_MACHINE_NAME)/AN.DB: $(BSG_MACHINE_PATH)/
 platform.hardware.clean: 
 	rm -rf $(BSG_PLATFORM_PATH)/vcs_simlibs/BSG_*
 	rm -rf $(BSG_PLATFORM_PATH)/.cxl*
-	rm -rf $(BSG_PLATFORM_PATH)/vivado.jou
+	rm -rf $(BSG_PLATFORM_PATH)/*.jou
+	rm -rf $(BSG_PLATFORM_PATH)/*.log 
+	rm -rf $(BSG_PLATFORM_PATH)/*.log.bak
+
+platform.hardware.bleach:
+	rm -rf $(BSG_PLATFORM_PATH)/synopsys_sim.setup
+	rm -rf $(BSG_PLATFORM_PATH)/vcs_simlibs
 
 hardware.clean: platform.hardware.clean
 hardware.bleach: platform.hardware.bleach


### PR DESCRIPTION
Platforms can support different features. For example, we support DMA in simulation, but not on the FPGA (though we could). This change will also encapsulate MMIO, where in simulation we use the DPI interface, and on the FPGA we use PCIe (another PR). I'm sure there are other features we'll add in the future. 

In this PR I split the cosim-specific DMA into a new file and defined an API. F1 uses the "noimpl" driver, but all the functions do is return HB_MC_NOIMPL.

This PR also moves the makefiles fragments `infmem.mk` `libdmamem.mk` and `libdramsim3.mk` into the `features/dma/simulation` directory. 

This removes the last COSIM macro checks in bsg_manycore.cpp. There are a couple more in bsg_manycore_printing (probably my next PR).

This is currently based on top of #590. It passes regression on cosimulation with timing_v0_8_4, 4x4_fast_n_fake, and 4x4_blocking_vcache_f1_model, and on F1. 