### PR TITLE
Move epa_check_alignment from bsg_manycore.cpp into bsg_manycore_epa.h

### DIFF
--- a/libraries/bsg_manycore.cpp
+++ b/libraries/bsg_manycore.cpp
@@ -55,7 +55,7 @@
 #define sarray_size(x)                          \
         ((ssize_t)array_size(x))
 
-/* these are conveniance macros that are only good for one line prints */
+/* these are convenience macros that are only good for one line prints */
 #define manycore_pr_dbg(mc, fmt, ...)                   \
         bsg_pr_dbg("%s: " fmt, mc->name, ##__VA_ARGS__)
 
@@ -651,32 +651,6 @@ int hb_mc_manycore_flush_vcache(hb_mc_manycore_t *mc)
 ////////////////
 // Memory API //
 ////////////////
-
-/**
- * Checks alignment of an epa based on data size in bytes.
- * @param[in] epa  epa address
- * @param[in] sz   data size in bytes.
- * @return         HB_MC_SUCCESS if npa is aligned and HB_MC_UNALIGNED if not,
- *                 and HB_MC_INVALID otherwise.
- */
-static inline int hb_mc_manycore_epa_check_alignment(const hb_mc_epa_t *epa, size_t sz)
-{
-        switch (sz) {
-        case 4:
-                if (*epa & 0x3)
-                        return HB_MC_UNALIGNED;
-                break;
-        case 2:
-                if (*epa & 0x1)
-                        return HB_MC_UNALIGNED;
-                break;
-        case 1:
-                break;
-        default:
-                return HB_MC_INVALID;
-        }
-        return HB_MC_SUCCESS;
-}
 
 /* send a read request and don't wait for the return packet */
 static int hb_mc_manycore_send_read_rqst(hb_mc_manycore_t *mc,

--- a/libraries/bsg_manycore_epa.cpp
+++ b/libraries/bsg_manycore_epa.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, University of Washington All rights reserved.
+// Copyright (c) 2021, University of Washington All rights reserved.
 // 
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -25,45 +25,33 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#ifndef BSG_MANYCORE_EPA_H
-#define BSG_MANYCORE_EPA_H
 #include <bsg_manycore_features.h>
-
-#ifdef __cplusplus
-#include <cstdint>
+#include <bsg_manycore_epa.h>
 #include <cstddef>
-#else
-#include <stdint.h>
-#include <stddef.h>
-#endif
+#include <bsg_manycore_errno.h>
 
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-        /**
-         * An Endpoint Physical Address. This type uniquely identifies a physical
-         * memory address within a manycore endpoint. It is a byte address.
-         */
-        typedef uint32_t hb_mc_epa_t;
-        typedef hb_mc_epa_t epa_t;
-
-        /**
-         * Checks alignment of an epa based on data size in bytes.
-         * @param[in] epa  epa address
-         * @param[in] sz   data size in bytes.
-         * @return         HB_MC_SUCCESS if npa is aligned and HB_MC_UNALIGNED if not,
-         *                 and HB_MC_INVALID otherwise.
-         */
-        int hb_mc_manycore_epa_check_alignment(const hb_mc_epa_t *epa, size_t sz);
-
-#define HB_MC_EPA_LOGSZ 18
-
-#define EPA_FROM_BASE_AND_OFFSET(base, offset)  \
-        (((base)+(offset)))
-
-#ifdef __cplusplus
-};
-#endif
-#endif
+/**
+ * Checks alignment of an epa based on data size in bytes.
+ * @param[in] epa  epa address
+ * @param[in] sz   data size in bytes.
+ * @return         HB_MC_SUCCESS if npa is aligned and HB_MC_UNALIGNED if not,
+ *                 and HB_MC_INVALID otherwise.
+ */
+int hb_mc_manycore_epa_check_alignment(const hb_mc_epa_t *epa, size_t sz)
+{
+        switch (sz) {
+        case 4:
+                if (*epa & 0x3)
+                        return HB_MC_UNALIGNED;
+                break;
+        case 2:
+                if (*epa & 0x1)
+                        return HB_MC_UNALIGNED;
+                break;
+        case 1:
+                break;
+        default:
+                return HB_MC_INVALID;
+        }
+        return HB_MC_SUCCESS;
+}

--- a/libraries/bsg_manycore_epa.h
+++ b/libraries/bsg_manycore_epa.h
@@ -28,7 +28,8 @@
 #ifndef BSG_MANYCORE_EPA_H
 #define BSG_MANYCORE_EPA_H
 #include <bsg_manycore_features.h>
-
+#include <bsg_manycore_errno.h>
+#include <cstddef>
 #ifdef __cplusplus
 #include <cstdint>
 #else
@@ -45,6 +46,32 @@ extern "C" {
          */
         typedef uint32_t hb_mc_epa_t;
         typedef hb_mc_epa_t epa_t;
+
+/**
+ * Checks alignment of an epa based on data size in bytes.
+ * @param[in] epa  epa address
+ * @param[in] sz   data size in bytes.
+ * @return         HB_MC_SUCCESS if npa is aligned and HB_MC_UNALIGNED if not,
+ *                 and HB_MC_INVALID otherwise.
+ */
+static inline int hb_mc_manycore_epa_check_alignment(const hb_mc_epa_t *epa, size_t sz)
+{
+        switch (sz) {
+        case 4:
+                if (*epa & 0x3)
+                        return HB_MC_UNALIGNED;
+                break;
+        case 2:
+                if (*epa & 0x1)
+                        return HB_MC_UNALIGNED;
+                break;
+        case 1:
+                break;
+        default:
+                return HB_MC_INVALID;
+        }
+        return HB_MC_SUCCESS;
+}
 
 #define HB_MC_EPA_LOGSZ 18
 

--- a/libraries/libraries.mk
+++ b/libraries/libraries.mk
@@ -31,6 +31,7 @@ __BSG_LIBRARIES_MK := 1
 LIB_CSOURCES   += 
 LIB_CSOURCES   += $(LIBRARIES_PATH)/bsg_manycore_memsys.c
 LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore.cpp
+LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_epa.cpp
 LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_bits.cpp
 LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_config.cpp
 LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_cuda.cpp


### PR DESCRIPTION
Super useful when writing a DPI tile. Also, just generally useful when checking addresses.