### PR TITLE
Add parameter to disable profilers

### DIFF
--- a/hardware/hardware.mk
+++ b/hardware/hardware.mk
@@ -280,6 +280,7 @@ $(BSG_MACHINE_PATH)/bsg_bladerunner_pkg.v: $(BSG_MACHINE_PATH)/bsg_bladerunner_c
 	@echo "parameter bsg_machine_noc_y_max_gp = bsg_machine_core_y_global_max_gp + 2; // Caches on both sides" >> $@
 	@echo "parameter bsg_machine_noc_x_coord_width_gp = \`BSG_SAFE_CLOG2(bsg_machine_noc_x_max_gp);" >> $@
 	@echo "parameter bsg_machine_noc_y_coord_width_gp = \`BSG_SAFE_CLOG2(bsg_machine_noc_y_max_gp);" >> $@
+	@echo "parameter bsg_machine_noinst_profilers_gp = $(BSG_MACHINE_NOINST_PROFILERS);" >> $@
 	@echo >> $@
 	@echo "endpackage" >> $@
 	@echo >> $@

--- a/libraries/platforms/aws-vcs/library.mk
+++ b/libraries/platforms/aws-vcs/library.mk
@@ -38,8 +38,17 @@ include $(CL_DIR)/hdk.mk
 PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/platforms/aws-vcs/bsg_manycore_mmio.cpp
 PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/platforms/aws-fpga/bsg_manycore_platform.cpp
 PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/platforms/aws-vcs/bsg_manycore_platform.cpp
+
+# If the machine does not instantiate profilers, then include the "noimpl" source files
+# This is necessary for SAIF file generation, and DPI Tile/Network simulations
+# This parameter is set in Makefile.machine.include
+ifneq ($(BSG_MACHINE_NOINST_PROFILERS),0)
+PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/features/profiler/noimpl/bsg_manycore_profiler.cpp
+PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/features/tracer/noimpl/bsg_manycore_tracer.cpp
+else
 PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/features/profiler/simulation/bsg_manycore_profiler.cpp
 PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/features/tracer/simulation/bsg_manycore_tracer.cpp
+endif
 
 # aws-fpga does not provide a DMA feature. Therefore, we use the fragment in 
 # features/dma/noimpl/feature.mk that simply returns

--- a/libraries/platforms/dpi-vcs/library.mk
+++ b/libraries/platforms/dpi-vcs/library.mk
@@ -30,8 +30,16 @@ PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/platforms/dpi-verilator/bsg_manycore_pl
 
 PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/platforms/dpi-vcs/bsg_manycore_simulator.cpp
 
+# If the machine does not instantiate profilers, then include the "noimpl" source files
+# This is necessary for SAIF file generation, and DPI Tile/Network simulations
+# This parameter is set in Makefile.machine.include
+ifneq ($(BSG_MACHINE_NOINST_PROFILERS),0)
+PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/features/profiler/noimpl/bsg_manycore_profiler.cpp
+PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/features/tracer/noimpl/bsg_manycore_tracer.cpp
+else
 PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/features/profiler/simulation/bsg_manycore_profiler.cpp
 PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/features/tracer/simulation/bsg_manycore_tracer.cpp
+endif
 
 # The aws-vcs platform supports simulation DMA on certain
 # machines. Support is determined by the memory system configuration

--- a/libraries/platforms/dpi-verilator/bsg_manycore_platform.cpp
+++ b/libraries/platforms/dpi-verilator/bsg_manycore_platform.cpp
@@ -231,14 +231,20 @@ int hb_mc_platform_init(hb_mc_manycore_t *mc, hb_mc_manycore_id_t id)
         hb_mc_platform_get_config_at(mc, HB_MC_CONFIG_DEVICE_DIM_Y, &rd);
         y = rd;
         err = hb_mc_profiler_init(&(platform->prof), x, y, profiler);
