### PR TITLE
Add support for ruche networks

### DIFF
--- a/hardware/hardware.mk
+++ b/hardware/hardware.mk
@@ -92,6 +92,7 @@ FPGA_IMAGE_VERSION     ?= 0.0.0
 # sim_filelist.mk. Each file adds to VSOURCES and VINCLUDES and depends on
 # BSG_MANYCORE_DIR
 include $(BSG_MANYCORE_DIR)/machines/arch_filelist.mk
+VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/bsg_manycore_network_cfg_pkg.v
 
 # So that we can limit tool-specific to a few specific spots we use VDEFINES,
 # VINCLUDES, and VSOURCES to hold lists of macros, include directores, and
@@ -260,15 +261,18 @@ $(BSG_MACHINE_PATH)/bsg_bladerunner_pkg.v: $(BSG_MACHINE_PATH)/bsg_bladerunner_c
 	@echo >> $@
 	@echo "package bsg_bladerunner_pkg;" >> $@
 	@echo >> $@
+	@echo "import bsg_manycore_network_cfg_pkg::*;" >> $@
+	@echo >> $@
 	@echo "parameter dpi_fifo_els_gp = $(CL_MANYCORE_IO_REMOTE_LOAD_CAP);" >> $@
 	@echo >> $@
 	@echo "parameter rom_width_gp = 32;" >> $@
 	@echo "parameter rom_els_gp = `wc -l < $<`;" >> $@
-	@echo "parameter bsg_machine_crossbar_network_gp = $(CL_MANYCORE_CROSSBAR_NETWORK);" >> $@
 	@echo "parameter bit [rom_width_gp-1:0] rom_arr_gp [rom_els_gp-1:0] = '{$(ROM_STR)};" >> $@
 	@echo "parameter num_tiles_y_gp = $(CL_MANYCORE_DIM_Y);" >> $@
 	@echo "parameter num_tiles_x_gp = $(CL_MANYCORE_DIM_X);" >> $@
 	@echo "parameter int hetero_type_vec_gp [0:(num_tiles_y_gp*num_tiles_x_gp)-1] = '{$(strip $(BSG_MACHINE_HETERO_TYPE_VEC))};" >> $@
+	@echo "parameter bsg_manycore_network_cfg_e bsg_manycore_network_cfg_p = $(BSG_MACHINE_NETWORK_CFG);" >> $@
+	@echo "parameter int bsg_ruche_factor_X_p = $(BSG_MACHINE_RUCHE_FACTOR_X);" >> $@
 	@echo >> $@
 	@echo "endpackage" >> $@
 	@echo >> $@

--- a/libraries/platforms/aws-fpga/hardware/bsg_manycore_wrapper_mesh.v
+++ b/libraries/platforms/aws-fpga/hardware/bsg_manycore_wrapper_mesh.v
@@ -58,7 +58,7 @@ module bsg_manycore_wrapper_mesh
   bsg_manycore_link_sif_s [num_tiles_x_p-1:0] io_link_sif_li;
   bsg_manycore_link_sif_s [num_tiles_x_p-1:0] io_link_sif_lo;
   
-  bsg_manycore #(
+  bsg_manycore_top_mesh #(
     .dmem_size_p(dmem_size_p)
     ,.icache_entries_p(icache_entries_p)
     ,.icache_tag_width_p(icache_tag_width_p)

--- a/machine.mk
+++ b/machine.mk
@@ -38,7 +38,7 @@ endif
 
 # To switch machines, simply switch the path of BSG_MACHINE_PATH to
 # another directory with a Makefile.machine.include file.
-BSG_MACHINE_PATH ?= $(BSG_F1_DIR)/machines/baseline_v0_32_16
+BSG_MACHINE_PATH ?= $(BSG_F1_DIR)/machines/timing_v1_16_8
 
 # Convert the machine path to an abspath
 override BSG_MACHINE_PATH := $(abspath $(BSG_MACHINE_PATH))

--- a/machines/16x8_fast_n_fake/Makefile.machine.include
+++ b/machines/16x8_fast_n_fake/Makefile.machine.include
@@ -64,7 +64,8 @@ BSG_MACHINE_NAME                      =BSG_Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHIN
 BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG:e_%=%)
 
 # Define network topology
-BSG_MACHINE_CROSSBAR_NETWORK =  0
+BSG_MACHINE_NETWORK_CFG              := e_network_mesh
+BSG_MACHINE_RUCHE_FACTOR_X           := 0
 
 # Define heterogeneous tile composition.
 # 0 is for Vanilla Core (RV32).

