### PR TITLE
Fixed floating-point errors in convolution examples

### DIFF
--- a/examples/cuda/Makefile
+++ b/examples/cuda/Makefile
@@ -97,9 +97,8 @@ INDEPENDENT_TESTS += test_log_softmax
 INDEPENDENT_TESTS += test_hammer_cache
 INDEPENDENT_TESTS += test_profiler
 INDEPENDENT_TESTS += test_tracer
-# Tests currently not working with new FPU.
-#INDEPENDENT_TESTS += test_conv1d
-#INDEPENDENT_TESTS += test_conv2d
+INDEPENDENT_TESTS += test_conv1d
+INDEPENDENT_TESTS += test_conv2d
 
 REGRESSION_TESTS = $(UNIFIED_TESTS) $(INDEPENDENT_TESTS)
 

--- a/examples/cuda/test_conv1d.c
+++ b/examples/cuda/test_conv1d.c
@@ -74,8 +74,7 @@ void conv1d(const float *A,
                         float a = 0;
                         if(0 <= a_idx && a_idx < N)
                                 a = A[a_idx];
-
-                        res += filter[j] * a;
+                        res = fmaf(filter[j], a, res);
                 }
                 B[i] = res;
         }
@@ -90,7 +89,7 @@ int kernel_conv1d(int argc, char **argv)
         elf = args.path;
         test_name = args.name;
 
-        srand(time(0));
+        srand(42);
         int rc;
         hb_mc_device_t manycore, *mc = &manycore;
         rc = hb_mc_device_init(mc, test_name, 0);

--- a/examples/cuda/test_conv2d.c
+++ b/examples/cuda/test_conv2d.c
@@ -89,7 +89,7 @@ void conv2d(const float *A,
                                         if((0 <= ay && ay < M) &&
                                            (0 <= ax && ax < N))
                                                 a = A[ay * N + ax];
-                                        res += filter[fy * W + fx] * a;
+                                        res = fmaf(filter[fy * W + fx], a, res);
                                  }
                         B[by * result_w + bx] = res;
                 }
@@ -104,7 +104,7 @@ int kernel_conv2d(int argc, char **argv)
         elf = args.path;
         test_name = args.name;
 
-        srand(time(0));
+        srand(42);
         int rc;
         hb_mc_device_t manycore, *mc = &manycore;
         rc = hb_mc_device_init(mc, test_name, 0);


### PR DESCRIPTION
The root cause was how x86 compilers handle FMA.

In the new HardFloat FPU pipeline, we provide an fma instruction. The new compiler flags enable this instruction in the RISC-V code. fma has different precision than doing fmul + fadd, so this produces errors in direct floating-point comparison between the two instruction sequences.

On x86, FMA is not used and the compiler uses fmul (x86) and fadd (x86), not the SSE/AVX fma instruction. On the pre-hardFloat pipeline this was fine, because RISC-V did the same. However, with the new pipeline x86 fmul + fadd produces a different result than RISC-V fma. 

I've switched the host code to use fmaf -- which is the floating point FMA equivalent from the standard library. This produces the IEEE-compliant result and doesn't require gcc flags.

See more here: https://en.cppreference.com/w/c/numeric/math/fma

Fixes #600 