-        if (err != HB_MC_SUCCESS){
+        if (err == HB_MC_NOIMPL){
+                manycore_pr_warn(mc, "Profiler init returned HB_MC_NOIMPL "
+                                 "(This can happen with SAIF generation, or DPI tile.)\n");
+        } else if (err != HB_MC_SUCCESS){
                 hb_mc_platform_dpi_cleanup(platform);
                 delete platform;
                 return err;
         }
 
         err = hb_mc_tracer_init(&(platform->tracer), hierarchy);
-        if (err != HB_MC_SUCCESS){
+        if (err == HB_MC_NOIMPL){
+                manycore_pr_warn(mc, "Tracer init returned HB_MC_NOIMPL "
+                                 "(This can happen with SAIF generation, or DPI tile.)\n");
+        } else if (err != HB_MC_SUCCESS){
                 hb_mc_profiler_cleanup(&(platform->prof));
                 hb_mc_platform_dpi_cleanup(platform);
                 delete platform;

--- a/libraries/platforms/dpi-verilator/hardware/dpi_top.sv
+++ b/libraries/platforms/dpi-verilator/hardware/dpi_top.sv
@@ -37,6 +37,8 @@ module manycore_tb_top
       $display("[INFO][TESTBENCH] bsg_machine_dram_num_channels_gp      = %d", bsg_machine_dram_num_channels_gp);
       $display("[INFO][TESTBENCH] bsg_machine_dram_cfg_gp               = %s", bsg_machine_dram_cfg_gp.name());
       
+      $display("[INFO][TESTBENCH] bsg_machine_noinst_profilers_gp       = %s", bsg_machine_noinst_profilers_gp);
+
       $display("[INFO][TESTBENCH] bsg_machine_num_cores_x_gp            = %d", bsg_machine_num_cores_x_gp);
       $display("[INFO][TESTBENCH] bsg_machine_num_cores_y_gp            = %d", bsg_machine_num_cores_y_gp);
    end
@@ -483,40 +485,40 @@ module manycore_tb_top
   end
 
    // Manycore Profiling, Trace, and Debug Infrastructure
+   if(!bsg_machine_noinst_profilers_gp) begin
+      bind vanilla_core vanilla_core_trace
+        #(// Reminder: parameters are scoped to the bind target, not in the scope of the declaration!
+          .x_cord_width_p(x_cord_width_p)
+          ,.y_cord_width_p(y_cord_width_p)
+          ,.icache_tag_width_p(icache_tag_width_p)
+          ,.icache_entries_p(icache_entries_p)
+          ,.data_width_p(data_width_p)
+          ,.dmem_size_p(dmem_size_p)
+          )
+      vtrace
+        (
+         .*
+         ,.trace_en_i($root.manycore_tb_top.log_en));
 
-   bind vanilla_core vanilla_core_trace
-     #(// Reminder: parameters are scoped to the bind target, not in the scope of the declaration!
-       .x_cord_width_p(x_cord_width_p)
-       ,.y_cord_width_p(y_cord_width_p)
-       ,.icache_tag_width_p(icache_tag_width_p)
-       ,.icache_entries_p(icache_entries_p)
-       ,.data_width_p(data_width_p)
-       ,.dmem_size_p(dmem_size_p)
-       )
-   vtrace
-     (
-      .*
-      ,.trace_en_i($root.manycore_tb_top.log_en));
-
-   bind vanilla_core vanilla_core_profiler
-     #(// Reminder: parameters are scoped to the bind target, not in the scope of the declaration!
-       .x_cord_width_p(x_cord_width_p)
-       ,.y_cord_width_p(y_cord_width_p)
-       ,.origin_x_cord_p(`BSG_MACHINE_ORIGIN_COORD_X)
-       ,.origin_y_cord_p(`BSG_MACHINE_ORIGIN_COORD_Y)
-       ,.icache_tag_width_p(icache_tag_width_p)
-       ,.icache_entries_p(icache_entries_p)
-       ,.data_width_p(data_width_p)
-       )
-   vcore_prof
-     (
-      .*
-      ,.global_ctr_i($root.manycore_tb_top.global_ctr)
-      ,.print_stat_v_i($root.manycore_tb_top.print_stat_v_lo)
-      ,.print_stat_tag_i($root.manycore_tb_top.print_stat_tag_lo)
-      ,.trace_en_i($root.manycore_tb_top.trace_en)
-      );
-
+      bind vanilla_core vanilla_core_profiler
+        #(// Reminder: parameters are scoped to the bind target, not in the scope of the declaration!
+          .x_cord_width_p(x_cord_width_p)
+          ,.y_cord_width_p(y_cord_width_p)
+          ,.origin_x_cord_p(`BSG_MACHINE_ORIGIN_COORD_X)
+          ,.origin_y_cord_p(`BSG_MACHINE_ORIGIN_COORD_Y)
+          ,.icache_tag_width_p(icache_tag_width_p)
+          ,.icache_entries_p(icache_entries_p)
+          ,.data_width_p(data_width_p)
+          )
+      vcore_prof
+        (
+         .*
+         ,.global_ctr_i($root.manycore_tb_top.global_ctr)
+         ,.print_stat_v_i($root.manycore_tb_top.print_stat_v_lo)
+         ,.print_stat_tag_i($root.manycore_tb_top.print_stat_tag_lo)
+         ,.trace_en_i($root.manycore_tb_top.trace_en)
+         );
+   end
 
 
    // --------------------------------------------------------------------------

