### PR TITLE
Adds conveniance iterators for looping over coordinate space

### DIFF
--- a/examples/library/Makefile
+++ b/examples/library/Makefile
@@ -55,6 +55,7 @@ REGRESSION_TESTS_TYPE = library
 UNIFIED_TESTS = 
 
 INDEPENDENT_TESTS += test_rom
+INDEPENDENT_TESTS += test_coordinate
 INDEPENDENT_TESTS += test_get_cycle
 INDEPENDENT_TESTS += test_struct_size
 INDEPENDENT_TESTS += test_vcache_flush

--- a/examples/library/test_coordinate.cpp
+++ b/examples/library/test_coordinate.cpp
@@ -79,7 +79,7 @@ static int iterate_x_y(hb_mc_coordinate_t origin, hb_mc_dimension_t dimension, c
         if (!r) return HB_MC_FAIL;                      \
     } while (0)
 
-int test_rom (int argc, char **argv) {
+int test_coordinate (int argc, char **argv) {
     hb_mc_coordinate_t origin;
     hb_mc_dimension_t dim;
     std::vector<hb_mc_coordinate_t> expect;

--- a/examples/library/test_coordinate.cpp
+++ b/examples/library/test_coordinate.cpp
@@ -49,11 +49,34 @@ static int iterate(hb_mc_coordinate_t origin, hb_mc_dimension_t dimension, const
 }
 
 
-#define TEST(origin, dim, expect)               \
-    do {                                        \
-        bsg_pr_info("Starting test\n");         \
-        int r = iterate(origin, dim, expect);   \
-        if (!r) return HB_MC_FAIL;              \
+static int iterate_x_y(hb_mc_coordinate_t origin, hb_mc_dimension_t dimension, const std::vector<hb_mc_coordinate_t> &expect)
+{
+    int good = 1;
+    int i = 0;
+    char buffer[256];
+    hb_mc_idx_t x,y;
+
+    foreach_x_y(x, y, origin, dimension)
+    {
+        hb_mc_coordinate_t now = HB_MC_COORDINATE(x,y);
+        good = good && hb_mc_coordinate_eq(now, expect[i]);
+        bsg_pr_info("iteration %2d: %s\n", i, hb_mc_coordinate_to_string(now, buffer, sizeof(buffer)));
+        i++;
+    }
+
+    return good && (i == expect.size());
+}
+
+
+
+#define TEST(origin, dim, expect)                               \
+    do {                                                        \
+        bsg_pr_info("Starting test foreach_coordinate\n");      \
+        int r = iterate(origin, dim, expect);                   \
+        if (!r) return HB_MC_FAIL;                      \
+        bsg_pr_info("Starting test foreach_x_y\n");     \
+        r = iterate_x_y(origin, dim, expect);           \
+        if (!r) return HB_MC_FAIL;                      \
     } while (0)
 
 int test_rom (int argc, char **argv) {
@@ -91,12 +114,6 @@ int test_rom (int argc, char **argv) {
         HB_MC_COORDINATE(1,3),
     };
     TEST(origin, dim, expect);
-
-    origin = HB_MC_COORDINATE(0,2);
-    dim    = HB_MC_DIMENSION(0,0);
-    expect = {HB_MC_COORDINATE(1,1)};
-    TEST(origin, dim, expect);
-
 
     return HB_MC_SUCCESS;
 }

--- a/examples/library/test_coordinate.cpp
+++ b/examples/library/test_coordinate.cpp
@@ -1,0 +1,114 @@
+// Copyright (c) 2019, University of Washington All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// Redistributions of source code must retain the above copyright notice, this list
+// of conditions and the following disclaimer.
+//
+// Redistributions in binary form must reproduce the above copyright notice, this
+// list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// Neither the name of the copyright holder nor the names of its contributors may
+// be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "test_coordinate.hpp"
+#include "bsg_manycore_coordinate.h"
+#include "bsg_manycore_printing.h"
+#include <inttypes.h>
+#include <vector>
+
+static int iterate(hb_mc_coordinate_t origin, hb_mc_dimension_t dimension, const std::vector<hb_mc_coordinate_t> &expect)
+{
+    hb_mc_coordinate_t now;
+    int good = 1;
+    int i = 0;
+    char buffer[256];
+
+    foreach_coordinate(now, origin, dimension)
+    {
+        good = good && hb_mc_coordinate_eq(now, expect[i]);
+        bsg_pr_info("iteration %2d: %s\n", i, hb_mc_coordinate_to_string(now, buffer, sizeof(buffer)));
+        i++;
+    }
+
+    return good && (i == expect.size());
+}
+
+
+#define TEST(origin, dim, expect)               \
+    do {                                        \
+        bsg_pr_info("Starting test\n");         \
+        int r = iterate(origin, dim, expect);   \
+        if (!r) return HB_MC_FAIL;              \
+    } while (0)
+
+int test_rom (int argc, char **argv) {
+    hb_mc_coordinate_t origin;
+    hb_mc_dimension_t dim;
+    std::vector<hb_mc_coordinate_t> expect;
+
+    origin = HB_MC_COORDINATE(0,0);
+
+    dim    = HB_MC_DIMENSION(1,1);
+    expect = { HB_MC_COORDINATE(0,0) };
+    TEST(origin, dim, expect);
+
+
+    dim    = HB_MC_DIMENSION(2,1);
+    expect = {
+        HB_MC_COORDINATE(0,0),
+        HB_MC_COORDINATE(1,0),
+    };
+    TEST(origin, dim, expect);
+
+    dim = HB_MC_DIMENSION(1,2);
+    expect = {
+        HB_MC_COORDINATE(0,0),
+        HB_MC_COORDINATE(0,1),
+    };
+    TEST(origin, dim, expect);
+
+    origin = HB_MC_COORDINATE(0,2);
+    dim    = HB_MC_DIMENSION(2,2);
+    expect = {
+        HB_MC_COORDINATE(0,2),
+        HB_MC_COORDINATE(0,3),
+        HB_MC_COORDINATE(1,2),
+        HB_MC_COORDINATE(1,3),
+    };
+    TEST(origin, dim, expect);
+
+    origin = HB_MC_COORDINATE(0,2);
+    dim    = HB_MC_DIMENSION(0,0);
+    expect = {HB_MC_COORDINATE(1,1)};
+    TEST(origin, dim, expect);
+
+
+    return HB_MC_SUCCESS;
+}
+
+#ifdef VCS
+int vcs_main(int argc, char ** argv) {
+#else
+int main(int argc, char ** argv) {
+#endif
+
+        bsg_pr_test_info("test_rom Regression Test \n");
+        int rc = test_rom(argc, argv);
+        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
+        return rc;
+}

--- a/examples/library/test_coordinate.hpp
+++ b/examples/library/test_coordinate.hpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2019, University of Washington All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// 
+// Redistributions of source code must retain the above copyright notice, this list
+// of conditions and the following disclaimer.
+// 
+// Redistributions in binary form must reproduce the above copyright notice, this
+// list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+// 
+// Neither the name of the copyright holder nor the names of its contributors may
+// be used to endorse or promote products derived from this software without
+// specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+#include <bsg_manycore.h>
+#include <inttypes.h>
+#include "../cl_manycore_regression.h"

--- a/libraries/bsg_manycore_coordinate.h
+++ b/libraries/bsg_manycore_coordinate.h
@@ -188,6 +188,23 @@ extern "C" {
         }
 
         /**
+         * Calculate the element-wise difference between to coordinates
+         * @param[in]  first
+         * @param[in]  second
+         * @param[out] result
+         * @return HB_MC_IOVERFLOW if the subtraction will result in an integer underflow. HB_MC_SUCCESS otherwise.
+         */
+        static inline int hb_mc_coordinate_sub_safe(hb_mc_coodinate_t first, hb_mc_coordinate_t second, hb_mc_coordinate_t *result)
+        {
+                if (first.x < second.x || first.y < second.y)
+                        return HB_MC_IOVERFLOW;
+
+                result->x = first.x - second.x;
+                result->y = first.y - second.y;
+                return HB_MC_SUCCESS;
+        }
+
+        /**
          * Returns non-zero if the two coordinates are equal
          */
         static inline int hb_mc_coordinate_eq(hb_mc_coordinate_t first, hb_mc_coordinate_t second)

--- a/libraries/bsg_manycore_coordinate.h
+++ b/libraries/bsg_manycore_coordinate.h
@@ -194,7 +194,7 @@ extern "C" {
          * @param[out] result
          * @return HB_MC_IOVERFLOW if the subtraction will result in an integer underflow. HB_MC_SUCCESS otherwise.
          */
-        static inline int hb_mc_coordinate_sub_safe(hb_mc_coodinate_t first, hb_mc_coordinate_t second, hb_mc_coordinate_t *result)
+        static inline int hb_mc_coordinate_sub_safe(hb_mc_coordinate_t first, hb_mc_coordinate_t second, hb_mc_coordinate_t *result)
         {
                 if (first.x < second.x || first.y < second.y)
                         return HB_MC_IOVERFLOW;

--- a/libraries/bsg_manycore_coordinate.h
+++ b/libraries/bsg_manycore_coordinate.h
@@ -28,6 +28,7 @@
 #ifndef BSG_MANYCORE_COORDINATE_H
 #define BSG_MANYCORE_COORDINATE_H
 #include <bsg_manycore_features.h>
+#include <bsg_manycore_errno.h>
 
 #ifdef __cplusplus
 #include <cstdint>

--- a/libraries/bsg_manycore_coordinate.h
+++ b/libraries/bsg_manycore_coordinate.h
@@ -250,6 +250,10 @@ extern "C" {
              !hb_mc_coordinate_stop(coordinate, origin, dim);           \
              coordinate = hb_mc_coordinate_next(coordinate, origin, dim))
 
+#define foreach_x_y(x_var, y_var, origin, dim)                          \
+        for ((x_var = origin.x, y_var = origin.y);                      \
+             x_var < (origin.x+dim.x);                                  \
+             ++y_var >= (origin.y+dim.y) ? (y_var = origin.y, x_var++) : y_var)
 
 #ifdef __cplusplus
 }

--- a/libraries/bsg_manycore_coordinate.h
+++ b/libraries/bsg_manycore_coordinate.h
@@ -178,11 +178,59 @@ extern "C" {
         } 
 
 
+        /**
+         * Adds two coordinates together
+         * @return A coordinate that is the element-wise sum of the inputs
+         */
+        static inline hb_mc_coordinate_t hb_mc_coordinate_add(hb_mc_coordinate_t first, hb_mc_coordinate_t second)
+        {
+                return HB_MC_COORDINATE(first.x+second.x, first.y+second.y);
+        }
 
+        /**
+         * Returns non-zero if the two coordinates are equal
+         */
+        static inline int hb_mc_coordinate_eq(hb_mc_coordinate_t first, hb_mc_coordinate_t second)
+        {
+                return (first.x == second.x) && (first.y == second.y);
+        }
 
+        /**
+         * Returns the next greatest coordinate from the origin subject a boundary condition of origin + dim
+         */
+        static inline hb_mc_coordinate_t hb_mc_coordinate_next(hb_mc_coordinate_t now, hb_mc_coordinate_t origin, hb_mc_coordinate_t dim)
+        {
+                now.y += 1;
+                if (now.y >= origin.y + dim.y) {
+                        now.y = origin.y;
+                        now.x += 1;
+                }
+                return now;
+        }
 
+        /**
+         * Returns non-zero if calling hb_mc_coordinate_next() with same inputs will fall outside boundary
+         */
+        static inline int hb_mc_coordinate_stop(hb_mc_coordinate_t now, hb_mc_coordinate_t origin, hb_mc_coordinate_t dim)
+        {
+                return (now.x >= origin.x+dim.x) || (now.y >= origin.y+dim.y);
+        }
 
-
+        /**
+         * Iterate over the coordinate space begining at origin and subject to the boundary condition of origin + dim
+         * @param[in] coordinate  An unset coordinate variable declared in parent scope.
+         * @param[in] origin      The origin coordinate.
+         * @param[in] dim         The dimension of the coordinate space overwhich to iterate.
+         *
+         * This is a conveniance macro for iterating over a coordinate space defined by (origin, origin + dim).
+         * The input parameter coordinate must be declared in the parent scope.
+         * At each iteration, coordinate is updated.
+         * Behavior is undefined if coordinate is modified in the loop body.
+         */
+#define foreach_coordinate(coordinate, origin, dim)                     \
+        for (coordinate = origin;                                       \
+             !hb_mc_coordinate_stop(coordinate, origin, dim);           \
+             coordinate = hb_mc_coordinate_next(coordinate, origin, dim))
 
 
 #ifdef __cplusplus

--- a/libraries/bsg_manycore_coordinate.h
+++ b/libraries/bsg_manycore_coordinate.h
@@ -250,6 +250,18 @@ extern "C" {
              !hb_mc_coordinate_stop(coordinate, origin, dim);           \
              coordinate = hb_mc_coordinate_next(coordinate, origin, dim))
 
+        /**
+         * Iterate over the coordinate space begining at origin and subject to the boundary condition of origin + dim
+         * @param[in] x_var       An unset x index declared in parent scope.
+         * @param[in] y_var       An unset y index declared in parent scope.
+         * @param[in] origin      The origin coordinate.
+         * @param[in] dim         The dimension of the coordinate space overwhich to iterate.
+         *
+         * This is a conveniance macro for iterating over a coordinate space defined by (origin, origin + dim).
+         * The input parameters x_var and y_var must be declared in the parent scope.
+         * At each iteration, x_var and y_var are updated.
+         * Behavior is undefined if coordinate is modified in the loop body.
+         */
 #define foreach_x_y(x_var, y_var, origin, dim)                          \
         for ((x_var = origin.x, y_var = origin.y);                      \
              x_var < (origin.x+dim.x);                                  \

--- a/libraries/bsg_manycore_errno.h
+++ b/libraries/bsg_manycore_errno.h
@@ -44,6 +44,7 @@ extern "C" {
 #define HB_MC_NOTFOUND      (-7)
 #define HB_MC_BUSY          (-8)
 #define HB_MC_UNALIGNED     (-9)
+#define HB_MC_IOVERFLOW    (-10)
 
         static inline const char * hb_mc_strerror(int err)
         {
@@ -58,6 +59,7 @@ extern "C" {
                         [-HB_MC_NOTFOUND]          = "Not found",
                         [-HB_MC_BUSY]              = "Busy",
                         [-HB_MC_UNALIGNED]         = "Unaligned memory request",
+                        [-HB_MC_IOVERFLOW]         = "Integer overflow",
                 };
                 return strtab[-err];
         }


### PR DESCRIPTION
The core CUDA-Lite code has quite a bit of loop logic that makes the over all code hard to follow.
This PR provides a helper loop macro to simplify code.