### PR TITLE
(Re-?) Added support for heterogeneous machines

### DIFF
--- a/hardware/hardware.mk
+++ b/hardware/hardware.mk
@@ -266,6 +266,9 @@ $(BSG_MACHINE_PATH)/bsg_bladerunner_pkg.v: $(BSG_MACHINE_PATH)/bsg_bladerunner_c
 	@echo "parameter rom_els_gp = `wc -l < $<`;" >> $@
 	@echo "parameter bsg_machine_crossbar_network_gp = $(CL_MANYCORE_CROSSBAR_NETWORK);" >> $@
 	@echo "parameter bit [rom_width_gp-1:0] rom_arr_gp [rom_els_gp-1:0] = '{$(ROM_STR)};" >> $@
+	@echo "parameter num_tiles_y_gp = $(CL_MANYCORE_DIM_Y);" >> $@
+	@echo "parameter num_tiles_x_gp = $(CL_MANYCORE_DIM_X);" >> $@
+	@echo "parameter int hetero_type_vec_gp [0:(num_tiles_y_gp*num_tiles_x_gp)-1] = $(BSG_MACHINE_HETERO_TYPE_VEC);" >> $@
 	@echo >> $@
 	@echo "endpackage" >> $@
 	@echo >> $@

--- a/libraries/features/profiler/simulation/bsg_manycore_profiler.cpp
+++ b/libraries/features/profiler/simulation/bsg_manycore_profiler.cpp
@@ -84,7 +84,11 @@ int hb_mc_profiler_init(hb_mc_profiler_t *p, hb_mc_idx_t x, hb_mc_idx_t y, strin
                 for(int ix = 0; ix < x; ++ix){
                         ostringstream stream;
                         stream << hier << ".y[" << iy << "]" << ".x[" << ix << "]" << tail;
-                        profilers->push_back(new dpi_vanilla_core_profiler(stream.str()));
+                        // If the scope does not exist, then there is
+                        // not a profiler module bound to a tile at
+                        // that location. Do not instantiate an object
+                        if(svGetScopeFromName(stream.str().c_str()))
+                                profilers->push_back(new dpi_vanilla_core_profiler(stream.str()));
                 }
         }
         

--- a/libraries/platforms/aws-fpga/hardware/bsg_manycore_wrapper_mesh.v
+++ b/libraries/platforms/aws-fpga/hardware/bsg_manycore_wrapper_mesh.v
@@ -11,6 +11,12 @@ module bsg_manycore_wrapper_mesh
     , parameter num_tiles_x_p="inv"
     , parameter num_tiles_y_p="inv"
 
+    // This is used to define heterogeneous arrays. Each index defines
+    // the type of an X/Y coordinate in the array. This is a vector of
+    // num_tiles_x_p*num_tiles_y_p ints; type "0" is the
+    // default. See bsg_manycore_hetero_socket.v for more types.
+    , parameter int hetero_type_vec_p [0:((num_tiles_y_p-1)*num_tiles_x_p) - 1]  = '{default:0}
+
     , parameter dmem_size_p="inv"
     , parameter icache_entries_p="inv"
     , parameter icache_tag_width_p="inv"
@@ -66,6 +72,7 @@ module bsg_manycore_wrapper_mesh
     ,.vcache_block_size_in_words_p(vcache_block_size_in_words_p)
     ,.vcache_sets_p(vcache_sets_p)
     ,.branch_trace_en_p(branch_trace_en_p)
