### PR TITLE
bugfix in execution Makefile to avoid removing intermediate stats after cosim

### DIFF
--- a/libraries/platforms/aws-vcs/execution.mk
+++ b/libraries/platforms/aws-vcs/execution.mk
@@ -148,6 +148,9 @@ endif
 %.dve: %.vpd
 	$(DVE) -full64 -vpd $< &
 
+# Not remove intermediate targets 
+.PRECIOUS: %.operation_trace.csv %.vanilla_operation_trace.csv %.vcache_operation_trace.csv %.vanilla_stats.csv %.vcache_stats.csv
+
 .PHONY: platform.execution.clean
 platform.execution.clean:
 	rm -rf infinite_mem_stats.csv vcache_stats.csv


### PR DESCRIPTION
Title is self-explanatory. Passes with machines 4x4_fast_n_fake, 4x4_blocking_vcache_f1_model, timing_v0_8_4