### PR TITLE
Updated signal name change in endpoint_standard module

### DIFF
--- a/libraries/platforms/aws-fpga/hardware/bsg_manycore_endpoint_to_fifos.v
+++ b/libraries/platforms/aws-fpga/hardware/bsg_manycore_endpoint_to_fifos.v
@@ -230,7 +230,7 @@ module bsg_manycore_endpoint_to_fifos
     // fifo -> manycore packet
     .out_v_i              (endpoint_out_v_li     ),
     .out_packet_i         (endpoint_out_packet_li),
-    .out_ready_o          (endpoint_out_ready_lo ),
+    .out_credit_or_ready_o(endpoint_out_ready_lo ),
 
     // manycore credit -> fifo
     .returned_data_r_o    (returned_data_r_lo    ),


### PR DESCRIPTION
Cosim regression passes with 4x4_fast_n_fake, 4x4_blocking_vcache_f1_model, timing_v0_8_4.
