### PR TITLE
Bring Replicant up-to-date with Manycore

### DIFF
--- a/libraries/platforms/aws-fpga/hardware/bsg_manycore_wrapper_mesh.v
+++ b/libraries/platforms/aws-fpga/hardware/bsg_manycore_wrapper_mesh.v
@@ -58,7 +58,7 @@ module bsg_manycore_wrapper_mesh
   bsg_manycore_link_sif_s [num_tiles_x_p-1:0] io_link_sif_li;
   bsg_manycore_link_sif_s [num_tiles_x_p-1:0] io_link_sif_lo;
   
-  bsg_manycore #(
+  bsg_manycore_top_mesh #(
     .dmem_size_p(dmem_size_p)
     ,.icache_entries_p(icache_entries_p)
     ,.icache_tag_width_p(icache_tag_width_p)

--- a/libraries/platforms/aws-fpga/hardware/cl_manycore.sv
+++ b/libraries/platforms/aws-fpga/hardware/cl_manycore.sv
@@ -439,8 +439,13 @@ module cl_manycore
       .data_width_p(data_width_p)
       ,.addr_width_p(addr_width_p)
       ,.header_print_p("vcache[0]")
+      ,.ways_p(ways_p)
     ) vcache_prof (
       .*
+
+      // bsg_cache_miss
+      ,.chosen_way_n(miss.chosen_way_n)
+
       ,.global_ctr_i($root.tb.card.fpga.CL.global_ctr)
       ,.print_stat_v_i($root.tb.card.fpga.CL.print_stat_v)
       ,.print_stat_tag_i($root.tb.card.fpga.CL.print_stat_tag)
@@ -494,28 +499,11 @@ module cl_manycore
       ,.ways_p(ways_p)
       ,.id_width_p(id_width_p)
       ,.block_size_in_words_p(block_size_in_words_p)
+      ,.ways_p(ways_p)
     ) vcache_prof (
-      .clk_i(clk_i)
-      ,.reset_i(reset_i)
-
-      ,.tl_data_mem_pkt_i(tl_data_mem_pkt_lo)
-      ,.tl_data_mem_pkt_v_i(tl_data_mem_pkt_v_lo)
-      ,.tl_data_mem_pkt_ready_i(tl_data_mem_pkt_ready_li)
-
-      ,.mhu_idle_i(mhu_idle)
-
-      ,.mhu_data_mem_pkt_i(mhu_data_mem_pkt_lo)
-      ,.mhu_data_mem_pkt_v_i(mhu_data_mem_pkt_v_lo)
-      ,.mhu_data_mem_pkt_yumi_i(mhu_data_mem_pkt_yumi_li)
-
-      ,.miss_fifo_data_i(miss_fifo_data_li)
-      ,.miss_fifo_v_i(miss_fifo_v_li)
-      ,.miss_fifo_ready_i(miss_fifo_ready_lo)
-
-      ,.dma_pkt_i(dma_pkt_o)
-      ,.dma_pkt_v_i(dma_pkt_v_o)
-      ,.dma_pkt_yumi_i(dma_pkt_yumi_i)
-
+      .*
+      ,.replacement_dirty(mhu0.replacement_dirty)
+      ,.replacement_valid(mhu0.replacement_valid)
       ,.global_ctr_i($root.tb.card.fpga.CL.global_ctr)
       ,.print_stat_v_i($root.tb.card.fpga.CL.print_stat_v_lo)
       ,.print_stat_tag_i($root.tb.card.fpga.CL.print_stat_tag_lo)

--- a/libraries/platforms/dpi-verilator/hardware/dpi_top.sv
+++ b/libraries/platforms/dpi-verilator/hardware/dpi_top.sv
@@ -261,8 +261,9 @@ module manycore_tb_top
 
    bsg_manycore_link_sif_s [E:W][num_tiles_y_p:0] hor_link_sif_li;
    bsg_manycore_link_sif_s [E:W][num_tiles_y_p:0] hor_link_sif_lo;
-
-   bsg_manycore 
+     
+     
+   bsg_manycore_top_mesh
      #(
      .dmem_size_p(dmem_size_p)
      ,.icache_entries_p(icache_entries_p)
@@ -539,10 +540,15 @@ module manycore_tb_top
           .data_width_p(data_width_p)
           ,.addr_width_p(addr_width_p)
           ,.header_print_p("vcache[0]")
+          ,.ways_p(ways_p)
           ) 
       vcache_prof 
         (
          .*
+         // bsg_cache_miss
+         ,.chosen_way_n(miss.chosen_way_n)
+
+         // From top-level
          ,.global_ctr_i($root.manycore_tb_top.global_ctr)
          ,.print_stat_v_i($root.manycore_tb_top.print_stat_v_lo)
          ,.print_stat_tag_i($root.manycore_tb_top.print_stat_tag_lo)
@@ -598,27 +604,9 @@ module manycore_tb_top
           ) 
       vcache_prof
         (
-         .clk_i(clk_i)
-         ,.reset_i(reset_i)
-
-         ,.tl_data_mem_pkt_i(tl_data_mem_pkt_lo)
-         ,.tl_data_mem_pkt_v_i(tl_data_mem_pkt_v_lo)
-         ,.tl_data_mem_pkt_ready_i(tl_data_mem_pkt_ready_li)
-
-         ,.mhu_idle_i(mhu_idle)
-
-         ,.mhu_data_mem_pkt_i(mhu_data_mem_pkt_lo)
-         ,.mhu_data_mem_pkt_v_i(mhu_data_mem_pkt_v_lo)
-         ,.mhu_data_mem_pkt_yumi_i(mhu_data_mem_pkt_yumi_li)
-
-         ,.miss_fifo_data_i(miss_fifo_data_li)
-         ,.miss_fifo_v_i(miss_fifo_v_li)
-         ,.miss_fifo_ready_i(miss_fifo_ready_lo)
-
-         ,.dma_pkt_i(dma_pkt_o)
-         ,.dma_pkt_v_i(dma_pkt_v_o)
-         ,.dma_pkt_yumi_i(dma_pkt_yumi_i)
-
+         .*
+         ,.replacement_dirty(mhu0.replacement_dirty)
+         ,.replacement_valid(mhu0.replacement_valid)
          ,.global_ctr_i($root.manycore_tb_top.global_ctr)
          ,.print_stat_v_i($root.manycore_tb_top.print_stat_v_lo)
          ,.print_stat_tag_i($root.manycore_tb_top.print_stat_tag_lo)


### PR DESCRIPTION
* The manycore top level was renamed with the addition of ruche networks. This adapts to the naming change.
* The vcache profiler added new ports