### PR TITLE
Removing cruft headers from library tests and guarding mutexes in the memory manager

### DIFF
--- a/examples/library/test_manycore_alignment/main.c
+++ b/examples/library/test_manycore_alignment/main.c
@@ -33,7 +33,6 @@
 #include <bsg_manycore_npa.h>
 #include <bsg_manycore_config_pod.h>
 #include <stdio.h>
-#include <sys/ioctl.h>
 #include <unistd.h>
 #include <string.h>
 #include <time.h>

--- a/examples/library/test_manycore_credits/main.c
+++ b/examples/library/test_manycore_credits/main.c
@@ -33,7 +33,6 @@
 #include <inttypes.h>
 #include <cl_manycore_regression.h>
 #include <stdio.h>
-#include <sys/ioctl.h>
 #include <unistd.h>
 #include <string.h>
 #include <time.h>

--- a/examples/library/test_manycore_dmem_read_write/main.cpp
+++ b/examples/library/test_manycore_dmem_read_write/main.cpp
@@ -32,7 +32,6 @@
 #include <cinttypes>
 #include <type_traits>
 #include <stdio.h>
-#include <sys/ioctl.h>
 #include <unistd.h>
 #include <string.h>
 #include <time.h>

--- a/examples/library/test_manycore_dram_read_write/main.c
+++ b/examples/library/test_manycore_dram_read_write/main.c
@@ -31,7 +31,6 @@
 #include <bsg_manycore_coordinate.h>
 #include <bsg_manycore_vcache.h>
 #include <stdio.h>
-#include <sys/ioctl.h>
 #include <unistd.h>
 #include <string.h>
 #include <time.h>