--- a/machines/4x4_blocking_vcache_f1_dram/Makefile.machine.include
+++ b/machines/4x4_blocking_vcache_f1_dram/Makefile.machine.include
@@ -64,7 +64,8 @@ BSG_MACHINE_NAME                      =BSG_Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHIN
 BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG:e_%=%)
 
 # Define network topology
-BSG_MACHINE_CROSSBAR_NETWORK =  0
+BSG_MACHINE_NETWORK_CFG              := e_network_mesh
+BSG_MACHINE_RUCHE_FACTOR_X           := 0
 
 # Define heterogeneous tile composition.
 # 0 is for Vanilla Core (RV32).

--- a/machines/4x4_blocking_vcache_f1_model/Makefile.machine.include
+++ b/machines/4x4_blocking_vcache_f1_model/Makefile.machine.include
@@ -64,7 +64,8 @@ BSG_MACHINE_NAME                      =BSG_Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHIN
 BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG:e_%=%)
 
 # Define network topology
-BSG_MACHINE_CROSSBAR_NETWORK =  0
+BSG_MACHINE_NETWORK_CFG              := e_network_mesh
+BSG_MACHINE_RUCHE_FACTOR_X           := 0
 
 # Define heterogeneous tile composition.
 # 0 is for Vanilla Core (RV32).

--- a/machines/4x4_fast_n_fake/Makefile.machine.include
+++ b/machines/4x4_fast_n_fake/Makefile.machine.include
@@ -64,10 +64,8 @@ BSG_MACHINE_NAME                      =BSG_Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHIN
 BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG:e_%=%)
 
 # Define network topology
-BSG_MACHINE_CROSSBAR_NETWORK =  0
-
-# Heterogeneous cores are not currently supported when
-# BSG_MACHINE_CROSSBAR_NETWORK == 1
+BSG_MACHINE_NETWORK_CFG              := e_network_mesh
+BSG_MACHINE_RUCHE_FACTOR_X           := 0
 
 # Define heterogeneous tile composition.
 # 0 is for Vanilla Core (RV32).

--- a/machines/8x4_blocking_dramsim3_hbm2_4gb/Makefile.machine.include
+++ b/machines/8x4_blocking_dramsim3_hbm2_4gb/Makefile.machine.include
@@ -64,7 +64,8 @@ BSG_MACHINE_NAME                      =BSG_Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHIN
 BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG:e_%=%)
 
 # Define network topology
-BSG_MACHINE_CROSSBAR_NETWORK =  0
+BSG_MACHINE_NETWORK_CFG              := e_network_mesh
+BSG_MACHINE_RUCHE_FACTOR_X           := 0
 
 # Define heterogeneous tile composition.
 # 0 is for Vanilla Core (RV32).

--- a/machines/baseline_v0_16_8/Makefile.machine.include
+++ b/machines/baseline_v0_16_8/Makefile.machine.include
@@ -64,7 +64,8 @@ BSG_MACHINE_NAME                      =BSG_Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHIN
 BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG:e_%=%)_crossbar
 
 # Define network topology
-BSG_MACHINE_CROSSBAR_NETWORK =  1
+BSG_MACHINE_NETWORK_CFG              := e_network_crossbar
+BSG_MACHINE_RUCHE_FACTOR_X           := 0
 
 # Define heterogeneous tile composition.
 # 0 is for Vanilla Core (RV32).

--- a/machines/baseline_v0_32_16/Makefile.machine.include
+++ b/machines/baseline_v0_32_16/Makefile.machine.include
@@ -64,7 +64,8 @@ BSG_MACHINE_NAME                      =BSG_Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHIN
 BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG:e_%=%)_crossbar
 
 # Define network topology
-BSG_MACHINE_CROSSBAR_NETWORK =  1
+BSG_MACHINE_NETWORK_CFG              := e_network_crossbar
+BSG_MACHINE_RUCHE_FACTOR_X           := 0
 
 # Define heterogeneous tile composition.
 # 0 is for Vanilla Core (RV32).

--- a/machines/baseline_v0_64_32/Makefile.machine.include
+++ b/machines/baseline_v0_64_32/Makefile.machine.include
@@ -64,7 +64,8 @@ BSG_MACHINE_NAME                      =BSG_Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHIN
 BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG:e_%=%)_crossbar
 
 # Define network topology