--- a/libraries/platforms/dpi-verilator/library.mk
+++ b/libraries/platforms/dpi-verilator/library.mk
@@ -31,8 +31,17 @@
 # handles DPI-based MMIO.
 PLATFORM_CXXSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_dpi_clock_gen.cpp
 PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/platforms/dpi-verilator/bsg_manycore_platform.cpp
+
+# If the machine does not instantiate profilers, then include the "noimpl" source files
+# This is necessary for SAIF file generation, and DPI Tile/Network simulations
+# This parameter is set in Makefile.machine.include
+ifneq ($(BSG_MACHINE_NOINST_PROFILERS),0)
+PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/features/profiler/noimpl/bsg_manycore_profiler.cpp
+PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/features/tracer/noimpl/bsg_manycore_tracer.cpp
+else
 PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/features/profiler/simulation/bsg_manycore_profiler.cpp
 PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/features/tracer/simulation/bsg_manycore_tracer.cpp
+endif
 
 # The aws-vcs platform supports simulation DMA on certain
 # machines. Support is determined by the memory system configuration

--- a/machines/4x4_blocking_vcache_f1_model/Makefile.machine.include
+++ b/machines/4x4_blocking_vcache_f1_model/Makefile.machine.include
@@ -71,6 +71,9 @@ BSG_MACHINE_IO_EP_CREDITS             = 16
 BSG_MACHINE_IO_HOST_CREDITS           = $(BSG_MACHINE_IO_EP_CREDITS)
 BSG_MACHINE_IO_REMOTE_LOAD_CAP        = $(BSG_MACHINE_IO_EP_CREDITS)
 
+# (Don't) Instantiate Profilers (needed for SAIF generation, DPI Tile)
+BSG_MACHINE_NOINST_PROFILERS          = 0
+
 ##################### Constants and Computations #####################
 
 BSG_MACHINE_NUM_VCACHE               := $(shell echo $(BSG_MACHINE_NUM_CORES_X)*2 | bc)

--- a/machines/baseline_16_8/Makefile.machine.include
+++ b/machines/baseline_16_8/Makefile.machine.include
@@ -55,6 +55,9 @@ BSG_MACHINE_IO_EP_CREDITS             = 16
 BSG_MACHINE_IO_HOST_CREDITS           = $(BSG_MACHINE_IO_EP_CREDITS)
 BSG_MACHINE_IO_REMOTE_LOAD_CAP        = $(BSG_MACHINE_IO_EP_CREDITS)
 
+# (Don't) Instantiate Profilers (needed for SAIF generation, DPI Tile)
+BSG_MACHINE_NOINST_PROFILERS          = 0
+
 ##################### Constants and Computations #####################
 # Cannot be changed for xbar networks:
 BSG_MACHINE_HETERO_TYPE_VEC           = default:0

--- a/machines/baseline_32_16/Makefile.machine.include
+++ b/machines/baseline_32_16/Makefile.machine.include
@@ -55,6 +55,9 @@ BSG_MACHINE_IO_EP_CREDITS             = 16
 BSG_MACHINE_IO_HOST_CREDITS           = $(BSG_MACHINE_IO_EP_CREDITS)
 BSG_MACHINE_IO_REMOTE_LOAD_CAP        = $(BSG_MACHINE_IO_EP_CREDITS)
 
