### PR TITLE
Fixed leaking CFLAGS/LDFLAGS

### DIFF
--- a/libraries/features/dma/simulation/dramsim3.mk
+++ b/libraries/features/dma/simulation/dramsim3.mk
@@ -57,9 +57,6 @@ _BSG_F1_TESTBENCHES_DRAMSIM3_MK := 1
 # Check if dramsim3 is the memory model for this design
 ifneq ($(filter dramsim3, $(subst _, ,$(CL_MANYCORE_MEM_CFG))),)
 
-# Define USING_DRAMSIM3 for host library
-$(LIB_OBJECTS): CXXFLAGS += -DUSING_DRAMSIM3=1
-
 # Add a clean rule
 .PHONY: dramsim3.clean
 
@@ -67,7 +64,7 @@ $(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so.1.0: LDFLAGS += -L$(LIBRARIES_PA
 $(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so.1.0: $(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so
 
 # Rules for building dramsim3 library
-$(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: CXXFLAGS += -std=c++11 -D_GNU_SOURCE -Wall -fPIC -shared
+$(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: CXXFLAGS := -std=c++11 -D_GNU_SOURCE -Wall -fPIC -shared
 $(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: CXXFLAGS += -I$(BASEJUMP_STL_DIR)/imports/DRAMSim3/src
 $(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: CXXFLAGS += -I$(BASEJUMP_STL_DIR)/imports/DRAMSim3/ext/headers
 $(LIBRARIES_PATH)/features/dma/simulation/libdramsim3.so: CXXFLAGS += -I$(BASEJUMP_STL_DIR)/imports/DRAMSim3/ext/fmt/include

--- a/libraries/libraries.mk
+++ b/libraries/libraries.mk
@@ -103,8 +103,8 @@ $(LIB_OBJECTS): INCLUDES += -I$(LIBRARIES_PATH)/features/dma
 $(LIB_OBJECTS): INCLUDES += -I$(LIBRARIES_PATH)/features/profiler
 # We should move this from AWS (and keep the license)
 $(LIB_OBJECTS): INCLUDES += -I$(AWS_FPGA_REPO_DIR)/SDAccel/userspace/include
-$(LIB_OBJECTS): CFLAGS    += -std=c11 -fPIC -D_GNU_SOURCE $(INCLUDES)
-$(LIB_OBJECTS): CXXFLAGS  += -std=c++11 -fPIC -D_GNU_SOURCE $(INCLUDES)
+$(LIB_OBJECTS): CFLAGS   := -std=c11 -fPIC -D_GNU_SOURCE $(INCLUDES)
+$(LIB_OBJECTS): CXXFLAGS := -std=c++11 -fPIC -D_GNU_SOURCE $(INCLUDES)
 # Need to move this, eventually
 #$(LIB_OBJECTS) $(PLATFORM_OBJECTS): $(BSG_MACHINE_PATH)/bsg_manycore_machine.h
 


### PR DESCRIPTION
Fixes library compilation, when `make regression` is called in the python examples directory. Compilation flags cause the libraries compilation to fail.

Fixes #611  