+    ,.hetero_type_vec_p(hetero_type_vec_p)
   ) manycore (
     .clk_i(clk_i)
     ,.reset_i(reset_i)

--- a/libraries/platforms/aws-fpga/hardware/cl_manycore.sv
+++ b/libraries/platforms/aws-fpga/hardware/cl_manycore.sv
@@ -326,6 +326,7 @@ module cl_manycore
        ,.vcache_block_size_in_words_p(block_size_in_words_p)
        ,.vcache_sets_p(sets_p)
        ,.branch_trace_en_p(branch_trace_en_p)
+       ,.hetero_type_vec_p(hetero_type_vec_gp)
        )
    manycore_wrapper
      (

--- a/libraries/platforms/dpi-verilator/hardware/dpi_top.sv
+++ b/libraries/platforms/dpi-verilator/hardware/dpi_top.sv
@@ -277,6 +277,7 @@ module manycore_tb_top
      ,.vcache_block_size_in_words_p(block_size_in_words_p)
      ,.vcache_sets_p(sets_p)
      ,.branch_trace_en_p(branch_trace_en_p)
+     ,.hetero_type_vec_p(hetero_type_vec_gp)
    ) manycore (
      .clk_i(core_clk)
      ,.reset_i(core_reset)

--- a/machines/16x8_fast_n_fake/Makefile.machine.include
+++ b/machines/16x8_fast_n_fake/Makefile.machine.include
@@ -65,3 +65,8 @@ BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG
 
 # Define network topology
 BSG_MACHINE_CROSSBAR_NETWORK =  0
+
+# Define heterogeneous tile composition.
+# 0 is for Vanilla Core (RV32).
+# Anything else should be described here :)
+BSG_MACHINE_HETERO_TYPE_VEC           = default:0

--- a/machines/4x4_blocking_dramsim3_hbm2_512mb/Makefile.machine.include
+++ b/machines/4x4_blocking_dramsim3_hbm2_512mb/Makefile.machine.include
@@ -65,3 +65,8 @@ BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG
 
 # Define network topology
 BSG_MACHINE_CROSSBAR_NETWORK =  0
+
+# Define heterogeneous tile composition.
+# 0 is for Vanilla Core (RV32).
+# Anything else should be described here :)
+BSG_MACHINE_HETERO_TYPE_VEC           = default:0

--- a/machines/4x4_blocking_vcache_f1_dram/Makefile.machine.include
+++ b/machines/4x4_blocking_vcache_f1_dram/Makefile.machine.include
@@ -65,3 +65,8 @@ BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG
 
 # Define network topology
 BSG_MACHINE_CROSSBAR_NETWORK =  0
+
+# Define heterogeneous tile composition.
+# 0 is for Vanilla Core (RV32).
+# Anything else should be described here :)
+BSG_MACHINE_HETERO_TYPE_VEC           = default:0

--- a/machines/4x4_blocking_vcache_f1_model/Makefile.machine.include
+++ b/machines/4x4_blocking_vcache_f1_model/Makefile.machine.include
@@ -65,3 +65,8 @@ BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG
 
 # Define network topology
 BSG_MACHINE_CROSSBAR_NETWORK =  0
+
+# Define heterogeneous tile composition.
+# 0 is for Vanilla Core (RV32).
+# Anything else should be described here :)
+BSG_MACHINE_HETERO_TYPE_VEC           = default:0

--- a/machines/4x4_fast_n_fake/Makefile.machine.include
+++ b/machines/4x4_fast_n_fake/Makefile.machine.include
@@ -65,3 +65,11 @@ BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG
 
 # Define network topology
 BSG_MACHINE_CROSSBAR_NETWORK =  0
+
+# Heterogeneous cores are not currently supported when
+# BSG_MACHINE_CROSSBAR_NETWORK == 1
+
+# Define heterogeneous tile composition.
+# 0 is for Vanilla Core (RV32).
+# Anything else should be described here :)
+BSG_MACHINE_HETERO_TYPE_VEC           = default:0

--- a/machines/8x4_blocking_dramsim3_hbm2_4gb/Makefile.machine.include
+++ b/machines/8x4_blocking_dramsim3_hbm2_4gb/Makefile.machine.include
@@ -65,3 +65,8 @@ BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG
 
 # Define network topology
 BSG_MACHINE_CROSSBAR_NETWORK =  0
+
+# Define heterogeneous tile composition.
+# 0 is for Vanilla Core (RV32).
+# Anything else should be described here :)
+BSG_MACHINE_HETERO_TYPE_VEC           = default:0

--- a/machines/baseline_v0_16_8/Makefile.machine.include
+++ b/machines/baseline_v0_16_8/Makefile.machine.include
@@ -65,3 +65,8 @@ BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG
 
 # Define network topology
 BSG_MACHINE_CROSSBAR_NETWORK =  1
+
+# Define heterogeneous tile composition.
+# 0 is for Vanilla Core (RV32).
+# Anything else should be described here :)
+BSG_MACHINE_HETERO_TYPE_VEC           = default:0

--- a/machines/baseline_v0_32_16/Makefile.machine.include
+++ b/machines/baseline_v0_32_16/Makefile.machine.include
@@ -65,3 +65,8 @@ BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG
 
 # Define network topology
 BSG_MACHINE_CROSSBAR_NETWORK =  1
+
+# Define heterogeneous tile composition.
+# 0 is for Vanilla Core (RV32).
+# Anything else should be described here :)
+BSG_MACHINE_HETERO_TYPE_VEC           = default:0

--- a/machines/baseline_v0_64_32/Makefile.machine.include
+++ b/machines/baseline_v0_64_32/Makefile.machine.include
@@ -65,3 +65,8 @@ BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG
 
 # Define network topology
 BSG_MACHINE_CROSSBAR_NETWORK =  1
+
+# Define heterogeneous tile composition.
+# 0 is for Vanilla Core (RV32).
+# Anything else should be described here :)
+BSG_MACHINE_HETERO_TYPE_VEC           = default:0

--- a/machines/baseline_v0_8_4/Makefile.machine.include
+++ b/machines/baseline_v0_8_4/Makefile.machine.include
@@ -65,3 +65,8 @@ BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG
 
 # Define network topology
 BSG_MACHINE_CROSSBAR_NETWORK =  1
+
+# Define heterogeneous tile composition.
+# 0 is for Vanilla Core (RV32).
+# Anything else should be described here :)
+BSG_MACHINE_HETERO_TYPE_VEC           = default:0

--- a/machines/timing_v0_16_8/Makefile.machine.include
+++ b/machines/timing_v0_16_8/Makefile.machine.include
@@ -77,3 +77,8 @@ BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG
 
 # Define network topology
 BSG_MACHINE_CROSSBAR_NETWORK =  0
+
+# Define heterogeneous tile composition.
+# 0 is for Vanilla Core (RV32).
+# Anything else should be described here :)
+BSG_MACHINE_HETERO_TYPE_VEC           = default:0

--- a/machines/timing_v0_32_16/Makefile.machine.include
+++ b/machines/timing_v0_32_16/Makefile.machine.include
@@ -76,3 +76,8 @@ BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG
 
 # Define network topology
 BSG_MACHINE_CROSSBAR_NETWORK =  0
+
+# Define heterogeneous tile composition.
+# 0 is for Vanilla Core (RV32).
+# Anything else should be described here :)
+BSG_MACHINE_HETERO_TYPE_VEC           = default:0

--- a/machines/timing_v0_64_32/Makefile.machine.include
+++ b/machines/timing_v0_64_32/Makefile.machine.include
@@ -76,3 +76,8 @@ BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG
 
 # Define network topology
 BSG_MACHINE_CROSSBAR_NETWORK =  0
+
+# Define heterogeneous tile composition.
+# 0 is for Vanilla Core (RV32).
+# Anything else should be described here :)
+BSG_MACHINE_HETERO_TYPE_VEC           = default:0

--- a/machines/timing_v0_8_4/Makefile.machine.include
+++ b/machines/timing_v0_8_4/Makefile.machine.include
@@ -77,3 +77,8 @@ BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG
 
 # Define network topology
 BSG_MACHINE_CROSSBAR_NETWORK =  0
+
+# Define heterogeneous tile composition.
+# 0 is for Vanilla Core (RV32).
+# Anything else should be described here :)
+BSG_MACHINE_HETERO_TYPE_VEC           = default:0


### PR DESCRIPTION
* hetero_type_vec_gp is now defined in bsg_bladerunner_pkg.v
* Vanilla Core profiler module checks before instantiation
* Only supports mesh network

Pulled from @ptpan's changes