@@ -121,7 +120,7 @@ int test_manycore_dram_read_write() {
                                 if (err != HB_MC_SUCCESS) {
                                         bsg_pr_err("%s: failed to read A[%d] "
                                                    "from DRAM coord(%d,%d) @ 0x%08" PRIx32 "\n",
-                                                   i,
+                                                   __func__, i,
                                                    hb_mc_coordinate_get_x(dram_coord),
                                                    hb_mc_coordinate_get_y(dram_coord),
                                                    BASE_ADDR + i);

--- a/examples/library/test_manycore_eva/main.c
+++ b/examples/library/test_manycore_eva/main.c
@@ -33,7 +33,6 @@
 #include "test_manycore_parameters.h"
 
 #include <stdio.h>
-#include <sys/ioctl.h>
 #include <unistd.h>
 #include <string.h>
 #include <time.h>
@@ -166,7 +165,7 @@ int test_manycore_eva () {
                         tgt_epa = rand() % DRAM_EPA_SIZE; // Small, but we'll deal.
 
                         tgt_x = (rand() % (dim_x - 1)) + origin_x;
-                        tgt_y = hb_mc_config_get_dram_y(config);
+                        // tgt_y = hb_mc_config_get_dram_y(config);
 
                         eva =   (  (tgt_epa & DRAM_STRIPE_MASK)
                                  | (tgt_x << dram_x_offset)

--- a/examples/library/test_manycore_packets/main.c
+++ b/examples/library/test_manycore_packets/main.c
@@ -31,7 +31,6 @@
 #include <bsg_manycore_tile.h>
 #include <bsg_manycore_printing.h>
 #include <stdio.h>
-#include <sys/ioctl.h>
 #include <unistd.h>
 #include <string.h>
 #include <time.h>

--- a/examples/library/test_manycore_vcache_sequence/main.c
+++ b/examples/library/test_manycore_vcache_sequence/main.c
@@ -33,7 +33,6 @@
 #include <bsg_manycore_npa.h>
 #include <bsg_manycore_config_pod.h>
 #include <stdio.h>
-#include <sys/ioctl.h>
 #include <unistd.h>
 #include <string.h>
 #include <time.h>
@@ -118,7 +117,7 @@ int test_manycore_vcache_sequence() {
                                         bsg_pr_test_info("\n%s: mismatch @ index %d: "
                                                          "wrote 0x%08" PRIx32 " -- "
                                                          "read 0x%08" PRIx32 ": @ 0x%08" PRIx32 "\n",
-                                                         __func__, i, i, write_data, read_data,
+                                                         __func__, i, write_data, read_data,
                                                          hb_mc_npa_get_epa(&npa));
                                 }
                         

--- a/examples/library/test_printing/main.c
+++ b/examples/library/test_printing/main.c
@@ -44,7 +44,6 @@
 /********************************************************************/
 
 #include <stdio.h>
-#include <sys/ioctl.h>
 #include <unistd.h>
 #include <string.h>
 #include <time.h>

--- a/examples/library/test_struct_size/main.c
+++ b/examples/library/test_struct_size/main.c
@@ -26,7 +26,6 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdio.h>
-#include <sys/ioctl.h>
 #include <unistd.h>
 #include <string.h>
 #include <time.h>

--- a/examples/library/test_vcache_sequence/main.c
+++ b/examples/library/test_vcache_sequence/main.c
@@ -26,7 +26,6 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <bsg_manycore_config_pod.h>
 #include <stdio.h>
-#include <sys/ioctl.h>
 #include <unistd.h>
 #include <string.h>
 #include <time.h>

--- a/examples/library/test_vcache_simplified/main.c
+++ b/examples/library/test_vcache_simplified/main.c
@@ -26,7 +26,6 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdio.h>
-#include <sys/ioctl.h>
 #include <unistd.h>
 #include <string.h>
 #include <time.h>

--- a/libraries/bsg_manycore_eva.cpp
+++ b/libraries/bsg_manycore_eva.cpp
@@ -25,13 +25,16 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-///////////////////////////////////////////////////////////////////////////////////////
-// This code is written to match the System Verilog found here:                      //
-// https://github.com:bespoke-silicon-group/bsg_manycore/v/bsg_manycore_eva_to_npa.v //
-//                                                                                   //
-// It also matches address translation code found here:                              //
-// https://github.com:bespoke-silicon-group/bsg_manycore/software/py/nbf.py          //
-///////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+// This code is written to match the System Verilog found here:                                      //
+// https://github.com:bespoke-silicon-group/bsg_manycore/v/bsg_manycore_eva_to_npa.v                 //
+//                                                                                                   //
+// It also matches address translation code found here:                                              //
+// https://github.com:bespoke-silicon-group/bsg_manycore/software/py/nbf.py                          //
+//                                                                                                   //
+// Changing the EVA map should reflect corresponding changes in:                                     //
+// https://github.com:bespoke-silicon-group/bsg_replicant/examples/library/test_manycore_eva/main.c  //
+///////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include <bsg_manycore_eva.h>
 #include <bsg_manycore_tile.h>

--- a/libraries/bsg_manycore_loader.cpp
+++ b/libraries/bsg_manycore_loader.cpp
@@ -37,7 +37,6 @@
 
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <sys/mman.h>
 #include <unistd.h>
 
 #ifdef __cplusplus

--- a/libraries/bsg_manycore_memory_manager.cpp
+++ b/libraries/bsg_manycore_memory_manager.cpp
@@ -50,7 +50,9 @@ awsbwhal::MemoryManager::alloc(size_t size)
         const size_t pad = (mod_size > 0) ? (mAlignment - mod_size) : 0;
         size += pad;
 
-        std::lock_guard<std::mutex> lock(mMemManagerMutex);
+        #ifdef _MMAN_MUTEX_
+          std::lock_guard<std::mutex> lock(mMemManagerMutex);
+        #endif
         for (PairList::iterator i = mFreeBufferList.begin(), e = mFreeBufferList.end(); i != e; ++i) {
                 if (i->second < size)
                         continue;
@@ -74,7 +76,9 @@ awsbwhal::MemoryManager::alloc(size_t size)
 void
 awsbwhal::MemoryManager::free(uint64_t buf)
 {
-        std::lock_guard<std::mutex> lock(mMemManagerMutex);
+        #ifdef _MMAN_MUTEX_
+          std::lock_guard<std::mutex> lock(mMemManagerMutex);
+        #endif
         PairList::iterator i = find(buf);
         if (i == mBusyBufferList.end())
                 return;
@@ -134,7 +138,9 @@ awsbwhal::MemoryManager::find(uint64_t buf)
 void
 awsbwhal::MemoryManager::reset()
 {
-        std::lock_guard<std::mutex> lock(mMemManagerMutex);
+        #ifdef _MMAN_MUTEX_
+          std::lock_guard<std::mutex> lock(mMemManagerMutex);
+        #endif
         mFreeBufferList.clear();
         mBusyBufferList.clear();
         mFreeBufferList.push_back(std::make_pair(mStart, mSize));
@@ -144,7 +150,9 @@ awsbwhal::MemoryManager::reset()
 std::pair<uint64_t, uint64_t>
 awsbwhal::MemoryManager::lookup(uint64_t buf)
 {
-        std::lock_guard<std::mutex> lock(mMemManagerMutex);
+        #ifdef _MMAN_MUTEX_
+          std::lock_guard<std::mutex> lock(mMemManagerMutex);
+        #endif
         PairList::iterator i = find(buf);
         if (i != mBusyBufferList.end())
                 return *i;
@@ -173,7 +181,9 @@ awsbwhal::MemoryManager::reserve(uint64_t base, size_t size)
         const size_t pad = (mod_size > 0) ? (mAlignment - mod_size) : 0;
         size += pad;
 
-        std::lock_guard<std::mutex> lock(mMemManagerMutex);
+        #ifdef _MMAN_MUTEX_
+          std::lock_guard<std::mutex> lock(mMemManagerMutex);
+        #endif
         for (PairList::iterator i = mFreeBufferList.begin(), e = mFreeBufferList.end(); i != e; ++i) {
                 if (i->second < size)
                         continue;

--- a/libraries/bsg_manycore_memory_manager.h
+++ b/libraries/bsg_manycore_memory_manager.h
@@ -28,7 +28,9 @@
 
 namespace awsbwhal {
         class MemoryManager {
-                std::mutex mMemManagerMutex;
+                #ifdef _MMAN_MUTEX_
+                  std::mutex mMemManagerMutex;
+                #endif
                 std::list<std::pair<uint64_t, uint64_t> > mFreeBufferList;
                 std::list<std::pair<uint64_t, uint64_t> > mBusyBufferList;
                 const uint64_t mSize;


### PR DESCRIPTION
This PR removes cruft headers from the library tests and adds a macro guard around the use of mutexes. 

- Removes the use of sys/ioctl.h
- Removes the use of sys/mman.h
- Adds a ifdef around the memory manager mutex (using _MMAN_MUTEX_)