+# (Don't) Instantiate Profilers (needed for SAIF generation, DPI Tile)
+BSG_MACHINE_NOINST_PROFILERS          = 0
+
 ##################### Constants and Computations #####################
 # Cannot be changed for xbar networks:
 BSG_MACHINE_HETERO_TYPE_VEC           = default:0

--- a/machines/baseline_8_4/Makefile.machine.include
+++ b/machines/baseline_8_4/Makefile.machine.include
@@ -55,6 +55,9 @@ BSG_MACHINE_IO_EP_CREDITS             = 16
 BSG_MACHINE_IO_HOST_CREDITS           = $(BSG_MACHINE_IO_EP_CREDITS)
 BSG_MACHINE_IO_REMOTE_LOAD_CAP        = $(BSG_MACHINE_IO_EP_CREDITS)
 
+# (Don't) Instantiate Profilers (needed for SAIF generation, DPI Tile)
+BSG_MACHINE_NOINST_PROFILERS          = 0
+
 ##################### Constants and Computations #####################
 # Cannot be changed for xbar networks:
 BSG_MACHINE_HETERO_TYPE_VEC           = default:0

--- a/machines/infinite_mesh_16_8/Makefile.machine.include
+++ b/machines/infinite_mesh_16_8/Makefile.machine.include
@@ -61,6 +61,9 @@ BSG_MACHINE_IO_EP_CREDITS             = 16
 BSG_MACHINE_IO_HOST_CREDITS           = $(BSG_MACHINE_IO_EP_CREDITS)
 BSG_MACHINE_IO_REMOTE_LOAD_CAP        = $(BSG_MACHINE_IO_EP_CREDITS)
 
+# (Don't) Instantiate Profilers (needed for SAIF generation, DPI Tile)
+BSG_MACHINE_NOINST_PROFILERS          = 0
+
 ##################### Constants and Computations #####################
 # Every cache is replaced with an infinite memory channel
 BSG_MACHINE_NUM_VCACHE               := $(shell echo $(BSG_MACHINE_NUM_CORES_X)*2 | bc)

--- a/machines/infinite_mesh_32_16/Makefile.machine.include
+++ b/machines/infinite_mesh_32_16/Makefile.machine.include
@@ -61,6 +61,9 @@ BSG_MACHINE_IO_EP_CREDITS             = 16
 BSG_MACHINE_IO_HOST_CREDITS           = $(BSG_MACHINE_IO_EP_CREDITS)
 BSG_MACHINE_IO_REMOTE_LOAD_CAP        = $(BSG_MACHINE_IO_EP_CREDITS)
 
+# (Don't) Instantiate Profilers (needed for SAIF generation, DPI Tile)
+BSG_MACHINE_NOINST_PROFILERS          = 0
+
 ##################### Constants and Computations #####################
 # Every cache is replaced with an infinite memory channel
 BSG_MACHINE_NUM_VCACHE               := $(shell echo $(BSG_MACHINE_NUM_CORES_X)*2 | bc)

--- a/machines/infinite_mesh_4_4/Makefile.machine.include
+++ b/machines/infinite_mesh_4_4/Makefile.machine.include
@@ -61,6 +61,9 @@ BSG_MACHINE_IO_EP_CREDITS             = 16
 BSG_MACHINE_IO_HOST_CREDITS           = $(BSG_MACHINE_IO_EP_CREDITS)
 BSG_MACHINE_IO_REMOTE_LOAD_CAP        = $(BSG_MACHINE_IO_EP_CREDITS)
 
+# (Don't) Instantiate Profilers (needed for SAIF generation, DPI Tile)
+BSG_MACHINE_NOINST_PROFILERS          = 0
+
 ##################### Constants and Computations #####################
 # Every cache is replaced with an infinite memory channel
 BSG_MACHINE_NUM_VCACHE               := $(shell echo $(BSG_MACHINE_NUM_CORES_X)*2 | bc)

--- a/machines/infinite_mesh_8_4/Makefile.machine.include
+++ b/machines/infinite_mesh_8_4/Makefile.machine.include
@@ -61,6 +61,9 @@ BSG_MACHINE_IO_EP_CREDITS             = 16
 BSG_MACHINE_IO_HOST_CREDITS           = $(BSG_MACHINE_IO_EP_CREDITS)
 BSG_MACHINE_IO_REMOTE_LOAD_CAP        = $(BSG_MACHINE_IO_EP_CREDITS)
 
