### PR TITLE
Minor bug fix in vanilla core profiler parameter

### DIFF
--- a/libraries/platforms/aws-fpga/hardware/cl_manycore.sv
+++ b/libraries/platforms/aws-fpga/hardware/cl_manycore.sv
@@ -1300,7 +1300,7 @@ module cl_manycore
        ,.icache_tag_width_p(icache_tag_width_p)
        ,.icache_entries_p(icache_entries_p)
        ,.data_width_p(data_width_p)
-       ,.dmem_size_p(data_width_p)
+       ,.dmem_size_p(dmem_size_p)
        )
    vcore_prof
      (


### PR DESCRIPTION
Cosim regression passes with 4x4_fast_n_fake, 4x4_blocking_vcache_f1_model and timing_v0_8_4.
Related to Issue #589 .