### PR TITLE
Added cycle counter interface in HDL and in Software

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -70,7 +70,7 @@ help:
 	@echo "             a specific sub-directory (Options are: $(TARGETS))"
 	@echo "      clean: Remove all build files"
 
-clean: hardware.clean
+clean: hardware.clean libraries.clean
 	$(foreach t,$(TARGETS), $(MAKE) -C $t clean;)
 	rm -rf regression.log runtime.log
 

--- a/examples/library/Makefile
+++ b/examples/library/Makefile
@@ -55,6 +55,7 @@ REGRESSION_TESTS_TYPE = library
 UNIFIED_TESTS = 
 
 INDEPENDENT_TESTS += test_rom
+INDEPENDENT_TESTS += test_get_cycle
 INDEPENDENT_TESTS += test_struct_size
 INDEPENDENT_TESTS += test_vcache_flush
 INDEPENDENT_TESTS += test_vcache_simplified

--- a/examples/library/test_get_cycle.cpp
+++ b/examples/library/test_get_cycle.cpp
@@ -81,7 +81,7 @@ int test_get_cycle (int argc, char **argv) {
                         goto cleanup;
                 }
 
-                if(last >= cycle){
+                if(last > cycle){
                         bsg_pr_test_err("Cycle counter not increasing!\n");
                         fail = HB_MC_FAIL;
                         goto cleanup;

--- a/examples/library/test_get_cycle.cpp
+++ b/examples/library/test_get_cycle.cpp
@@ -62,6 +62,15 @@ int test_get_cycle (int argc, char **argv) {
         uint32_t dram_coord_y = hb_mc_config_get_dram_y(config);
         hb_mc_npa_t npa = { .x = dram_coord_x, .y = dram_coord_y, .epa = 0};
 
+        bsg_pr_test_info("Testing invalid input (This will print an ERROR message)\n");
+        rc = hb_mc_manycore_get_cycle(&mc, nullptr);
+        if(rc != HB_MC_INVALID){
+                bsg_pr_test_err("hb_mc_manycore_get_cycle() failed to fail on invalid input");
+                fail = HB_MC_FAIL;
+                goto cleanup;
+        }
+                
+
         last = 0;
         for(int i = 0 ; i < 10; ++i){
                 rc = hb_mc_manycore_get_cycle(&mc, &cycle);

--- a/examples/library/test_get_cycle.cpp
+++ b/examples/library/test_get_cycle.cpp
@@ -1,0 +1,110 @@
+// Copyright (c) 2019, University of Washington All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// 
+// Redistributions of source code must retain the above copyright notice, this list
+// of conditions and the following disclaimer.
+// 
+// Redistributions in binary form must reproduce the above copyright notice, this
+// list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+// 
+// Neither the name of the copyright holder nor the names of its contributors may
+// be used to endorse or promote products derived from this software without
+// specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// This test repeatedly reads the manycore cycle counter and makes
+// sure that time increases.
+
+#include "test_get_cycle.hpp"
+#include <cstdint>
+
+int test_get_cycle (int argc, char **argv) {
+        int rc = 0, fail = 0;
+        uint64_t cycle, last;
+        uint32_t data = 0;
+        hb_mc_manycore_t mc = {0};
+        const hb_mc_config_t *config;
+        struct arguments_none args = {};
+
+        rc = argp_parse (&argp_none, argc, argv, 0, 0, &args);
+
+        if(rc != HB_MC_SUCCESS){
+                return rc;
+        }
+
+        rc = hb_mc_manycore_init(&mc, "manycore@test_get_cycle", 0);
+        if(rc != HB_MC_SUCCESS){
+                bsg_pr_test_err("Failed to initialize manycore device: %s\n",
+                                hb_mc_strerror(rc));
+                return HB_MC_FAIL;
+        }
+
+        config = hb_mc_manycore_get_config(&mc);
+
+        // To cause time to proceed, we write to DRAM.
+        uint32_t manycore_dim_x = hb_mc_coordinate_get_x(hb_mc_config_get_dimension_vcore(config));
+        uint32_t manycore_dim_y = hb_mc_coordinate_get_y(hb_mc_config_get_dimension_vcore(config));
+
+        uint32_t dram_coord_x = 0;
+        uint32_t dram_coord_y = hb_mc_config_get_dram_y(config);
+        hb_mc_npa_t npa = { .x = dram_coord_x, .y = dram_coord_y, .epa = 0};
+
+        last = 0;
+        for(int i = 0 ; i < 10; ++i){
+                rc = hb_mc_manycore_get_cycle(&mc, &cycle);
+                if(rc != HB_MC_SUCCESS){
+                        bsg_pr_test_err("Failed to read cycle counter: %s\n",
+                                        hb_mc_strerror(rc));
+                        fail = rc;
+                        goto cleanup;
+                }
+
+                if(last >= cycle){
+                        bsg_pr_test_err("Cycle counter not increasing!\n");
+                        fail = HB_MC_FAIL;
+                        goto cleanup;
+                }
+
+                last = cycle;
+
+                bsg_pr_test_info("Current cycle is: %llu\n", cycle);
+                rc = hb_mc_manycore_write_mem(&mc, &npa, &data, sizeof(data));
+                if(rc != HB_MC_SUCCESS){
+                        bsg_pr_test_err("Failed to write DRAM: %s\n",
+                                        hb_mc_strerror(rc));
+                        fail = rc;
+                        goto cleanup;
+                }
+
+        }
+
+cleanup:
+        rc = hb_mc_manycore_exit(&mc);
+
+        return fail ? HB_MC_FAIL : HB_MC_SUCCESS;
+}
+
+#ifdef VCS
+int vcs_main(int argc, char ** argv) {
+#else
+int main(int argc, char ** argv) {
+#endif
+
+        bsg_pr_test_info("test_get_cycle Regression Test \n");
+        int rc = test_get_cycle(argc, argv);
+        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
+        return rc;
+}

--- a/examples/library/test_get_cycle.hpp
+++ b/examples/library/test_get_cycle.hpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2020, University of Washington All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// 
+// Redistributions of source code must retain the above copyright notice, this list
+// of conditions and the following disclaimer.
+// 
+// Redistributions in binary form must reproduce the above copyright notice, this
+// list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+// 
+// Neither the name of the copyright holder nor the names of its contributors may
+// be used to endorse or promote products derived from this software without
+// specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef TEST_GET_CYCLE_H
+#define TEST_GET_CYCLE_H
+#include <bsg_manycore.h>
+#include <inttypes.h>
+#include "../cl_manycore_regression.h"
+
+#endif

--- a/libraries/bsg_manycore.cpp
+++ b/libraries/bsg_manycore.cpp
@@ -200,6 +200,18 @@ int hb_mc_manycore_exit(hb_mc_manycore_t *mc)
         return HB_MC_SUCCESS;
 }
 
+/**
+ * Get the current cycle counter value of the Manycore Platform
+ *
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[out] time   The current counter value.
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_manycore_get_cycle(hb_mc_manycore_t *mc, uint64_t *time)
+{
+        return hb_mc_platform_get_cycle(mc, time);
+}
+
 ////////////////
 // Packet API //
 ////////////////
@@ -1260,6 +1272,10 @@ int hb_mc_manycore_disable_dram(hb_mc_manycore_t *mc)
         mc->dram_enabled = 0;
         return HB_MC_SUCCESS;
 }
+
+//------------------------------------------------------------
+// DMA API (in features/dma)
+//------------------------------------------------------------
 
 /**
  * Check if NPA is in DRAM.

--- a/libraries/bsg_manycore.cpp
+++ b/libraries/bsg_manycore.cpp
@@ -209,6 +209,12 @@ int hb_mc_manycore_exit(hb_mc_manycore_t *mc)
  */
 int hb_mc_manycore_get_cycle(hb_mc_manycore_t *mc, uint64_t *time)
 {
+        if(time == nullptr){
+                bsg_pr_err("%s: Nullptr provided as argument time\n",
+                           __func__);
+                return HB_MC_INVALID;
+        }
+                
         return hb_mc_platform_get_cycle(mc, time);
 }
 

--- a/libraries/bsg_manycore.h
+++ b/libraries/bsg_manycore.h
@@ -503,6 +503,15 @@ extern "C" {
          * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
          */
         int hb_mc_manycore_host_request_fence(hb_mc_manycore_t *mc, long timeout);
+
+        /**
+         * Get the current cycle counter value of the Manycore Platform
+         *
+         * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+         * @param[out] time   The current counter value.
+         * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+         */
+        int hb_mc_manycore_get_cycle(hb_mc_manycore_t *mc, uint64_t *time);
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/bsg_manycore_platform.h
+++ b/libraries/bsg_manycore_platform.h
@@ -106,6 +106,15 @@ extern "C" {
          * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
          */
         int hb_mc_platform_finish_bulk_transfer(hb_mc_manycore_t *mc);
+
+        /**
+         * Get the current cycle counter of the Manycore Platform
+         *
+         * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+         * @param[out] time   The current counter value.
+         * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+         */
+        int hb_mc_platform_get_cycle(hb_mc_manycore_t *mc, uint64_t *time);
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/platforms/aws-fpga/bsg_manycore_mmio.h
+++ b/libraries/platforms/aws-fpga/bsg_manycore_mmio.h
@@ -50,6 +50,11 @@
 // For host receiving request from manycore 0x1C
 #define HB_MC_MMIO_FIFO_RX_DATA_OFFSET 0x0C
 
+// Low 32 bits of the manycore cycle counter
+#define HB_MC_MMIO_CYCLE_CTR_LO_OFFSET 0x1FF0
+// High 32 bits of the manycore cycle counter
+#define HB_MC_MMIO_CYCLE_CTR_HI_OFFSET 0x1FF4
+
 // Out credits of the endpoint standard in mcl
 #define HB_MC_MMIO_OUT_CREDITS_HOST_OFFSET 0x2000
 

--- a/libraries/platforms/aws-fpga/bsg_manycore_platform.cpp
+++ b/libraries/platforms/aws-fpga/bsg_manycore_platform.cpp
@@ -372,7 +372,9 @@ static std::set<hb_mc_manycore_id_t> active_ids;
 void hb_mc_platform_cleanup(hb_mc_manycore_t *mc)
 {
         hb_mc_platform_t *pl = reinterpret_cast<hb_mc_platform_t *>(mc->platform); 
-
+        uint64_t time;
+        hb_mc_platform_get_cycle(mc, &time);
+        printf("current time is: %d\n", time);
         hb_mc_platform_fifos_cleanup(mc, pl);
 
         hb_mc_mmio_cleanup(&pl->mmio, &pl->handle);
@@ -488,3 +490,40 @@ int hb_mc_platform_fence(hb_mc_manycore_t *mc,
         return HB_MC_SUCCESS;
 }
 
+
+/**
+ * Get the current cycle counter of the Manycore Platform
+ *
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @param[out] time   The current counter value.
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_platform_get_cycle(hb_mc_manycore_t *mc, 
+                             uint64_t *time)
+{
+        const hb_mc_platform_t *pl = reinterpret_cast<hb_mc_platform_t *>(mc->platform); 
+
+        int err;
+        uint64_t retval;
+        uint32_t rdval;
+
+        err = hb_mc_mmio_read32(pl->mmio, HB_MC_MMIO_CYCLE_CTR_HI_OFFSET, &rdval);
+        if (err != HB_MC_SUCCESS) {
+                platform_pr_err(pl, "%s: Failed to read high bits of cycle counter: %s\n",
+                                __func__, hb_mc_strerror(err));
+                return err;
+        }
+        retval = rdval;
+        retval = 32;
+
+        err = hb_mc_mmio_read32(pl->mmio, HB_MC_MMIO_CYCLE_CTR_LO_OFFSET, &rdval);
+        if (err != HB_MC_SUCCESS) {
+                platform_pr_err(pl, "%s: Failed to read LOW bits of cycle counter: %s\n",
+                                __func__, hb_mc_strerror(err));
+                return err;
+        }
+        retval |= rdval;
+        
+        *time = retval;
+        return HB_MC_SUCCESS;
+}

--- a/libraries/platforms/aws-fpga/bsg_manycore_platform.cpp
+++ b/libraries/platforms/aws-fpga/bsg_manycore_platform.cpp
@@ -504,6 +504,12 @@ int hb_mc_platform_get_cycle(hb_mc_manycore_t *mc, uint64_t *time)
         uint64_t retval;
         uint32_t lo, hi;
 
+        if(time == nullptr){
+                platform_pr_err("%s: Nullptr provided as argument time\n",
+                                __func__);
+                return HB_MC_INVALID;
+        }
+
         err = hb_mc_mmio_read32(pl->mmio, HB_MC_MMIO_CYCLE_CTR_LO_OFFSET, &lo);
         if (err != HB_MC_SUCCESS) {
                 platform_pr_err(pl, "%s: Failed to read LOW bits of cycle counter: %s\n",

--- a/libraries/platforms/aws-fpga/hardware/bsg_manycore_link_to_axil_pkg.v
+++ b/libraries/platforms/aws-fpga/hardware/bsg_manycore_link_to_axil_pkg.v
@@ -68,6 +68,8 @@ package bsg_manycore_link_to_axil_pkg;
   parameter mcl_ofs_rdr_req_gp  = 8'h1C;
   parameter mcl_ofs_rdfo_req_gp = 8'h18;
 
+  parameter mcl_ofs_counter_low_gp   = 32'h1FF0;
+  parameter mcl_ofs_counter_high_gp  = 32'h1FF4;
   parameter mcl_ofs_credits_gp  = 32'h2000;
 
   localparam integer mcl_addr_width_gp   = `BSG_CDIV(addr_width_p,8)*8  ;

--- a/libraries/platforms/aws-fpga/hardware/cl_manycore.sv
+++ b/libraries/platforms/aws-fpga/hardware/cl_manycore.sv
@@ -1142,6 +1142,17 @@ module cl_manycore
    assign m_axi4_manycore_arready = sh_cl_ddr_arready;
 `endif
 
+   localparam core_cycle_ctr_width_lp = 64;
+   logic [core_cycle_ctr_width_lp-1:0] core_cycle_ctr_l;
+   
+   bsg_cycle_counter
+     #(.width_p(core_cycle_ctr_width_lp))
+   core_cc
+     (.clk_i(core_clk)
+      ,.reset_i(core_reset)
+      ,.ctr_r_o(core_cycle_ctr_l)
+      );
+
    // manycore link
 
    logic [x_cord_width_p-1:0] mcl_x_cord_li = (x_cord_width_p)'(0);
@@ -1154,40 +1165,42 @@ module cl_manycore
    bsg_manycore_link_sif_s axil_link_sif_lo;
 
   bsg_manycore_link_to_axil #(
-    .x_cord_width_p     (x_cord_width_p   ),
-    .y_cord_width_p     (y_cord_width_p   ),
-    .addr_width_p       (addr_width_p     ),
-    .data_width_p       (data_width_p     ),
-    .host_io_pkt_width_p(host_io_pkt_width_p ), // Defined in cl_manycore_pkg.v
-    .host_io_pkts_tx_p  (host_io_pkts_cap_p), // Defined in cl_manycore_pkg.v
-    .host_io_pkts_rx_p  (host_io_pkts_cap_p), // Defined in cl_manycore_pkg.v
-    .max_out_credits_p  (max_out_credits_p)
+    .x_cord_width_p     (x_cord_width_p   )
+    ,.y_cord_width_p     (y_cord_width_p   )
+    ,.addr_width_p       (addr_width_p     )
+    ,.data_width_p       (data_width_p     )
+    ,.host_io_pkt_width_p(host_io_pkt_width_p) // Defined in cl_manycore_pkg.v
+    ,.host_io_pkts_tx_p  (host_io_pkts_cap_p) // Defined in cl_manycore_pkg.v
+    ,.host_io_pkts_rx_p  (host_io_pkts_cap_p) // Defined in cl_manycore_pkg.v
+    ,.max_out_credits_p  (max_out_credits_p)
+    ,.cycle_width_p(core_cycle_ctr_width_lp)
   ) mcl_to_axil (
-    .clk_i           (clk_main_a0       ),
-    .reset_i         (~rst_main_n_sync  ),
+    .clk_i           (clk_main_a0       )
+    ,.reset_i         (~rst_main_n_sync  )
     // axil slave interface
-    .axil_awvalid_i  (m_axil_ocl_awvalid),
-    .axil_awaddr_i   (m_axil_ocl_awaddr ),
-    .axil_awready_o  (m_axil_ocl_awready),
-    .axil_wvalid_i   (m_axil_ocl_wvalid ),
-    .axil_wdata_i    (m_axil_ocl_wdata  ),
-    .axil_wstrb_i    (m_axil_ocl_wstrb  ),
-    .axil_wready_o   (m_axil_ocl_wready ),
-    .axil_bresp_o    (m_axil_ocl_bresp  ),
-    .axil_bvalid_o   (m_axil_ocl_bvalid ),
-    .axil_bready_i   (m_axil_ocl_bready ),
-    .axil_araddr_i   (m_axil_ocl_araddr ),
-    .axil_arvalid_i  (m_axil_ocl_arvalid),
-    .axil_arready_o  (m_axil_ocl_arready),
-    .axil_rdata_o    (m_axil_ocl_rdata  ),
-    .axil_rresp_o    (m_axil_ocl_rresp  ),
-    .axil_rvalid_o   (m_axil_ocl_rvalid ),
-    .axil_rready_i   (m_axil_ocl_rready ),
+    ,.axil_awvalid_i  (m_axil_ocl_awvalid)
+    ,.axil_awaddr_i   (m_axil_ocl_awaddr )
+    ,.axil_awready_o  (m_axil_ocl_awready)
+    ,.axil_wvalid_i   (m_axil_ocl_wvalid )
+    ,.axil_wdata_i    (m_axil_ocl_wdata  )
+    ,.axil_wstrb_i    (m_axil_ocl_wstrb  )
+    ,.axil_wready_o   (m_axil_ocl_wready )
+    ,.axil_bresp_o    (m_axil_ocl_bresp  )
+    ,.axil_bvalid_o   (m_axil_ocl_bvalid )
+    ,.axil_bready_i   (m_axil_ocl_bready )
+    ,.axil_araddr_i   (m_axil_ocl_araddr )
+    ,.axil_arvalid_i  (m_axil_ocl_arvalid)
+    ,.axil_arready_o  (m_axil_ocl_arready)
+    ,.axil_rdata_o    (m_axil_ocl_rdata  )
+    ,.axil_rresp_o    (m_axil_ocl_rresp  )
+    ,.axil_rvalid_o   (m_axil_ocl_rvalid )
+    ,.axil_rready_i   (m_axil_ocl_rready )
     // manycore link
-    .link_sif_i      (axil_link_sif_li  ),
-    .link_sif_o      (axil_link_sif_lo  ),
-    .my_x_i          (mcl_x_cord_li     ),
-    .my_y_i          (mcl_y_cord_li     )
+    ,.link_sif_i      (axil_link_sif_li  )
+    ,.link_sif_o      (axil_link_sif_lo  )
+    ,.my_x_i          (mcl_x_cord_li     )
+    ,.my_y_i          (mcl_y_cord_li     )
+    ,.cycle_ctr_i       (core_cycle_ctr_l)
   );
 
 `ifdef COSIM


### PR DESCRIPTION
The cycle counter is a platform level feature, since each platform will implement it differently. This implementation is for AWS (both simulation and emulation). The cycle counter can be read by the host at any time, and is located in the AXI to MCL Interface.

Verilator also supports this, but it is in a different branch.

At the platform level, each platform is required to implement hb_mc_platform_get_cycle. This is exposed at the manycore level through hb_mc_manycore_get_cycle (with the same API). 

I have not exposed this at the CUDA level. It would be possible to call get_cycle after a kernel terminates, but this will cause a small (20 cycle?) latency between when the packet is seen in the fifo, and when get_cycle is read (~20 cycles to read a packet out, in simulation). 

I've added an example/test that demonstrates the use of this API. 

Max for review. Lin for input. 