+# (Don't) Instantiate Profilers (needed for SAIF generation, DPI Tile)
+BSG_MACHINE_NOINST_PROFILERS          = 0
+
 ##################### Constants and Computations #####################
 # Every cache is replaced with an infinite memory channel
 BSG_MACHINE_NUM_VCACHE               := $(shell echo $(BSG_MACHINE_NUM_CORES_X)*2 | bc)

--- a/machines/infinite_mesh_8_4_networksim/Makefile.machine.include
+++ b/machines/infinite_mesh_8_4_networksim/Makefile.machine.include
@@ -28,14 +28,14 @@
 # Change these parameters to define your machine. All other parameters should remain constant.
 
 # Manycore X/Y dimensions
-BSG_MACHINE_NUM_CORES_X               = 4
+BSG_MACHINE_NUM_CORES_X               = 8
 BSG_MACHINE_NUM_CORES_Y               = 4
 
 # Heterogeneous tile composition. Must be a 1-d array equal to the
 # number of tiles, or shorthand (default:0)
 # 0 is for Vanilla Core (RV32).
 # Anything else should be described here :)
-BSG_MACHINE_HETERO_TYPE_VEC           = default:0
+BSG_MACHINE_HETERO_TYPE_VEC           = default:9
 
 # Network Parameters
 BSG_MACHINE_NETWORK_CFG               = e_network_mesh
@@ -43,17 +43,7 @@ BSG_MACHINE_RUCHE_FACTOR_X            = 0
 
 # Memory System Parameters
 BSG_MACHINE_DRAM_INCLUDED             = 1
-BSG_MACHINE_MEM_CFG                   = e_vcache_blocking_axi4_f1_dram
-
-# Victim Cache Parameters
-# AWS Specific:
-BSG_MACHINE_VCACHE_PER_DRAM_CHANNEL   = $(shell echo $(BSG_MACHINE_NUM_CORES_X)*2 | bc)
-BSG_MACHINE_VCACHE_SET                = 64
-BSG_MACHINE_VCACHE_WAY                = 8
-BSG_MACHINE_VCACHE_LINE_WORDS         = 16
-BSG_MACHINE_VCACHE_STRIPE_WORDS       = $(BSG_MACHINE_VCACHE_LINE_WORDS)
-# Only applies to Non-blocking Cache
-BSG_MACHINE_VCACHE_MISS_FIFO_ELS      = 32
+BSG_MACHINE_MEM_CFG                   = e_infinite_mem
 
 # Host Coordinate (Rarely Changed)
 BSG_MACHINE_HOST_COORD_X              = 0
@@ -72,19 +62,25 @@ BSG_MACHINE_IO_HOST_CREDITS           = $(BSG_MACHINE_IO_EP_CREDITS)
 BSG_MACHINE_IO_REMOTE_LOAD_CAP        = $(BSG_MACHINE_IO_EP_CREDITS)
 
 # (Don't) Instantiate Profilers (needed for SAIF generation, DPI Tile)
-BSG_MACHINE_NOINST_PROFILERS          = 0
+BSG_MACHINE_NOINST_PROFILERS          = 1
 
 ##################### Constants and Computations #####################
-
+# Every cache is replaced with an infinite memory channel
 BSG_MACHINE_NUM_VCACHE               := $(shell echo $(BSG_MACHINE_NUM_CORES_X)*2 | bc)
-# Only one channel in AWS
-BSG_MACHINE_DRAM_NUM_CHANNELS        := 1
+BSG_MACHINE_DRAM_NUM_CHANNELS        := $(BSG_MACHINE_NUM_VCACHE)
 
-# AWS F1: 2GB (all we expose)
-BSG_MACHINE_DRAM_WORDS               := $(shell echo 2^29 | bc) # 2 GB
+BSG_MACHINE_DRAM_WORDS                = $(shell echo 2^30 | bc) # 4GB
 BSG_MACHINE_DRAM_PER_CACHE_WORDS      = $(shell echo "$(BSG_MACHINE_DRAM_WORDS) / $(BSG_MACHINE_NUM_VCACHE)" | bc)
 