-BSG_MACHINE_CROSSBAR_NETWORK =  1
+BSG_MACHINE_NETWORK_CFG              := e_network_crossbar
+BSG_MACHINE_RUCHE_FACTOR_X           := 0
 
 # Define heterogeneous tile composition.
 # 0 is for Vanilla Core (RV32).

--- a/machines/baseline_v0_8_4/Makefile.machine.include
+++ b/machines/baseline_v0_8_4/Makefile.machine.include
@@ -64,7 +64,8 @@ BSG_MACHINE_NAME                      =BSG_Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHIN
 BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG:e_%=%)_crossbar
 
 # Define network topology
-BSG_MACHINE_CROSSBAR_NETWORK =  1
+BSG_MACHINE_NETWORK_CFG              := e_network_crossbar
+BSG_MACHINE_RUCHE_FACTOR_X           := 0
 
 # Define heterogeneous tile composition.
 # 0 is for Vanilla Core (RV32).

--- a/machines/timing_v0_16_8/Makefile.machine.include
+++ b/machines/timing_v0_16_8/Makefile.machine.include
@@ -76,7 +76,8 @@ BSG_MACHINE_NAME                      =BSG_Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHIN
 BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG:e_%=%)
 
 # Define network topology
-BSG_MACHINE_CROSSBAR_NETWORK =  0
+BSG_MACHINE_NETWORK_CFG              := e_network_mesh
+BSG_MACHINE_RUCHE_FACTOR_X           := 0
 
 # Define heterogeneous tile composition.
 # 0 is for Vanilla Core (RV32).

--- a/machines/timing_v0_32_16/Makefile.machine.include
+++ b/machines/timing_v0_32_16/Makefile.machine.include
@@ -75,7 +75,8 @@ BSG_MACHINE_NAME                      =BSG_Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHIN
 BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG:e_%=%)
 
 # Define network topology
-BSG_MACHINE_CROSSBAR_NETWORK =  0
+BSG_MACHINE_NETWORK_CFG              := e_network_mesh
+BSG_MACHINE_RUCHE_FACTOR_X           := 0
 
 # Define heterogeneous tile composition.
 # 0 is for Vanilla Core (RV32).

--- a/machines/timing_v0_64_32/Makefile.machine.include
+++ b/machines/timing_v0_64_32/Makefile.machine.include
@@ -75,7 +75,8 @@ BSG_MACHINE_NAME                      =BSG_Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHIN
 BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG:e_%=%)
 
 # Define network topology
-BSG_MACHINE_CROSSBAR_NETWORK =  0
+BSG_MACHINE_NETWORK_CFG              := e_network_mesh
+BSG_MACHINE_RUCHE_FACTOR_X           := 0
 
 # Define heterogeneous tile composition.
 # 0 is for Vanilla Core (RV32).

--- a/machines/timing_v0_8_4/Makefile.machine.include
+++ b/machines/timing_v0_8_4/Makefile.machine.include
@@ -76,7 +76,8 @@ BSG_MACHINE_NAME                      =BSG_Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHIN
 BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG:e_%=%)
 
 # Define network topology
-BSG_MACHINE_CROSSBAR_NETWORK =  0
+BSG_MACHINE_NETWORK_CFG              := e_network_mesh
+BSG_MACHINE_RUCHE_FACTOR_X           := 0
 
 # Define heterogeneous tile composition.
 # 0 is for Vanilla Core (RV32).

--- a/machines/timing_v1_16_8/Makefile.machine.include
+++ b/machines/timing_v1_16_8/Makefile.machine.include
@@ -25,25 +25,38 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-BSG_MACHINE_GLOBAL_X                  = 4
-BSG_MACHINE_GLOBAL_Y                  = 5
-BSG_MACHINE_VCACHE_SET                = 64
+####################################################################################################################
+# TIMING_V0_16_8: this is a 16x8 array with v-caches on top and bottom (a “16x8 pod”).                             #
+# Each group of 16 v-caches is mapped to one channel.                                                              #
+# Each v-cache is mapped to a separate HBM bank.                                                                   #
+# There are two HBM channels.                                                                                      #
+# There is a ruche network with a ruche factor of 3                                                                #
+# This configuration should be the default for taking performance measurements and making decisions based on them. #
+####################################################################################################################
+
+# Specific to the HBM chip we're modeling
+__BSG_MACHINE_DRAMSIM3_CHIP_SIZE_IN_WORDS := $(shell echo 2^30 | bc) # 4GB
+__BSG_MACHINE_DRAMSIM3_CHIP_CH_SIZE_IN_WORDS := $(shell echo $(__BSG_MACHINE_DRAMSIM3_CHIP_SIZE_IN_WORDS)/8 | bc)
+
+BSG_MACHINE_GLOBAL_X                  = 16
+BSG_MACHINE_GLOBAL_Y                  = 9
+BSG_MACHINE_VCACHE_SET                = 16
 BSG_MACHINE_VCACHE_WAY                = 8
