### PR TITLE
Added host_request_fence to the end of hb_mc_device_finish 

### DIFF
--- a/libraries/bsg_manycore_cuda.cpp
+++ b/libraries/bsg_manycore_cuda.cpp
@@ -1568,7 +1568,14 @@ int hb_mc_device_finish (hb_mc_device_t *device) {
                 bsg_pr_err("%s: failed to freeze device tiles.\n", __func__); 
                 return error;
         }
-        
+
+
+        error = hb_mc_manycore_host_request_fence(device->mc, -1);
+        if (error != HB_MC_SUCCESS) {
+                bsg_pr_err("%s: failed to fence on host requests.\n", __func__);
+                return error;
+        }
+       
 
         error = hb_mc_device_manycore_exit (device->mc); 
         if (error != HB_MC_SUCCESS) { 


### PR DESCRIPTION
to make sure tiles are frozen before terminating.

Cosimulation in progress.