-# Required for BSG Manycore
+# Victim Cache Parameters (Not used for Infinite Memory)
+BSG_MACHINE_VCACHE_PER_DRAM_CHANNEL   = 16
+BSG_MACHINE_VCACHE_SET                = 64
+BSG_MACHINE_VCACHE_WAY                = 8
+BSG_MACHINE_VCACHE_LINE_WORDS         = 32
+BSG_MACHINE_VCACHE_STRIPE_WORDS       = $(BSG_MACHINE_VCACHE_LINE_WORDS)
+# Only applies to Non-blocking Cache
+BSG_MACHINE_VCACHE_MISS_FIFO_ELS      = 32
+
 # Aliases Required for BSG Manycore
 BSG_MACHINE_GLOBAL_X                  = $(BSG_MACHINE_NUM_CORES_X)
 BSG_MACHINE_GLOBAL_Y                  = $(shell echo $(BSG_MACHINE_NUM_CORES_Y)+$(BSG_MACHINE_ORIGIN_COORD_Y)-1 | bc)

--- a/machines/infinite_ruche_16_8/Makefile.machine.include
+++ b/machines/infinite_ruche_16_8/Makefile.machine.include
@@ -61,6 +61,9 @@ BSG_MACHINE_IO_EP_CREDITS             = 16
 BSG_MACHINE_IO_HOST_CREDITS           = $(BSG_MACHINE_IO_EP_CREDITS)
 BSG_MACHINE_IO_REMOTE_LOAD_CAP        = $(BSG_MACHINE_IO_EP_CREDITS)
 
+# (Don't) Instantiate Profilers (needed for SAIF generation, DPI Tile)
+BSG_MACHINE_NOINST_PROFILERS          = 0
+
 ##################### Constants and Computations #####################
 # Every cache is replaced with an infinite memory channel
 BSG_MACHINE_NUM_VCACHE               := $(shell echo $(BSG_MACHINE_NUM_CORES_X)*2 | bc)

--- a/machines/infinite_ruche_32_16/Makefile.machine.include
+++ b/machines/infinite_ruche_32_16/Makefile.machine.include
@@ -61,6 +61,9 @@ BSG_MACHINE_IO_EP_CREDITS             = 16
 BSG_MACHINE_IO_HOST_CREDITS           = $(BSG_MACHINE_IO_EP_CREDITS)
 BSG_MACHINE_IO_REMOTE_LOAD_CAP        = $(BSG_MACHINE_IO_EP_CREDITS)
 
+# (Don't) Instantiate Profilers (needed for SAIF generation, DPI Tile)
+BSG_MACHINE_NOINST_PROFILERS          = 0
+
 ##################### Constants and Computations #####################
 # Every cache is replaced with an infinite memory channel
 BSG_MACHINE_NUM_VCACHE               := $(shell echo $(BSG_MACHINE_NUM_CORES_X)*2 | bc)

--- a/machines/infinite_ruche_8_4/Makefile.machine.include
+++ b/machines/infinite_ruche_8_4/Makefile.machine.include
@@ -61,6 +61,9 @@ BSG_MACHINE_IO_EP_CREDITS             = 16
 BSG_MACHINE_IO_HOST_CREDITS           = $(BSG_MACHINE_IO_EP_CREDITS)
 BSG_MACHINE_IO_REMOTE_LOAD_CAP        = $(BSG_MACHINE_IO_EP_CREDITS)
 
+# (Don't) Instantiate Profilers (needed for SAIF generation, DPI Tile)
+BSG_MACHINE_NOINST_PROFILERS          = 0
+
 ##################### Constants and Computations #####################
 # Every cache is replaced with an infinite memory channel
 BSG_MACHINE_NUM_VCACHE               := $(shell echo $(BSG_MACHINE_NUM_CORES_X)*2 | bc)

--- a/machines/timing_mesh_16_8/Makefile.machine.include
+++ b/machines/timing_mesh_16_8/Makefile.machine.include
@@ -79,6 +79,9 @@ BSG_MACHINE_IO_EP_CREDITS             = 16
 BSG_MACHINE_IO_HOST_CREDITS           = $(BSG_MACHINE_IO_EP_CREDITS)
 BSG_MACHINE_IO_REMOTE_LOAD_CAP        = $(BSG_MACHINE_IO_EP_CREDITS)
 