-BSG_MACHINE_VCACHE_BLOCK_SIZE_WORDS   = 8
+BSG_MACHINE_VCACHE_BLOCK_SIZE_WORDS   = 32
 BSG_MACHINE_VCACHE_STRIPE_SIZE_WORDS  = $(BSG_MACHINE_VCACHE_BLOCK_SIZE_WORDS)
 BSG_MACHINE_VCACHE_DMA_DATA_WIDTH     = 32
 BSG_MACHINE_VCACHE_MISS_FIFO_ELS      = 32
 BSG_MACHINE_DRAM_INCLUDED             = 1
 BSG_MACHINE_MAX_EPA_WIDTH             = 28
+BSG_MACHINE_DRAM_CHANNELS             = 2
 
 # IO flow control parameters.
 # max host loads; max host request credits; max out credits of manycore endpoint standard module
 BSG_MACHINE_IO_REMOTE_LOAD_CAP        = 32
 BSG_MACHINE_IO_HOST_CREDITS_CAP       = 256
 BSG_MACHINE_IO_EP_MAX_OUT_CREDITS     = 16
-BSG_MACHINE_DRAM_SIZE_WORDS           = 134217728
-BSG_MACHINE_DRAM_BANK_SIZE_WORDS      =  16777216
-
+BSG_MACHINE_DRAM_SIZE_WORDS           := $(shell echo $(__BSG_MACHINE_DRAMSIM3_CHIP_CH_SIZE_IN_WORDS)*$(BSG_MACHINE_DRAM_CHANNELS) | bc)
+BSG_MACHINE_DRAM_BANK_SIZE_WORDS      := $(shell echo $(BSG_MACHINE_DRAM_SIZE_WORDS)/$(BSG_MACHINE_GLOBAL_X)/2 | bc)
 BSG_MACHINE_DATA_WIDTH                = 32
 
 # This flag has to be always 0 by default. Conditional
@@ -57,15 +70,15 @@ CL_MANYCORE_DIM_X                    := $(BSG_MACHINE_GLOBAL_X)
 CL_MANYCORE_DIM_Y                    := $(shell expr $(BSG_MACHINE_GLOBAL_Y) - 1)
 
 CL_MANYCORE_MEM_CFG                  := e_vcache_blocking_test_dramsim3_hbm2_4gb_x128
-CL_MANYCORE_DRAM_CHANNELS	     := 1
+CL_MANYCORE_DRAM_CHANNELS	     := $(BSG_MACHINE_DRAM_CHANNELS)
 
 # Define BSG_MACHINE_NAME using the Y and X dimensions, and CL_MANYCORE_MEM_CFG
 BSG_MACHINE_NAME                      =BSG_Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHINE_GLOBAL_X)
 BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG:e_%=%)
 
 # Define network topology
-BSG_MACHINE_NETWORK_CFG              := e_network_mesh
-BSG_MACHINE_RUCHE_FACTOR_X           := 0
+BSG_MACHINE_NETWORK_CFG              := e_network_half_ruche_x
+BSG_MACHINE_RUCHE_FACTOR_X           := 3
 
 # Define heterogeneous tile composition.
 # 0 is for Vanilla Core (RV32).

--- a/machines/timing_v1_32_16/Makefile.machine.include
+++ b/machines/timing_v1_32_16/Makefile.machine.include
@@ -25,25 +25,37 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-BSG_MACHINE_GLOBAL_X                  = 4
-BSG_MACHINE_GLOBAL_Y                  = 5
-BSG_MACHINE_VCACHE_SET                = 64
+###########################################################################################
+# TIMING_V1_32_16: this is a 32x16 array with v-caches on top and bottom (a “32x16 pod”). #
+# Each group of 16 v-caches is mapped to one channel.                                     #
+# Each v-cache is mapped to a separate HBM bank.                                          #
+# There are four HBM channels.                                                            #
+# There is a ruche network with a ruche factor of 3                                       #
+###########################################################################################
+
+# Specific to the HBM chip we're modeling
+__BSG_MACHINE_DRAMSIM3_CHIP_SIZE_IN_WORDS := $(shell echo 2^30 | bc) # 4GB
+__BSG_MACHINE_DRAMSIM3_CHIP_CH_SIZE_IN_WORDS := $(shell echo $(__BSG_MACHINE_DRAMSIM3_CHIP_SIZE_IN_WORDS)/8 | bc)
+
+BSG_MACHINE_GLOBAL_X                  = 32
+BSG_MACHINE_GLOBAL_Y                  = 17
+BSG_MACHINE_VCACHE_SET                = 16
 BSG_MACHINE_VCACHE_WAY                = 8
