### PR TITLE
Add tracer C/C++ API

### DIFF
--- a/examples/cuda/Makefile
+++ b/examples/cuda/Makefile
@@ -96,6 +96,7 @@ INDEPENDENT_TESTS += test_softmax
 INDEPENDENT_TESTS += test_log_softmax
 INDEPENDENT_TESTS += test_hammer_cache
 INDEPENDENT_TESTS += test_profiler
+INDEPENDENT_TESTS += test_tracer
 # Tests currently not working with new FPU.
 #INDEPENDENT_TESTS += test_conv1d
 #INDEPENDENT_TESTS += test_conv2d

--- a/examples/cuda/test_tracer.cpp
+++ b/examples/cuda/test_tracer.cpp
@@ -1,0 +1,250 @@
+// Copyright (c) 2019, University of Washington All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// 
+// Redistributions of source code must retain the above copyright notice, this list
+// of conditions and the following disclaimer.
+// 
+// Redistributions in binary form must reproduce the above copyright notice, this
+// list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+// 
+// Neither the name of the copyright holder nor the names of its contributors may
+// be used to endorse or promote products derived from this software without
+// specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "test_tracer.hpp"
+
+#define ALLOC_NAME "default_allocator"
+
+/*
+ * Runs the vector addition a grid of 2x2 tile groups. A[N] + B[N] --> C[N]
+ * Grid dimensions are determines by how much of a load we want for each tile group (block_size_x)
+ * This tests uses the software/spmd/bsg_cuda_lite_runtime/tracer/ Manycore binary in the BSG Manycore bitbucket repository.  
+*/
+
+void host_vec_add (uint32_t *A, uint32_t *B, uint32_t *C, uint32_t N) { 
+        for (uint32_t i = 0; i < N; i ++) { 
+                C[i] = A[i] + B[i];
+        }
+        return;
+}
+
+
+int kernel_tracer (int argc, char **argv) {
+        int rc;
+        char *bin_path, *test_name;
+        struct arguments_path args = {NULL, NULL};
+
+        argp_parse (&argp_path, argc, argv, 0, 0, &args);
+        bin_path = args.path;
+        test_name = args.name;
+
+        bsg_pr_test_info("Running the CUDA Vector Addition Kernel on a grid of 2x2 tile groups.\n\n");
+
+        srand(32);
+
+
+        /***********************************************************************
+        * Define path to binary.
+        * Initialize device, load binary and unfreeze tiles.
+        ************************************************************************/
+        hb_mc_device_t device;
+        rc = hb_mc_device_init(&device, test_name, 0);
+        if (rc != HB_MC_SUCCESS) { 
+                bsg_pr_err("failed to initialize device.\n");
+                return rc;
+        }
+
+        rc = hb_mc_device_program_init(&device, bin_path, ALLOC_NAME, 0);
+        if (rc != HB_MC_SUCCESS) { 
+                bsg_pr_err("failed to initialize program.\n");
+                return rc;
+        }
+
+        /************************************************************************
+        * Allocate memory on the device for A, B and C.
+        *************************************************************************/
+        uint32_t N = 16384;
+
+        eva_t A_device, B_device, C_device; 
+        rc = hb_mc_device_malloc(&device, N * sizeof(uint32_t), &A_device); /* allocate A[N] on the device */
+        if (rc != HB_MC_SUCCESS) { 
+                bsg_pr_err("failed to allocate memory on device.\n");
+                return rc;
+        }
+
+
+        rc = hb_mc_device_malloc(&device, N * sizeof(uint32_t), &B_device); /* allocate B[N] on the device */
+        if (rc != HB_MC_SUCCESS) { 
+                bsg_pr_err("failed to allocate memory on device.\n");
+                return rc;
+        }
+
+
+        rc = hb_mc_device_malloc(&device, N * sizeof(uint32_t), &C_device); /* allocate C[N] on the device */
+        if (rc != HB_MC_SUCCESS) { 
+                bsg_pr_err("failed to allocate memory on device.\n");
+                return rc;
+        }
+
+
+
+        /*************************************************************************
+        * Allocate memory on the host for A & B and initialize with random values.
+        **************************************************************************/
+        uint32_t A_host[N]; /* allocate A[N] on the host */ 
+        uint32_t B_host[N]; /* allocate B[N] on the host */
+        for (int i = 0; i < N; i++) { /* fill A with arbitrary data */
+                A_host[i] = rand() & 0xFFFF;
+                B_host[i] = rand() & 0xFFFF;
+        }
+
+
+
+        /**************************************************************************
+        * Copy A & B from host onto device DRAM.
+        ***************************************************************************/
+        void *dst = (void *) ((intptr_t) A_device);
+        void *src = (void *) &A_host[0];
+        rc = hb_mc_device_memcpy (&device, dst, src, N * sizeof(uint32_t), HB_MC_MEMCPY_TO_DEVICE); /* Copy A to the device  */ 
+        if (rc != HB_MC_SUCCESS) { 
+                bsg_pr_err("failed to copy memory to device.\n");
+                return rc;
+        }
+
+
+        dst = (void *) ((intptr_t) B_device);
+        src = (void *) &B_host[0];
+        rc = hb_mc_device_memcpy (&device, dst, src, N * sizeof(uint32_t), HB_MC_MEMCPY_TO_DEVICE); /* Copy B to the device */ 
+        if (rc != HB_MC_SUCCESS) { 
+                bsg_pr_err("failed to copy  memory to device.\n");
+                return rc;
+        }
+
+
+        /***************************************************************************
+        * Define block_size_x/y: amount of work for each tile group
+        * Define tg_dim_x/y: number of tiles in each tile group
+        * Calculate grid_dim_x/y: number of tile groups needed based on block_size_x/y
+        ****************************************************************************/
+        uint32_t block_size_x = 1024;
+
+        hb_mc_dimension_t tg_dim = { .x = 2, .y = 2 }; 
+
+        hb_mc_dimension_t grid_dim = { .x = N / block_size_x, .y = 1 } ;
+
+
+        /****************************************************************************
+        * Prepare list of input arguments for kernel.
+        *****************************************************************************/
+        uint32_t cuda_argv[5] = {A_device, B_device, C_device, N, block_size_x};
+
+        /*****************************************************************************
+        * Enquque grid of tile groups, pass in grid and tile group
+        * dimensions, kernel name, number and list of input arguments
+        ******************************************************************************/
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_vec_add_parallel", 5, cuda_argv);
+        if (rc != HB_MC_SUCCESS) { 
+                bsg_pr_err("failed to initialize grid.\n");
+                return rc;
+        }
+
+        /*****************************************************************************
+         * Start the tracer (vanilla_operation_trace.csv)
+         *****************************************************************************/
+        hb_mc_manycore_trace_enable((&device)->mc);
+
+        /*****************************************************************************
+         * Start the logger (vanilla.log)
+         *****************************************************************************/
+        hb_mc_manycore_log_enable((&device)->mc);
+
+        /******************************************************************************
+        * Launch and execute all tile groups on device and wait for all to finish. 
+        *******************************************************************************/
+        rc = hb_mc_device_tile_groups_execute(&device);
+        if (rc != HB_MC_SUCCESS) { 
+                bsg_pr_err("failed to execute tile groups.\n");
+                return rc;
+        }
+
+        /*******************************************************************************
+         * Finish logging
+         *******************************************************************************/
+        hb_mc_manycore_log_disable((&device)->mc);
+
+        /*******************************************************************************
+         * Finish Tracing
+         *******************************************************************************/
+        hb_mc_manycore_trace_disable((&device)->mc);
+
+
+        /********************************************************************************
+        * Copy result matrix back from device DRAM into host memory. 
+        *********************************************************************************/
+        uint32_t C_host[N];
+        src = (void *) ((intptr_t) C_device);
+        dst = (void *) &C_host[0];
+        rc = hb_mc_device_memcpy (&device, (void *) dst, src, N * sizeof(uint32_t), HB_MC_MEMCPY_TO_HOST); /* copy C to the host */
+        if (rc != HB_MC_SUCCESS) { 
+                bsg_pr_err("failed to copy  memory from device.\n");
+                return rc;
+        }
+
+
+        /*********************************************************************************
+        * Freeze the tiles and memory manager cleanup. 
+        **********************************************************************************/
+        rc = hb_mc_device_finish(&device); 
+        if (rc != HB_MC_SUCCESS) { 
+                bsg_pr_err("failed to de-initialize device.\n");
+                return rc;
+        }
+
+
+        /**********************************************************************************
+        * Calculate the expected result using host code and compare the results. 
+        ***********************************************************************************/
+        uint32_t C_expected[N]; 
+        host_vec_add (A_host, B_host, C_expected, N); 
+
+
+        int mismatch = 0; 
+        for (int i = 0; i < N; i++) {
+                if (A_host[i] + B_host[i] != C_host[i]) {
+                        bsg_pr_err(BSG_RED("Mismatch: ") "C[%d]:  0x%08" PRIx32 " + 0x%08" PRIx32 " = 0x%08" PRIx32 "\t Expected: 0x%08" PRIx32 "\n", i , A_host[i], B_host[i], C_host[i], C_expected[i]);
+                        mismatch = 1;
+                }
+        } 
+
+        if (mismatch) { 
+                return HB_MC_FAIL;
+        }
+        return HB_MC_SUCCESS;
+}
+
+#ifdef VCS
+int vcs_main(int argc, char ** argv) {
+#else
+int main(int argc, char ** argv) {
+#endif
+        bsg_pr_test_info("test_tracer Regression Test \n");
+        int rc = kernel_tracer(argc, argv);
+        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
+        return rc;
+}
+
+

--- a/examples/cuda/test_tracer.hpp
+++ b/examples/cuda/test_tracer.hpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2019, University of Washington All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// 
+// Redistributions of source code must retain the above copyright notice, this list
+// of conditions and the following disclaimer.
+// 
+// Redistributions in binary form must reproduce the above copyright notice, this
+// list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+// 
+// Neither the name of the copyright holder nor the names of its contributors may
+// be used to endorse or promote products derived from this software without
+// specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef TEST_TRACER_H
+#define TEST_TRACER_H
+
+
+#include <stdio.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <string.h>
+#include <time.h>
+#include <stdlib.h>
+
+#include "cuda_tests.h"
+
+
+#endif

--- a/libraries/bsg_manycore.cpp
+++ b/libraries/bsg_manycore.cpp
@@ -1465,3 +1465,39 @@ int hb_mc_manycore_dma_read(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa,
 int hb_mc_manycore_get_icount(hb_mc_manycore_t *mc, bsg_instr_type_e itype, int *count){
         return hb_mc_platform_get_icount(mc, itype, count);
 }
+
+/**
+ * Enable trace file generation (vanilla_operation_trace.csv)
+ * @param[in] mc    A manycore instance initialized with hb_mc_manycore_init()
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_manycore_trace_enable(hb_mc_manycore_t *mc){
+        return hb_mc_platform_trace_enable(mc);
+}
+
+/**
+ * Disable trace file generation (vanilla_operation_trace.csv)
+ * @param[in] mc    A manycore instance initialized with hb_mc_manycore_init()
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_manycore_trace_disable(hb_mc_manycore_t *mc){
+        return hb_mc_platform_trace_disable(mc);
+}
+
+/**
+ * Enable log file generation (vanilla.log)
+ * @param[in] mc    A manycore instance initialized with hb_mc_manycore_init()
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_manycore_log_enable(hb_mc_manycore_t *mc){
+        return hb_mc_platform_log_enable(mc);
+}
+
+/**
+ * Disable log file generation (vanilla.log)
+ * @param[in] mc    A manycore instance initialized with hb_mc_manycore_init()
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_manycore_log_disable(hb_mc_manycore_t *mc){
+        return hb_mc_platform_log_disable(mc);
+}

--- a/libraries/bsg_manycore.h
+++ b/libraries/bsg_manycore.h
@@ -528,6 +528,34 @@ extern "C" {
          */
         int hb_mc_manycore_get_icount(hb_mc_manycore_t *mc, bsg_instr_type_e itype, int *count);
 
+        /**
+         * Enable trace file generation (vanilla_operation_trace.csv)
+         * @param[in] mc    A manycore instance initialized with hb_mc_manycore_init()
+         * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+         */
+        int hb_mc_manycore_trace_enable(hb_mc_manycore_t *mc);
+
+        /**
+         * Disable trace file generation (vanilla_operation_trace.csv)
+         * @param[in] mc    A manycore instance initialized with hb_mc_manycore_init()
+         * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+         */
+        int hb_mc_manycore_trace_disable(hb_mc_manycore_t *mc);
+
+        /**
+         * Enable log file generation (vanilla.log)
+         * @param[in] mc    A manycore instance initialized with hb_mc_manycore_init()
+         * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+         */
+        int hb_mc_manycore_log_enable(hb_mc_manycore_t *mc);
+
+        /**
+         * Disable log file generation (vanilla.log)
+         * @param[in] mc    A manycore instance initialized with hb_mc_manycore_init()
+         * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+         */
+        int hb_mc_manycore_log_disable(hb_mc_manycore_t *mc);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/bsg_manycore_platform.h
+++ b/libraries/bsg_manycore_platform.h
@@ -124,7 +124,33 @@ extern "C" {
          */
         int hb_mc_platform_get_icount(hb_mc_manycore_t *mc, bsg_instr_type_e itype, int *count);
 
+        /**
+         * Enable trace file generation (vanilla_operation_trace.csv)
+         * @param[in] mc    A manycore instance initialized with hb_mc_manycore_init()
+         * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+         */
+        int hb_mc_platform_trace_enable(hb_mc_manycore_t *mc);
 
+        /**
+         * Disable trace file generation (vanilla_operation_trace.csv)
+         * @param[in] mc    A manycore instance initialized with hb_mc_manycore_init()
+         * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+         */
+        int hb_mc_platform_trace_disable(hb_mc_manycore_t *mc);
+
+        /**
+         * Enable log file generation (vanilla.log)
+         * @param[in] mc    A manycore instance initialized with hb_mc_manycore_init()
+         * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+         */
+        int hb_mc_platform_log_enable(hb_mc_manycore_t *mc);
+
+        /**
+         * Disable log file generation (vanilla.log)
+         * @param[in] mc    A manycore instance initialized with hb_mc_manycore_init()
+         * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+         */
+        int hb_mc_platform_log_disable(hb_mc_manycore_t *mc);
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/features/profiler/noimpl/bsg_manycore_profiler.cpp
+++ b/libraries/features/profiler/noimpl/bsg_manycore_profiler.cpp
@@ -50,3 +50,23 @@ int hb_mc_profiler_get_icount(hb_mc_profiler_t p, bsg_instr_type_e itype, int *c
         bsg_pr_warn("%s: Not supported.\n", __func__);
         return HB_MC_NOIMPL;
 }
+
+/**
+ * Enable trace file generation
+ * @param[in] mc    A manycore instance initialized with hb_mc_manycore_init()
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_profiler_trace_enable(hb_mc_profiler_t p){
+        bsg_pr_warn("%s: Not supported.\n", __func__);
+        return HB_MC_NOIMPL;
+}
+
+/**
+ * Disable trace file generation
+ * @param[in] mc    A manycore instance initialized with hb_mc_manycore_init()
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_profiler_trace_disable(hb_mc_profiler_t p){
+        bsg_pr_warn("%s: Not supported.\n", __func__);
+        return HB_MC_NOIMPL;
+}

--- a/libraries/features/profiler/simulation/bsg_manycore_profiler.cpp
+++ b/libraries/features/profiler/simulation/bsg_manycore_profiler.cpp
@@ -140,3 +140,4 @@ int hb_mc_profiler_get_icount(hb_mc_profiler_t p, bsg_instr_type_e itype, int *c
         *count = sum;
         return HB_MC_SUCCESS;
 }
+

--- a/libraries/features/tracer/bsg_manycore_tracer.hpp
+++ b/libraries/features/tracer/bsg_manycore_tracer.hpp
@@ -1,0 +1,60 @@
+#ifndef __BSG_MANYCORE_TRACER_HPP
+#define __BSG_MANYCORE_TRACER_HPP
+#include <bsg_manycore.h>
+#include <string>
+
+// Since the definition of hb_mc_tracer_t is implementation
+// dependent, we use void *
+typedef void* hb_mc_tracer_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+        /**
+         * Initialize an hb_mc_tracer_t instance
+         * @param[in] p    A pointer to the hb_mc_tracer_t instance to initialize
+         * @param[in] hier An implementation-dependent string. See the implementation for more details.
+         * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+         */
+        int hb_mc_tracer_init(hb_mc_tracer_t *p, std::string &hier);
+
+        /**
+         * Clean up an hb_mc_tracer_t instance
+         * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+         */
+        int hb_mc_tracer_cleanup(hb_mc_tracer_t *p);
+
+        /**
+         * Enable trace file generation (vanilla_operation_trace.csv)
+         * @param[in] p    A tracer instance initialized with hb_mc_tracer_init()
+         * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+         */
+        int hb_mc_tracer_trace_enable(hb_mc_tracer_t p);
+
+        /**
+         * Disable trace file generation (vanilla_operation_trace.csv)
+         * @param[in] p    A tracer instance initialized with hb_mc_tracer_init()
+         * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+         */
+        int hb_mc_tracer_trace_disable(hb_mc_tracer_t p);
+
+        /**
+         * Enable log file generation (vanilla.log)
+         * @param[in] p    A tracer instance initialized with hb_mc_tracer_init()
+         * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+         */
+        int hb_mc_tracer_log_enable(hb_mc_tracer_t p);
+
+        /**
+         * Disable log file generation (vanilla.log)
+         * @param[in] p    A tracer instance initialized with hb_mc_tracer_init()
+         * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+         */
+        int hb_mc_tracer_log_disable(hb_mc_tracer_t p);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libraries/features/tracer/noimpl/bsg_manycore_tracer.cpp
+++ b/libraries/features/tracer/noimpl/bsg_manycore_tracer.cpp
@@ -1,0 +1,112 @@
+// Copyright (c) 2020, University of Washington All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// 
+// Redistributions of source code must retain the above copyright notice, this list
+// of conditions and the following disclaimer.
+// 
+// Redistributions in binary form must reproduce the above copyright notice, this
+// list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+// 
+// Neither the name of the copyright holder nor the names of its contributors may
+// be used to endorse or promote products derived from this software without
+// specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include <bsg_manycore_tracer.hpp>
+#include <bsg_manycore_printing.h>
+
+/**
+ * Initialize an hb_mc_tracer_t instance
+ * @param[in] p    A pointer to the hb_mc_tracer_t instance to initialize
+ * @param[in] hier An implementation-dependent string. See the implementation for more details.
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ *
+ * NOTE: In this implementation, the argument hier indicates the path
+ * to the top level module in simulation.
+ */
+int hb_mc_tracer_init(hb_mc_tracer_t *p, string &hier){
+        return HB_MC_NOIMPL;
+}
+
+/**
+ * Clean up an hb_mc_tracer_t instance
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_tracer_cleanup(hb_mc_tracer_t *p){
+        return HB_MC_NOIMPL;
+}
+
+/**
+ * Enable trace file generation (vanilla_operation_trace.csv)
+ * @param[in] p    A tracer instance initialized with hb_mc_tracer_init()
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_tracer_trace_enable(hb_mc_tracer_t p){
+        bsg_pr_warn("%s: Not supported.\n", __func__);
+        return HB_MC_NOIMPL;
+}
+
+/**
+ * Disable trace file generation (vanilla_operation_trace.csv)
+ * @param[in] p    A tracer instance initialized with hb_mc_tracer_init()
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_tracer_trace_disable(hb_mc_tracer_t p){
+        bsg_pr_warn("%s: Not supported.\n", __func__);
+        return HB_MC_NOIMPL;
+}
+
+/**
+ * Enable log file generation (vanilla.log)
+ * @param[in] p    A tracer instance initialized with hb_mc_tracer_init()
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_tracer_log_enable(hb_mc_tracer_t p){
+        bsg_pr_warn("%s: Not supported.\n", __func__);
+        return HB_MC_NOIMPL;
+}
+
+/**
+ * Disable log file generation (vanilla.log)
+ * @param[in] p    A tracer instance initialized with hb_mc_tracer_init()
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_tracer_log_disable(hb_mc_tracer_t p){
+        bsg_pr_warn("%s: Not supported.\n", __func__);
+        return HB_MC_NOIMPL;
+}
+int hb_mc_profiler_init(hb_mc_profiler_t *p, hb_mc_idx_t x, hb_mc_idx_t y, string &hier){
+        return HB_MC_NOIMPL;
+}
+
+/**
+ * Clean up an hb_mc_profiler_t instance
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_profiler_cleanup(hb_mc_profiler_t *p){
+        return HB_MC_NOIMPL;
+}
+
+/**
+ * Get the number of instructions executed for a certain class of instructions
+ * @param[in] p     A hb_mc_profiler_t instance initialized with hb_mc_profiler_init()
+ * @param[in] itype An enum defining the class of instructions to query.
+ * @param[out] count The number of instructions executed in the queried class.
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_profiler_get_icount(hb_mc_profiler_t p, bsg_instr_type_e itype, int *count){
+        bsg_pr_warn("%s: Not supported.\n", __func__);
+        return HB_MC_NOIMPL;
+}

--- a/libraries/features/tracer/simulation/bsg_manycore_tracer.cpp
+++ b/libraries/features/tracer/simulation/bsg_manycore_tracer.cpp
@@ -1,0 +1,118 @@
+// Copyright (c) 2020, University of Washington All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// 
+// Redistributions of source code must retain the above copyright notice, this list
+// of conditions and the following disclaimer.
+// 
+// Redistributions in binary form must reproduce the above copyright notice, this
+// list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+// 
+// Neither the name of the copyright holder nor the names of its contributors may
+// be used to endorse or promote products derived from this software without
+// specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include <bsg_nonsynth_dpi_gpio.hpp>
+#include <bsg_manycore_printing.h>
+#include <bsg_manycore_coordinate.h>
+#include <bsg_manycore_tracer.hpp>
+#include <string>
+#include <sstream>
+#include <vector>
+using namespace bsg_nonsynth_dpi;
+using namespace std;
+
+// There are TWO GPIO pins:
+// -- One to control the TRACER (vanilla_operation_trace.csv)
+// -- One to control the LOGGGER (vanilla.log)
+// These correspond to the methods below
+#define HB_MC_TRACER_TRACE_IDX 0
+#define HB_MC_TRACER_LOG_IDX 1
+#define HB_MC_TRACER_PINS 2
+/**
+ * Initialize an hb_mc_tracer_t instance
+ * @param[in] p    A pointer to the hb_mc_tracer_t instance to initialize
+ * @param[in] hier An implementation-dependent string. See the implementation for more details.
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ *
+ * NOTE: In this implementation, the argument hier indicates the path
+ * to the top level module in simulation.
+ */
+int hb_mc_tracer_init(hb_mc_tracer_t *p, string &hier){
+        dpi_gpio<HB_MC_TRACER_PINS> *tracer = new dpi_gpio<HB_MC_TRACER_PINS>(hier + ".trace_control");
+
+        // Save the 2D vector
+        *p = reinterpret_cast<hb_mc_tracer_t>(tracer);
+        return HB_MC_SUCCESS;
+}
+
+/**
+ * Clean up an hb_mc_tracer_t instance
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_tracer_cleanup(hb_mc_tracer_t *p){
+        dpi_gpio<HB_MC_TRACER_PINS> *tracer = reinterpret_cast<dpi_gpio<HB_MC_TRACER_PINS> *>(*p);
+
+        delete tracer;
+        return HB_MC_SUCCESS;
+}
+
+/**
+ * Enable trace file generation (vanilla_operation_trace.csv)
+ * @param[in] p    A tracer instance initialized with hb_mc_tracer_init()
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_tracer_trace_enable(hb_mc_tracer_t p){
+        dpi_gpio<HB_MC_TRACER_PINS> *tracer = reinterpret_cast<dpi_gpio<HB_MC_TRACER_PINS> *>(p);
+
+        tracer->set(HB_MC_TRACER_TRACE_IDX, true);
+        return HB_MC_SUCCESS;
+}
+
+/**
+ * Disable trace file generation (vanilla_operation_trace.csv)
+ * @param[in] p    A tracer instance initialized with hb_mc_tracer_init()
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_tracer_trace_disable(hb_mc_tracer_t p){
+        dpi_gpio<HB_MC_TRACER_PINS> *tracer = reinterpret_cast<dpi_gpio<HB_MC_TRACER_PINS> *>(p);
+
+        tracer->set(HB_MC_TRACER_TRACE_IDX, false);
+        return HB_MC_SUCCESS;
+}
+
+/**
+ * Enable log file generation (vanilla.log)
+ * @param[in] p    A tracer instance initialized with hb_mc_tracer_init()
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_tracer_log_enable(hb_mc_tracer_t p){
+        dpi_gpio<HB_MC_TRACER_PINS> *tracer = reinterpret_cast<dpi_gpio<HB_MC_TRACER_PINS> *>(p);
+
+        tracer->set(HB_MC_TRACER_LOG_IDX, true);
+        return HB_MC_SUCCESS;
+}
+
+/**
+ * Disable log file generation (vanilla.log)
+ * @param[in] p    A tracer instance initialized with hb_mc_tracer_init()
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_tracer_log_disable(hb_mc_tracer_t p){
+        dpi_gpio<HB_MC_TRACER_PINS> *tracer = reinterpret_cast<dpi_gpio<HB_MC_TRACER_PINS> *>(p);
+
+        tracer->set(HB_MC_TRACER_LOG_IDX, false);
+        return HB_MC_SUCCESS;
+}

--- a/libraries/platforms/aws-fpga/hardware/cl_manycore.sv
+++ b/libraries/platforms/aws-fpga/hardware/cl_manycore.sv
@@ -1317,11 +1317,30 @@ module cl_manycore
 `endif //  `ifndef DISABLE_VJTAG_DEBUG
 
    // synopsys translate off
-   int                        status;
-   logic                      trace_en;
+   logic arg_trace_en;
+   logic trace_en;
+   logic log_en;
+   logic dpi_trace_en;
+   logic dpi_log_en;
    initial begin
-      assign trace_en = $test$plusargs("trace");
+      assign arg_trace_en = $test$plusargs("trace");
    end
+
+   assign trace_en = arg_trace_en | dpi_trace_en;
+   assign log_en = arg_trace_en | dpi_log_en;
+
+   bsg_nonsynth_dpi_gpio
+     #(
+       .width_p(2)
+       ,.init_o_p('0)
+       ,.use_output_p('1)
+       ,.debpug_p('0)
+       )
+   trace_control
+     (
+       .gpio_o({dpi_log_en, dpi_trace_en})
+       ,.gpio_i('0)
+       );
 
    bind vanilla_core vanilla_core_trace
      #(
@@ -1335,7 +1354,7 @@ module cl_manycore
    vtrace
      (
       .*
-      ,.trace_en_i($root.tb.card.fpga.CL.trace_en)
+      ,.trace_en_i($root.tb.card.fpga.CL.log_en)
       );
 
 

--- a/libraries/platforms/aws-vcs/hardware.mk
+++ b/libraries/platforms/aws-vcs/hardware.mk
@@ -89,6 +89,7 @@ VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/bsg_manycore_profile_pkg.v
 VSOURCES += $(BASEJUMP_STL_DIR)/bsg_misc/bsg_cycle_counter.v
 
 # Core Profiler/Trace
+VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_dpi_gpio.v
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/instr_trace.v
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/vanilla_core_trace.v
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/vanilla_core_profiler.v

--- a/libraries/platforms/aws-vcs/library.mk
+++ b/libraries/platforms/aws-vcs/library.mk
@@ -39,6 +39,7 @@ PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/platforms/aws-vcs/bsg_manycore_mmio.cpp
 PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/platforms/aws-fpga/bsg_manycore_platform.cpp
 PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/platforms/aws-vcs/bsg_manycore_platform.cpp
 PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/features/profiler/simulation/bsg_manycore_profiler.cpp
+PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/features/tracer/simulation/bsg_manycore_tracer.cpp
 
 # The aws-vcs platform supports simulation DMA on certain
 # machines. Support is determined by the memory system configuration
@@ -54,6 +55,7 @@ $(LIB_OBJECTS): CFLAGS += -DCOSIM
 $(PLATFORM_OBJECTS): INCLUDES := -I$(LIBRARIES_PATH)
 $(PLATFORM_OBJECTS): INCLUDES += -I$(LIBRARIES_PATH)/platforms/aws-fpga
 $(PLATFORM_OBJECTS): INCLUDES += -I$(LIBRARIES_PATH)/features/profiler
+$(PLATFORM_OBJECTS): INCLUDES += -I$(LIBRARIES_PATH)/features/tracer
 $(PLATFORM_OBJECTS): INCLUDES += -I$(VCS_HOME)/linux64/lib/
 $(PLATFORM_OBJECTS): INCLUDES += -I$(SDK_DIR)/userspace/include
 $(PLATFORM_OBJECTS): INCLUDES += -I$(BSG_MANYCORE_DIR)/testbenches/dpi/


### PR DESCRIPTION
Depends on [346](https://github.com/bespoke-silicon-group/bsg_manycore/pull/346/files)

This adds an API for enabling/disabling trace file and log file generation. This can drastically reduce runtime and trace file size when datasets are large. 

This is necessary because parsing "plus args", i.e. `+trace` isn't clean in Verilator.


The four new functions are
`bsg_manycore_trace_enable/disable` and `bsg_manycore_log_enable/disable`. The former creates `vanilla_operation_trace.csv` and the latter generates `vanilla.log`

Also added a regression test/example.