+# (Don't) Instantiate Profilers (needed for SAIF generation, DPI Tile)
+BSG_MACHINE_NOINST_PROFILERS          = 0
+
 ##################### Constants and Computations #####################
 
 # Aliases required for memsys.mk, and others.

--- a/machines/timing_mesh_32_16/Makefile.machine.include
+++ b/machines/timing_mesh_32_16/Makefile.machine.include
@@ -79,6 +79,9 @@ BSG_MACHINE_IO_EP_CREDITS             = 16
 BSG_MACHINE_IO_HOST_CREDITS           = $(BSG_MACHINE_IO_EP_CREDITS)
 BSG_MACHINE_IO_REMOTE_LOAD_CAP        = $(BSG_MACHINE_IO_EP_CREDITS)
 
+# (Don't) Instantiate Profilers (needed for SAIF generation, DPI Tile)
+BSG_MACHINE_NOINST_PROFILERS          = 0
+
 ##################### Constants and Computations #####################
 
 # Aliases required for memsys.mk, and others.

--- a/machines/timing_mesh_8_4/Makefile.machine.include
+++ b/machines/timing_mesh_8_4/Makefile.machine.include
@@ -79,6 +79,9 @@ BSG_MACHINE_IO_EP_CREDITS             = 16
 BSG_MACHINE_IO_HOST_CREDITS           = $(BSG_MACHINE_IO_EP_CREDITS)
 BSG_MACHINE_IO_REMOTE_LOAD_CAP        = $(BSG_MACHINE_IO_EP_CREDITS)
 
+# (Don't) Instantiate Profilers (needed for SAIF generation, DPI Tile)
+BSG_MACHINE_NOINST_PROFILERS          = 0
+
 ##################### Constants and Computations #####################
 
 # Aliases required for memsys.mk, and others.

--- a/machines/timing_ruche_16_8/Makefile.machine.include
+++ b/machines/timing_ruche_16_8/Makefile.machine.include
@@ -79,6 +79,9 @@ BSG_MACHINE_IO_EP_CREDITS             = 16
 BSG_MACHINE_IO_HOST_CREDITS           = $(BSG_MACHINE_IO_EP_CREDITS)
 BSG_MACHINE_IO_REMOTE_LOAD_CAP        = $(BSG_MACHINE_IO_EP_CREDITS)
 
+# (Don't) Instantiate Profilers (needed for SAIF generation, DPI Tile)
+BSG_MACHINE_NOINST_PROFILERS          = 0
+
 ##################### Constants and Computations #####################
 
 # Aliases required for memsys.mk, and others.

--- a/machines/timing_ruche_32_16/Makefile.machine.include
+++ b/machines/timing_ruche_32_16/Makefile.machine.include
@@ -79,6 +79,9 @@ BSG_MACHINE_IO_EP_CREDITS             = 16
 BSG_MACHINE_IO_HOST_CREDITS           = $(BSG_MACHINE_IO_EP_CREDITS)
 BSG_MACHINE_IO_REMOTE_LOAD_CAP        = $(BSG_MACHINE_IO_EP_CREDITS)
 
+# (Don't) Instantiate Profilers (needed for SAIF generation, DPI Tile)
+BSG_MACHINE_NOINST_PROFILERS          = 0
+
 ##################### Constants and Computations #####################
 
 # Aliases required for memsys.mk, and others.

--- a/machines/timing_ruche_8_4/Makefile.machine.include
+++ b/machines/timing_ruche_8_4/Makefile.machine.include
@@ -79,6 +79,9 @@ BSG_MACHINE_IO_EP_CREDITS             = 16
 BSG_MACHINE_IO_HOST_CREDITS           = $(BSG_MACHINE_IO_EP_CREDITS)
 BSG_MACHINE_IO_REMOTE_LOAD_CAP        = $(BSG_MACHINE_IO_EP_CREDITS)
 
+# (Don't) Instantiate Profilers (needed for SAIF generation, DPI Tile)
+BSG_MACHINE_NOINST_PROFILERS          = 0
+
 ##################### Constants and Computations #####################
 
 # Aliases required for memsys.mk, and others.


### PR DESCRIPTION
Credit @tommydcjung for the seed of this idea. 

This is necessary for two ongoing projects: The network simulator where there _are_ no tiles to bind to, and SAIF generation where the profilers cause VCS to crash.