-BSG_MACHINE_VCACHE_BLOCK_SIZE_WORDS   = 8
+BSG_MACHINE_VCACHE_BLOCK_SIZE_WORDS   = 32
 BSG_MACHINE_VCACHE_STRIPE_SIZE_WORDS  = $(BSG_MACHINE_VCACHE_BLOCK_SIZE_WORDS)
 BSG_MACHINE_VCACHE_DMA_DATA_WIDTH     = 32
 BSG_MACHINE_VCACHE_MISS_FIFO_ELS      = 32
 BSG_MACHINE_DRAM_INCLUDED             = 1
 BSG_MACHINE_MAX_EPA_WIDTH             = 28
+BSG_MACHINE_DRAM_CHANNELS             = 4
 
 # IO flow control parameters.
 # max host loads; max host request credits; max out credits of manycore endpoint standard module
 BSG_MACHINE_IO_REMOTE_LOAD_CAP        = 32
 BSG_MACHINE_IO_HOST_CREDITS_CAP       = 256
 BSG_MACHINE_IO_EP_MAX_OUT_CREDITS     = 16
-BSG_MACHINE_DRAM_SIZE_WORDS           = 134217728
-BSG_MACHINE_DRAM_BANK_SIZE_WORDS      =  16777216
-
+BSG_MACHINE_DRAM_SIZE_WORDS           := $(shell echo $(__BSG_MACHINE_DRAMSIM3_CHIP_CH_SIZE_IN_WORDS)*$(BSG_MACHINE_DRAM_CHANNELS) | bc)
+BSG_MACHINE_DRAM_BANK_SIZE_WORDS      := $(shell echo $(BSG_MACHINE_DRAM_SIZE_WORDS)/$(BSG_MACHINE_GLOBAL_X)/2 | bc)
 BSG_MACHINE_DATA_WIDTH                = 32
 
 # This flag has to be always 0 by default. Conditional
@@ -57,15 +69,15 @@ CL_MANYCORE_DIM_X                    := $(BSG_MACHINE_GLOBAL_X)
 CL_MANYCORE_DIM_Y                    := $(shell expr $(BSG_MACHINE_GLOBAL_Y) - 1)
 
 CL_MANYCORE_MEM_CFG                  := e_vcache_blocking_test_dramsim3_hbm2_4gb_x128
-CL_MANYCORE_DRAM_CHANNELS	     := 1
+CL_MANYCORE_DRAM_CHANNELS	     := $(BSG_MACHINE_DRAM_CHANNELS)
 
 # Define BSG_MACHINE_NAME using the Y and X dimensions, and CL_MANYCORE_MEM_CFG
 BSG_MACHINE_NAME                      =BSG_Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHINE_GLOBAL_X)
 BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG:e_%=%)
 
 # Define network topology
-BSG_MACHINE_NETWORK_CFG              := e_network_mesh
-BSG_MACHINE_RUCHE_FACTOR_X           := 0
+BSG_MACHINE_NETWORK_CFG              := e_network_half_ruche_x
+BSG_MACHINE_RUCHE_FACTOR_X           := 3
 
 # Define heterogeneous tile composition.
 # 0 is for Vanilla Core (RV32).

--- a/machines/timing_v1_8_4/Makefile.machine.include
+++ b/machines/timing_v1_8_4/Makefile.machine.include
@@ -25,25 +25,38 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-BSG_MACHINE_GLOBAL_X                  = 4
+############################################################################################
+# TIMING_V1_8_4: this is a 8x4 array with v-caches on top and bottom (a “8x4 pod”).        #
+# Each v-cache is mapped to a separate HBM bank.                                           #
+# There is one HBM channel.                                                                #
+# There is a ruche network with a ruche factor of 3                                        #
+# This is probably not a sensible configuration, as the tile to channel ratio is very low. #
+# But for memory bound benchmarks, it may be reasonable to use for iteration.              #
+############################################################################################
+
+# Specific to the HBM chip we're modeling
+__BSG_MACHINE_DRAMSIM3_CHIP_SIZE_IN_WORDS := $(shell echo 2^30 | bc) # 4GB
+__BSG_MACHINE_DRAMSIM3_CHIP_CH_SIZE_IN_WORDS := $(shell echo $(__BSG_MACHINE_DRAMSIM3_CHIP_SIZE_IN_WORDS)/8 | bc)
+
+BSG_MACHINE_GLOBAL_X                  = 8
 BSG_MACHINE_GLOBAL_Y                  = 5
