### PR TITLE
Verilog fixes for aws-fpga/aws-vcs platform

### DIFF
--- a/libraries/platforms/aws-fpga/hardware/bsg_manycore_wrapper_mesh.v
+++ b/libraries/platforms/aws-fpga/hardware/bsg_manycore_wrapper_mesh.v
@@ -15,7 +15,7 @@ module bsg_manycore_wrapper_mesh
     // the type of an X/Y coordinate in the array. This is a vector of
     // num_tiles_x_p*num_tiles_y_p ints; type "0" is the
     // default. See bsg_manycore_hetero_socket.v for more types.
-    , parameter int hetero_type_vec_p [0:((num_tiles_y_p-1)*num_tiles_x_p) - 1]  = '{default:0}
+    , parameter int hetero_type_vec_p [0:((num_tiles_y_p)*num_tiles_x_p) - 1]  = '{default:0}
 
     , parameter dmem_size_p="inv"
     , parameter icache_entries_p="inv"

--- a/libraries/platforms/aws-fpga/hardware/bsg_mcl_axil_fifos_master.v
+++ b/libraries/platforms/aws-fpga/hardware/bsg_mcl_axil_fifos_master.v
@@ -172,7 +172,7 @@ module bsg_mcl_axil_fifos_master
     .reset_i(reset_i          ),
     .valid_i(rsp_buf_v_lo     ),
     .data_i (rsp_buf_data_lo  ),
-    .ready_o(rsp_piso_ready_lo),
+    .ready_and_o(rsp_piso_ready_lo),
     .valid_o(r_v_o            ),
     .data_o (r_data_o         ),
     .yumi_i (rsp_piso_yumi_li )

--- a/libraries/platforms/aws-fpga/hardware/bsg_mcl_axil_fifos_slave.v
+++ b/libraries/platforms/aws-fpga/hardware/bsg_mcl_axil_fifos_slave.v
@@ -94,7 +94,7 @@ module bsg_mcl_axil_fifos_slave
     .reset_i(reset_i      ),
     .valid_i(buf_v_lo     ),
     .data_i (buf_data_lo  ),
-    .ready_o(piso_ready_lo),
+    .ready_and_o(piso_ready_lo),
     .valid_o(r_v_o        ),
     .data_o (r_data_o     ),
     .yumi_i (piso_yumi_li )

--- a/libraries/platforms/aws-fpga/hardware/cl_manycore.sv
+++ b/libraries/platforms/aws-fpga/hardware/cl_manycore.sv
@@ -346,7 +346,8 @@ module cl_manycore
   end
 
 
-  // synopsys translate_on
+
+  // synopsys translate_off
   // print stat signals for vanilla_core_profiler module
   logic print_stat_v;
   logic [data_width_p-1:0] print_stat_tag;
@@ -363,7 +364,7 @@ module cl_manycore
     ,.print_stat_v_o(print_stat_v)
     ,.print_stat_tag_o(print_stat_tag)
   );
-  // synopsys translate_off
+  // synopsys translate_on
 
   ////////////////////////////////
   // Configurable Memory System //


### PR DESCRIPTION
* ready_o -> ready_and_o
* Fixed parameter array length mis-declaration
* Fixed swapped translate off/on