-BSG_MACHINE_VCACHE_SET                = 64
+BSG_MACHINE_VCACHE_SET                = 16
 BSG_MACHINE_VCACHE_WAY                = 8
-BSG_MACHINE_VCACHE_BLOCK_SIZE_WORDS   = 8
+BSG_MACHINE_VCACHE_BLOCK_SIZE_WORDS   = 32
 BSG_MACHINE_VCACHE_STRIPE_SIZE_WORDS  = $(BSG_MACHINE_VCACHE_BLOCK_SIZE_WORDS)
 BSG_MACHINE_VCACHE_DMA_DATA_WIDTH     = 32
 BSG_MACHINE_VCACHE_MISS_FIFO_ELS      = 32
 BSG_MACHINE_DRAM_INCLUDED             = 1
 BSG_MACHINE_MAX_EPA_WIDTH             = 28
+BSG_MACHINE_DRAM_CHANNELS             = 1
 
 # IO flow control parameters.
 # max host loads; max host request credits; max out credits of manycore endpoint standard module
 BSG_MACHINE_IO_REMOTE_LOAD_CAP        = 32
 BSG_MACHINE_IO_HOST_CREDITS_CAP       = 256
 BSG_MACHINE_IO_EP_MAX_OUT_CREDITS     = 16
-BSG_MACHINE_DRAM_SIZE_WORDS           = 134217728
-BSG_MACHINE_DRAM_BANK_SIZE_WORDS      =  16777216
-
+BSG_MACHINE_DRAM_SIZE_WORDS           := $(shell echo $(__BSG_MACHINE_DRAMSIM3_CHIP_CH_SIZE_IN_WORDS)*$(BSG_MACHINE_DRAM_CHANNELS) | bc)
+BSG_MACHINE_DRAM_BANK_SIZE_WORDS      := $(shell echo $(BSG_MACHINE_DRAM_SIZE_WORDS)/$(BSG_MACHINE_GLOBAL_X)/2 | bc)
 BSG_MACHINE_DATA_WIDTH                = 32
 
 # This flag has to be always 0 by default. Conditional
@@ -57,15 +70,16 @@ CL_MANYCORE_DIM_X                    := $(BSG_MACHINE_GLOBAL_X)
 CL_MANYCORE_DIM_Y                    := $(shell expr $(BSG_MACHINE_GLOBAL_Y) - 1)
 
 CL_MANYCORE_MEM_CFG                  := e_vcache_blocking_test_dramsim3_hbm2_4gb_x128
-CL_MANYCORE_DRAM_CHANNELS	     := 1
+CL_MANYCORE_DRAM_CHANNELS	     := $(BSG_MACHINE_DRAM_CHANNELS)
 
 # Define BSG_MACHINE_NAME using the Y and X dimensions, and CL_MANYCORE_MEM_CFG
 BSG_MACHINE_NAME                      =BSG_Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHINE_GLOBAL_X)
 BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG:e_%=%)
 
 # Define network topology
-BSG_MACHINE_NETWORK_CFG              := e_network_mesh
-BSG_MACHINE_RUCHE_FACTOR_X           := 0
+BSG_MACHINE_NETWORK_CFG              := e_network_half_ruche_x
+BSG_MACHINE_RUCHE_FACTOR_X           := 3
+
 
 # Define heterogeneous tile composition.
 # 0 is for Vanilla Core (RV32).


### PR DESCRIPTION
* Renamed bsg_manycore to bsg_manycore_top_mesh
* Added network config package feature
* Added ruche network machines


Think of this as half a PR. This adds ruche networks (and they work!) but it's not as clean as I'd like. Makefile.machine.include files have a lot of parameters, and we need to add infinite memory ruche networks.

Since we're adding new machine parameters in [#447](https://github.com/bespoke-silicon-group/bsg_manycore/pull/447), and in this PR, and looking ahead to BP integration, and other top levels - I pushed a clean up of the machine files into my next PR. 

