### PR TITLE
Bigblade shared object Flow

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -65,7 +65,7 @@ help:
 	@echo "             a specific sub-directory (Options are: $(TARGETS))"
 	@echo "      clean: Remove all build files"
 
-clean: hardware.clean libraries.clean
+clean: hardware.clean libraries.clean link.clean
 	$(foreach t,$(TARGETS), $(MAKE) -C $t clean;)
 	rm -rf regression.log runtime.log
 

--- a/examples/cuda/test_binary_load_buffer/Makefile
+++ b/examples/cuda/test_binary_load_buffer/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_binary_load_buffer/Makefile
+++ b/examples/cuda/test_binary_load_buffer/Makefile
@@ -121,18 +121,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_conv1d/Makefile
+++ b/examples/cuda/test_conv1d/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = conv1d
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_conv1d/Makefile
+++ b/examples/cuda/test_conv1d/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_conv2d/Makefile
+++ b/examples/cuda/test_conv2d/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_conv2d/Makefile
+++ b/examples/cuda/test_conv2d/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = conv2d
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_credit_csr_tile/Makefile
+++ b/examples/cuda/test_credit_csr_tile/Makefile
@@ -46,8 +46,6 @@ SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = vec_add_parallel
 
@@ -120,18 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_credit_csr_tile/Makefile
+++ b/examples/cuda/test_credit_csr_tile/Makefile
@@ -117,7 +117,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_device_memcpy/Makefile
+++ b/examples/cuda/test_device_memcpy/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_device_memcpy/Makefile
+++ b/examples/cuda/test_device_memcpy/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = device_memcpy
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_device_memset/Makefile
+++ b/examples/cuda/test_device_memset/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_device_memset/Makefile
+++ b/examples/cuda/test_device_memset/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = device_memset
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_dma/Makefile
+++ b/examples/cuda/test_dma/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = dma
 
@@ -119,18 +117,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_dma/Makefile
+++ b/examples/cuda/test_dma/Makefile
@@ -116,7 +116,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_dma_valid_invalid/Makefile
+++ b/examples/cuda/test_dma_valid_invalid/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = dma
 
@@ -119,18 +117,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_dma_valid_invalid/Makefile
+++ b/examples/cuda/test_dma_valid_invalid/Makefile
@@ -116,7 +116,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_dram_device_allocated/Makefile
+++ b/examples/cuda/test_dram_device_allocated/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = dram_device_allocated
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_dram_device_allocated/Makefile
+++ b/examples/cuda/test_dram_device_allocated/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_dram_host_allocated/Makefile
+++ b/examples/cuda/test_dram_host_allocated/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_dram_host_allocated/Makefile
+++ b/examples/cuda/test_dram_host_allocated/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = dram_host_allocated
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_dram_load_store/Makefile
+++ b/examples/cuda/test_dram_load_store/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = dram_load_store
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_dram_load_store/Makefile
+++ b/examples/cuda/test_dram_load_store/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_empty_parallel/Makefile
+++ b/examples/cuda/test_empty_parallel/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = empty_parallel
 
@@ -119,18 +117,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_empty_parallel/Makefile
+++ b/examples/cuda/test_empty_parallel/Makefile
@@ -116,7 +116,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_float_all_ops/Makefile
+++ b/examples/cuda/test_float_all_ops/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_float_all_ops/Makefile
+++ b/examples/cuda/test_float_all_ops/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = float_all_ops
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_float_matrix_mul/Makefile
+++ b/examples/cuda/test_float_matrix_mul/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_float_matrix_mul/Makefile
+++ b/examples/cuda/test_float_matrix_mul/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = float_matrix_mul
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_float_matrix_mul_shared_mem/Makefile
+++ b/examples/cuda/test_float_matrix_mul_shared_mem/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_float_matrix_mul_shared_mem/Makefile
+++ b/examples/cuda/test_float_matrix_mul_shared_mem/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = float_matrix_mul_shared_mem
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_float_vec_add/Makefile
+++ b/examples/cuda/test_float_vec_add/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_float_vec_add/Makefile
+++ b/examples/cuda/test_float_vec_add/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = float_vec_add
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_float_vec_add_shared_mem/Makefile
+++ b/examples/cuda/test_float_vec_add_shared_mem/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_float_vec_add_shared_mem/Makefile
+++ b/examples/cuda/test_float_vec_add_shared_mem/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = float_vec_add_shared_mem
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_float_vec_div/Makefile
+++ b/examples/cuda/test_float_vec_div/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_float_vec_div/Makefile
+++ b/examples/cuda/test_float_vec_div/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = float_vec_div
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_float_vec_exp/Makefile
+++ b/examples/cuda/test_float_vec_exp/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_float_vec_exp/Makefile
+++ b/examples/cuda/test_float_vec_exp/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = float_vec_exp
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_float_vec_log/Makefile
+++ b/examples/cuda/test_float_vec_log/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = float_vec_log
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_float_vec_log/Makefile
+++ b/examples/cuda/test_float_vec_log/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_float_vec_mul/Makefile
+++ b/examples/cuda/test_float_vec_mul/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_float_vec_mul/Makefile
+++ b/examples/cuda/test_float_vec_mul/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = float_vec_mul
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_float_vec_sqrt/Makefile
+++ b/examples/cuda/test_float_vec_sqrt/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_float_vec_sqrt/Makefile
+++ b/examples/cuda/test_float_vec_sqrt/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = float_vec_sqrt
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_hammer_cache/Makefile
+++ b/examples/cuda/test_hammer_cache/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = hammer_cache
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_hammer_cache/Makefile
+++ b/examples/cuda/test_hammer_cache/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_high_mem/Makefile
+++ b/examples/cuda/test_high_mem/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_high_mem/Makefile
+++ b/examples/cuda/test_high_mem/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = high_mem
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_host_memset/Makefile
+++ b/examples/cuda/test_host_memset/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_host_memset/Makefile
+++ b/examples/cuda/test_host_memset/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = host_memset
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_loader/Makefile
+++ b/examples/cuda/test_loader/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_loader/Makefile
+++ b/examples/cuda/test_loader/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = loader
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_loader_pod/Makefile
+++ b/examples/cuda/test_loader_pod/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = loader_pod
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_loader_pod/Makefile
+++ b/examples/cuda/test_loader_pod/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_log_softmax/Makefile
+++ b/examples/cuda/test_log_softmax/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = log_softmax
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_log_softmax/Makefile
+++ b/examples/cuda/test_log_softmax/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_matrix_mul/Makefile
+++ b/examples/cuda/test_matrix_mul/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_matrix_mul/Makefile
+++ b/examples/cuda/test_matrix_mul/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = matrix_mul
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_matrix_mul_shared_mem/Makefile
+++ b/examples/cuda/test_matrix_mul_shared_mem/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = matrix_mul_shared_mem
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_matrix_mul_shared_mem/Makefile
+++ b/examples/cuda/test_matrix_mul_shared_mem/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_max_pool2d/Makefile
+++ b/examples/cuda/test_max_pool2d/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_max_pool2d/Makefile
+++ b/examples/cuda/test_max_pool2d/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = max_pool2d
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_memory_leak/Makefile
+++ b/examples/cuda/test_memory_leak/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_memory_leak/Makefile
+++ b/examples/cuda/test_memory_leak/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = memory_leak
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_multiple_binary_load/Makefile
+++ b/examples/cuda/test_multiple_binary_load/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_multiple_binary_load/Makefile
+++ b/examples/cuda/test_multiple_binary_load/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = multiple_binary_load
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_profiler/Makefile
+++ b/examples/cuda/test_profiler/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_profiler/Makefile
+++ b/examples/cuda/test_profiler/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = profiler
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_shared_mem/Makefile
+++ b/examples/cuda/test_shared_mem/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_shared_mem/Makefile
+++ b/examples/cuda/test_shared_mem/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = shared_mem
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_shared_mem_load_store/Makefile
+++ b/examples/cuda/test_shared_mem_load_store/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_shared_mem_load_store/Makefile
+++ b/examples/cuda/test_shared_mem_load_store/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = shared_mem_load_store
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_softmax/Makefile
+++ b/examples/cuda/test_softmax/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = softmax
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_softmax/Makefile
+++ b/examples/cuda/test_softmax/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_stack_load/Makefile
+++ b/examples/cuda/test_stack_load/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = stack_load
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_stack_load/Makefile
+++ b/examples/cuda/test_stack_load/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_tracer/Makefile
+++ b/examples/cuda/test_tracer/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_tracer/Makefile
+++ b/examples/cuda/test_tracer/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = tracer
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_vec_add/Makefile
+++ b/examples/cuda/test_vec_add/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_vec_add/Makefile
+++ b/examples/cuda/test_vec_add/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = vec_add
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_vec_add_dma/Makefile
+++ b/examples/cuda/test_vec_add_dma/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_vec_add_dma/Makefile
+++ b/examples/cuda/test_vec_add_dma/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = vec_add_dma
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_vec_add_parallel/Makefile
+++ b/examples/cuda/test_vec_add_parallel/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = vec_add_parallel
 
@@ -118,18 +116,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_vec_add_parallel/Makefile
+++ b/examples/cuda/test_vec_add_parallel/Makefile
@@ -115,7 +115,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_vec_add_parallel_multi_grid/Makefile
+++ b/examples/cuda/test_vec_add_parallel_multi_grid/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = vec_add_parallel_multi_grid
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_vec_add_parallel_multi_grid/Makefile
+++ b/examples/cuda/test_vec_add_parallel_multi_grid/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_vec_add_serial_multi_grid/Makefile
+++ b/examples/cuda/test_vec_add_serial_multi_grid/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_vec_add_serial_multi_grid/Makefile
+++ b/examples/cuda/test_vec_add_serial_multi_grid/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = vec_add_serial_multi_grid
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/cuda/test_vec_add_shared_mem/Makefile
+++ b/examples/cuda/test_vec_add_shared_mem/Makefile
@@ -118,7 +118,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/cuda/test_vec_add_shared_mem/Makefile
+++ b/examples/cuda/test_vec_add_shared_mem/Makefile
@@ -45,8 +45,6 @@ include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = vec_add_shared_mem
 
@@ -121,18 +119,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/library/test_coordinate/Makefile
+++ b/examples/library/test_coordinate/Makefile
@@ -43,8 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -94,18 +92,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/library/test_coordinate/Makefile
+++ b/examples/library/test_coordinate/Makefile
@@ -91,7 +91,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/library/test_dma/Makefile
+++ b/examples/library/test_dma/Makefile
@@ -92,7 +92,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/library/test_dma/Makefile
+++ b/examples/library/test_dma/Makefile
@@ -43,8 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -95,18 +93,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/library/test_get_cycle/Makefile
+++ b/examples/library/test_get_cycle/Makefile
@@ -43,8 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -94,18 +92,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/library/test_get_cycle/Makefile
+++ b/examples/library/test_get_cycle/Makefile
@@ -91,7 +91,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/library/test_manycore_alignment/Makefile
+++ b/examples/library/test_manycore_alignment/Makefile
@@ -43,8 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -94,18 +92,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/library/test_manycore_alignment/Makefile
+++ b/examples/library/test_manycore_alignment/Makefile
@@ -91,7 +91,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/library/test_manycore_compile/Makefile
+++ b/examples/library/test_manycore_compile/Makefile
@@ -43,8 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -94,18 +92,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/library/test_manycore_compile/Makefile
+++ b/examples/library/test_manycore_compile/Makefile
@@ -91,7 +91,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/library/test_manycore_credits/Makefile
+++ b/examples/library/test_manycore_credits/Makefile
@@ -43,8 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -94,18 +92,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/library/test_manycore_credits/Makefile
+++ b/examples/library/test_manycore_credits/Makefile
@@ -91,7 +91,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/library/test_manycore_dmem_read_write/Makefile
+++ b/examples/library/test_manycore_dmem_read_write/Makefile
@@ -43,8 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -94,18 +92,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/library/test_manycore_dmem_read_write/Makefile
+++ b/examples/library/test_manycore_dmem_read_write/Makefile
@@ -91,7 +91,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/library/test_manycore_dram_read_write/Makefile
+++ b/examples/library/test_manycore_dram_read_write/Makefile
@@ -43,8 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -94,18 +92,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/library/test_manycore_dram_read_write/Makefile
+++ b/examples/library/test_manycore_dram_read_write/Makefile
@@ -91,7 +91,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/library/test_manycore_eva/Makefile
+++ b/examples/library/test_manycore_eva/Makefile
@@ -43,8 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -94,18 +92,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/library/test_manycore_eva/Makefile
+++ b/examples/library/test_manycore_eva/Makefile
@@ -91,7 +91,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/library/test_manycore_eva_read_write/Makefile
+++ b/examples/library/test_manycore_eva_read_write/Makefile
@@ -43,8 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -94,18 +92,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/library/test_manycore_eva_read_write/Makefile
+++ b/examples/library/test_manycore_eva_read_write/Makefile
@@ -91,7 +91,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/library/test_manycore_init/Makefile
+++ b/examples/library/test_manycore_init/Makefile
@@ -43,8 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -94,18 +92,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/library/test_manycore_init/Makefile
+++ b/examples/library/test_manycore_init/Makefile
@@ -91,7 +91,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/library/test_manycore_packets/Makefile
+++ b/examples/library/test_manycore_packets/Makefile
@@ -43,8 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -97,18 +95,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/library/test_manycore_packets/Makefile
+++ b/examples/library/test_manycore_packets/Makefile
@@ -94,7 +94,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/library/test_manycore_vcache_sequence/Makefile
+++ b/examples/library/test_manycore_vcache_sequence/Makefile
@@ -43,8 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -94,18 +92,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/library/test_manycore_vcache_sequence/Makefile
+++ b/examples/library/test_manycore_vcache_sequence/Makefile
@@ -91,7 +91,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/library/test_packet/Makefile
+++ b/examples/library/test_packet/Makefile
@@ -43,8 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -94,18 +92,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/library/test_packet/Makefile
+++ b/examples/library/test_packet/Makefile
@@ -91,7 +91,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/library/test_pod_iteration/Makefile
+++ b/examples/library/test_pod_iteration/Makefile
@@ -43,8 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -94,18 +92,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/library/test_pod_iteration/Makefile
+++ b/examples/library/test_pod_iteration/Makefile
@@ -91,7 +91,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/library/test_printing/Makefile
+++ b/examples/library/test_printing/Makefile
@@ -43,8 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -94,18 +92,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/library/test_printing/Makefile
+++ b/examples/library/test_printing/Makefile
@@ -91,7 +91,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/library/test_read_mem_scatter_gather/Makefile
+++ b/examples/library/test_read_mem_scatter_gather/Makefile
@@ -43,8 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -94,18 +92,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/library/test_read_mem_scatter_gather/Makefile
+++ b/examples/library/test_read_mem_scatter_gather/Makefile
@@ -91,7 +91,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/library/test_rom/Makefile
+++ b/examples/library/test_rom/Makefile
@@ -95,7 +95,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/library/test_rom/Makefile
+++ b/examples/library/test_rom/Makefile
@@ -43,9 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
-
 ###############################################################################
 # Host code compilation flags and flow
 ###############################################################################
@@ -98,18 +95,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/library/test_struct_size/Makefile
+++ b/examples/library/test_struct_size/Makefile
@@ -43,8 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -94,18 +92,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/library/test_struct_size/Makefile
+++ b/examples/library/test_struct_size/Makefile
@@ -91,7 +91,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/library/test_vcache_flush/Makefile
+++ b/examples/library/test_vcache_flush/Makefile
@@ -43,8 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -94,18 +92,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/library/test_vcache_flush/Makefile
+++ b/examples/library/test_vcache_flush/Makefile
@@ -91,7 +91,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/library/test_vcache_sequence/Makefile
+++ b/examples/library/test_vcache_sequence/Makefile
@@ -43,8 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -94,18 +92,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/library/test_vcache_sequence/Makefile
+++ b/examples/library/test_vcache_sequence/Makefile
@@ -91,7 +91,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/library/test_vcache_simplified/Makefile
+++ b/examples/library/test_vcache_simplified/Makefile
@@ -43,8 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -94,18 +92,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/library/test_vcache_simplified/Makefile
+++ b/examples/library/test_vcache_simplified/Makefile
@@ -91,7 +91,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/library/test_vcache_stride/Makefile
+++ b/examples/library/test_vcache_stride/Makefile
@@ -43,8 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -94,18 +92,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/library/test_vcache_stride/Makefile
+++ b/examples/library/test_vcache_stride/Makefile
@@ -91,7 +91,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/link.mk
+++ b/examples/link.mk
@@ -47,6 +47,4 @@ include $(BSG_PLATFORM_PATH)/link.mk
 .PHONY: link.clean
 link.clean:
 
-clean: link.clean
-
 endif

--- a/examples/python/test_loader/Makefile
+++ b/examples/python/test_loader/Makefile
@@ -93,7 +93,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/python/test_loader/Makefile
+++ b/examples/python/test_loader/Makefile
@@ -43,8 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -96,18 +94,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/spmd/loader.mk
+++ b/examples/spmd/loader.mk
@@ -44,9 +44,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 
-ifndef TEST_NAME
-$(error $(shell echo -e "$(RED)BSG MAKE ERROR: TEST_NAME is not defined$(NC)"))
-endif
 ifndef SPMD_NAME
 $(error $(shell echo -e "$(RED)BSG MAKE ERROR: SPMD_NAME is not defined$(NC)"))
 endif
@@ -116,18 +113,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: main.exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/spmd/loader.mk
+++ b/examples/spmd/loader.mk
@@ -110,7 +110,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 .DEFAULT_GOAL := help

--- a/examples/spmd/test_bsg_dram_loopback_cache/Makefile
+++ b/examples/spmd/test_bsg_dram_loopback_cache/Makefile
@@ -44,8 +44,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # SPMD name is the name of the SPMD test
 SPMD_NAME = bsg_dram_loopback_cache
 
@@ -116,18 +114,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/spmd/test_bsg_dram_loopback_cache/Makefile
+++ b/examples/spmd/test_bsg_dram_loopback_cache/Makefile
@@ -113,7 +113,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/spmd/test_bsg_loader_suite/Makefile
+++ b/examples/spmd/test_bsg_loader_suite/Makefile
@@ -44,8 +44,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # SPMD name is the name of the SPMD test
 SPMD_NAME = bsg_loader_suite
 
@@ -116,18 +114,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/spmd/test_bsg_loader_suite/Makefile
+++ b/examples/spmd/test_bsg_loader_suite/Makefile
@@ -113,7 +113,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/spmd/test_bsg_print_stat/Makefile
+++ b/examples/spmd/test_bsg_print_stat/Makefile
@@ -44,8 +44,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # SPMD name is the name of the SPMD test
 SPMD_NAME = bsg_print_stat
 

--- a/examples/spmd/test_bsg_scalar_print/Makefile
+++ b/examples/spmd/test_bsg_scalar_print/Makefile
@@ -44,8 +44,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # SPMD name is the name of the SPMD test
 SPMD_NAME = bsg_scalar_print
 
@@ -116,18 +114,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/spmd/test_bsg_scalar_print/Makefile
+++ b/examples/spmd/test_bsg_scalar_print/Makefile
@@ -113,7 +113,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/spmd/test_fib/Makefile
+++ b/examples/spmd/test_fib/Makefile
@@ -44,8 +44,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # SPMD name is the name of the SPMD test
 SPMD_NAME = fib
 

--- a/examples/spmd/test_loader/Makefile
+++ b/examples/spmd/test_loader/Makefile
@@ -43,8 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 
 SPMD_TESTS = fib
 
@@ -112,18 +110,7 @@ $(EXE_TARGETS):
 %.vpd: SIM_ARGS += +vpdfile+$(@:.debug.log=.vpd)
 %.vpd: %.debug.log ;
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/spmd/test_putchar_stream/Makefile
+++ b/examples/spmd/test_putchar_stream/Makefile
@@ -44,8 +44,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # SPMD name is the name of the SPMD test
 SPMD_NAME = putchar_stream
 

--- a/examples/spmd/test_saif/Makefile
+++ b/examples/spmd/test_saif/Makefile
@@ -44,8 +44,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # SPMD name is the name of the SPMD test
 SPMD_NAME = saif
 

--- a/examples/spmd/test_symbol_to_eva/Makefile
+++ b/examples/spmd/test_symbol_to_eva/Makefile
@@ -44,8 +44,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
 
-# TEST_NAME is the basename of the executable
-TEST_NAME = main
 # SPMD name is the name of the SPMD test
 SPMD_NAME = symbol_to_eva
 
@@ -116,18 +114,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/spmd/test_symbol_to_eva/Makefile
+++ b/examples/spmd/test_symbol_to_eva/Makefile
@@ -113,7 +113,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/unit/L2/read-set/template.mk
+++ b/examples/unit/L2/read-set/template.mk
@@ -53,18 +53,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/unit/L2/read-set/template.mk
+++ b/examples/unit/L2/read-set/template.mk
@@ -50,7 +50,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/unit/L2/read-set2/template.mk
+++ b/examples/unit/L2/read-set2/template.mk
@@ -53,18 +53,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/examples/unit/L2/read-set2/template.mk
+++ b/examples/unit/L2/read-set2/template.mk
@@ -50,7 +50,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/unit/vcore-tile/dmem-rw/template.mk
+++ b/examples/unit/vcore-tile/dmem-rw/template.mk
@@ -53,17 +53,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
 
 
 .PHONY: clean

--- a/examples/unit/vcore-tile/dmem-rw/template.mk
+++ b/examples/unit/vcore-tile/dmem-rw/template.mk
@@ -50,7 +50,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/unit/vcore-tile/icache/template.mk
+++ b/examples/unit/vcore-tile/icache/template.mk
@@ -64,7 +64,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: main.exec.log
+regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 ###############################################################################

--- a/examples/unit/vcore-tile/icache/template.mk
+++ b/examples/unit/vcore-tile/icache/template.mk
@@ -67,18 +67,7 @@ include $(EXAMPLES_PATH)/execution.mk
 regression: exec.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
-###############################################################################
-# Default rules, help, and clean
-###############################################################################
 .DEFAULT_GOAL := help
-help:
-	@echo "Usage:"
-	@echo "make {clean | $(TEST_NAME).{profile,debug} | $(TEST_NAME).{profile,debug}.log}"
-	@echo "      $(TEST_NAME).profile: Build executable with profilers enabled"
-	@echo "      $(TEST_NAME).debug: Build waveform executable (if VCS)"
-	@echo "      $(TEST_NAME).{profile,debug}.log: Run specific executable"
-	@echo "      clean: Remove all subdirectory-specific outputs"
-
 
 .PHONY: clean
 

--- a/libraries/platforms/bigblade-vcs/bsg_manycore_regression_platform.c
+++ b/libraries/platforms/bigblade-vcs/bsg_manycore_regression_platform.c
@@ -1,6 +1,7 @@
 #include <stdint.h>
 #include <unistd.h>
 #include <bsg_manycore_regression.h>
+#include <dlfcn.h>
 // Given a string, determine the number of space-separated arguments
 static int get_argc(char * args){
         char *cur = args, prev=' ';
@@ -50,16 +51,37 @@ void get_argv(char * args, int argc, char **argv){
 }
 
 // This function is the VCS hook for cosimulation
-void cosim_main(uint32_t *exit_code, char *args) {
+void cosim_main(uint32_t *exit_code, char *args, char *sopath) {
         // We aren't passed command line arguments directly so we parse them
         // from *args. args is a string from VCS - to pass a string of arguments
         // to args, pass c_args to VCS as follows: +c_args="<space separated
         // list of args>"
         int argc = get_argc(args);
         char *argv[argc];
+        char *error;
         get_argv(args, argc, argv);
 
-        int rc = vcs_main(argc, argv);
+        // To reduce the number of VCS compilations we do, this
+        // platform compiles the executable machine and then loads the
+        // program as a shared object file. This shared object is
+        // passed as the string sopath and _must_ define a method
+        // vcs_main that can be called as the main function of the
+        // program
+        void *handle = dlopen(sopath, RTLD_LAZY | RTLD_DEEPBIND);
+	printf("%s\n", sopath);
+        int (*vcs_main)(int , char **) = dlsym(handle, "vcs_main");
+
+        error = dlerror();
+        if (error != NULL) {
+                bsg_pr_err("Error when finding dynamically loaded symbol vcs_main: %s\n", error);
+                *exit_code = -1;
+                dlclose(handle);
+                return;
+        }
+
+        int rc = (*vcs_main)(argc, argv);
+
+        dlclose(handle);
         *exit_code = rc;
         bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
         return;

--- a/libraries/platforms/bigblade-vcs/bsg_manycore_regression_platform.c
+++ b/libraries/platforms/bigblade-vcs/bsg_manycore_regression_platform.c
@@ -68,7 +68,6 @@ void cosim_main(uint32_t *exit_code, char *args, char *sopath) {
         // vcs_main that can be called as the main function of the
         // program
         void *handle = dlopen(sopath, RTLD_LAZY | RTLD_DEEPBIND);
-	printf("%s\n", sopath);
         int (*vcs_main)(int , char **) = dlsym(handle, "vcs_main");
 
         error = dlerror();

--- a/libraries/platforms/bigblade-vcs/compilation.mk
+++ b/libraries/platforms/bigblade-vcs/compilation.mk
@@ -40,8 +40,9 @@ DEFINES    += -DVCS
 INCLUDES   += -I$(LIBRARIES_PATH)
 INCLUDES   += -I$(BSG_PLATFORM_PATH)
 
-CXXFLAGS   += -lstdc++ $(DEFINES)
-CFLAGS     += $(DEFINES)
+LDFLAGS    += -lstdc++ -lc -L$(BSG_PLATFORM_PATH)
+CXXFLAGS   += $(DEFINES) -fPIC
+CFLAGS     += $(DEFINES) -fPIC
 
 # each regression target needs to build its .o from a .c and .h of the
 # same name
@@ -52,10 +53,19 @@ CFLAGS     += $(DEFINES)
 %.o: %.cpp
 	$(CXX) -c -o $@ $< $(INCLUDES) $(CXXFLAGS) $(CXXDEFINES)
 
-.PRECIOUS: %.o
+# Compile all of the sources into a shared object file for dynamic loading.
+TEST_CSOURCES   += $(filter %.c,$(TEST_SOURCES))
+TEST_CXXSOURCES += $(filter %.cpp,$(TEST_SOURCES))
+TEST_OBJECTS    += $(TEST_CXXSOURCES:.cpp=.o)
+TEST_OBJECTS    += $(TEST_CSOURCES:.c=.o)
+
+main.so: $(TEST_OBJECTS)
+	$(CXX) -shared -o $@ $^ $(LDFLAGS)
+
+.PRECIOUS: %.o %.so
 
 .PHONY: platform.compilation.clean
 platform.compilation.clean:
-	rm -rf *.o
+	rm -rf *.o *.so
 
 compilation.clean: platform.compilation.clean

--- a/libraries/platforms/bigblade-vcs/execution.mk
+++ b/libraries/platforms/bigblade-vcs/execution.mk
@@ -76,3 +76,12 @@ platform.execution.clean:
 	rm -rf dramsim3.json dramsim3.tag.json dramsim3.txt dramsim3epoch.json
 
 execution.clean: platform.execution.clean
+
+help:
+	@echo "Usage:"
+	@echo "make {clean | exec.log | profile.log | debug.log | debug.vpd | saifgen.log | saifgen.saif }"
+	@echo "      exec.log: Run program with SAIF, profilers, and waveform generation disabled (Fastest)"
+	@echo "      profile.log: Run program with profilers enabled, SAIF and waveform generation disabled"
+	@echo "      saifgen.log saifgen.saif: Run program with SAIF generation enabled, profilers and waveform generation disabled"
+	@echo "      debug.log debug.vpd: Run program with waveform and profiles enabled, SAIF generation disabled"
+	@echo "      clean: Remove all subdirectory-specific outputs"

--- a/libraries/platforms/bigblade-vcs/hardware/dpi_top.sv
+++ b/libraries/platforms/bigblade-vcs/hardware/dpi_top.sv
@@ -324,13 +324,15 @@ module replicant_tb_top
    //
    // This mirrors the DPI functions in aws simulation
 `ifndef VERILATOR
-   import "DPI-C" context task cosim_main(output int unsigned exit_code, input string args);
+   import "DPI-C" context task cosim_main(output int unsigned exit_code, input string args, input string path);
    initial begin
       int exit_code;
       string args;
+      string path;
       longint t;
+      $value$plusargs("c_path=%s", path);
       $value$plusargs("c_args=%s", args);
-      replicant_tb_top.cosim_main(exit_code, args);
+      replicant_tb_top.cosim_main(exit_code, args, path);
       if(exit_code < 0) begin
         $display("BSG COSIM FAIL: Test failed with exit code: %d", exit_code);
         $fatal;
@@ -339,7 +341,6 @@ module replicant_tb_top
         $finish;
       end
    end
-
 `endif
 
 `ifdef BSG_MACHINE_ENABLE_SAIF

--- a/libraries/platforms/bigblade-vcs/library.mk
+++ b/libraries/platforms/bigblade-vcs/library.mk
@@ -34,9 +34,6 @@ PLATFORM_CXXSOURCES += $(LIBRARIES_PATH)/features/tracer/simulation/bsg_manycore
 
 PLATFORM_REGRESSION_CSOURCES += $(LIBRARIES_PATH)/platforms/bigblade-vcs/bsg_manycore_regression_platform.c
 
-# The aws-vcs platform supports simulation DMA on certain
-# machines. Support is determined by the memory system configuration
-# at runtime.
 include $(LIBRARIES_PATH)/features/dma/simulation/feature.mk
 
 PLATFORM_OBJECTS += $(patsubst %cpp,%o,$(PLATFORM_CXXSOURCES))
@@ -58,6 +55,7 @@ $(PLATFORM_OBJECTS) $(PLATFORM_REGRESSION_OBJECTS): INCLUDES += -I$(BASEJUMP_STL
 $(PLATFORM_OBJECTS) $(PLATFORM_REGRESSION_OBJECTS): CFLAGS    = -std=c11 -fPIC -D_GNU_SOURCE -D_DEFAULT_SOURCE -DVERILATOR $(INCLUDES)
 $(PLATFORM_OBJECTS) $(PLATFORM_REGRESSION_OBJECTS): CXXFLAGS  = -std=c++11 -fPIC -D_GNU_SOURCE -D_DEFAULT_SOURCE -DVERILATOR $(INCLUDES)
 $(PLATFORM_OBJECTS) $(PLATFORM_REGRESSION_OBJECTS): LDFLAGS   = -fPIC
+$(PLATFORM_REGRESSION_OBJECTS): LDFLAGS   = -ldl
 
 $(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so.1.0: $(PLATFORM_OBJECTS)
 $(BSG_PLATFORM_PATH)/libbsg_manycore_regression.so.1.0: $(PLATFORM_REGRESSION_OBJECTS)
@@ -83,7 +81,7 @@ $(BSG_PLATFORM_PATH)/libbsg_manycore_regression.so: %: %.1
 	ln -sf $@.1 $@
 
 platform.clean:
-	rm -f $(PLATFORM_OBJECTS)
+	rm -f $(PLATFORM_OBJECTS) $(PLATFORM_REGRESSION_OBJECTS)
 	rm -f $(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so
 	rm -f $(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so.1
 	rm -f $(BSG_PLATFORM_PATH)/libbsg_manycore_regression.so*

--- a/libraries/platforms/bigblade-vcs/link.mk
+++ b/libraries/platforms/bigblade-vcs/link.mk
@@ -48,14 +48,11 @@ include $(HARDWARE_PATH)/hardware.mk
 # pre-linked against all other simulation binaries.
 include $(LIBRARIES_PATH)/libraries.mk
 
-
 # VHEADERS must be compiled before VSOURCES.
 VDEFINES += BSG_MACHINE_ORIGIN_X_CORD=$(BSG_MACHINE_ORIGIN_COORD_X)
 VDEFINES += BSG_MACHINE_ORIGIN_Y_CORD=$(BSG_MACHINE_ORIGIN_COORD_Y)
 VDEFINES += HOST_MODULE_PATH=replicant_tb_top
 VDEFINES += BSG_MACHINE_DRAMSIM3_PKG=$(BSG_MACHINE_MEM_DRAMSIM3_PKG)
-# VLOGAN_VFLAGS   += +systemverilogext+.svh +systemverilogext+.sv
-# VLOGAN_VFLAGS   += +libext+.sv +libext+.v +libext+.vh +libext+.svh
 
 # libbsg_manycore_runtime will be compiled in $(BSG_PLATFORM_PATH)
 VLDFLAGS += -L$(BSG_PLATFORM_PATH) -Wl,-rpath=$(BSG_PLATFORM_PATH)

--- a/libraries/platforms/bigblade-vcs/link.mk
+++ b/libraries/platforms/bigblade-vcs/link.mk
@@ -48,104 +48,66 @@ include $(HARDWARE_PATH)/hardware.mk
 # pre-linked against all other simulation binaries.
 include $(LIBRARIES_PATH)/libraries.mk
 
+
 # VHEADERS must be compiled before VSOURCES.
 VDEFINES += BSG_MACHINE_ORIGIN_X_CORD=$(BSG_MACHINE_ORIGIN_COORD_X)
 VDEFINES += BSG_MACHINE_ORIGIN_Y_CORD=$(BSG_MACHINE_ORIGIN_COORD_Y)
 VDEFINES += HOST_MODULE_PATH=replicant_tb_top
 VDEFINES += BSG_MACHINE_DRAMSIM3_PKG=$(BSG_MACHINE_MEM_DRAMSIM3_PKG)
-VLOGAN_SOURCES  += $(VHEADERS) $(VSOURCES)
-VLOGAN_INCLUDES += $(foreach inc,$(VINCLUDES),+incdir+"$(inc)")
-VLOGAN_DEFINES  += $(foreach def,$(VDEFINES),+define+"$(def)")
-VLOGAN_VFLAGS   += -timescale=1ps/1ps
-VLOGAN_VFLAGS   += -sverilog
-VLOGAN_VFLAGS   += +systemverilogext+.svh +systemverilogext+.sv
-VLOGAN_VFLAGS   += +libext+.sv +libext+.v +libext+.vh +libext+.svh
-VLOGAN_VFLAGS   += -full64 -lca -assert svaext
-VLOGAN_VFLAGS   += -undef_vcs_macro
-VLOGAN_FLAGS    = $(VLOGAN_VFLAGS) $(VLOGAN_DEFINES) $(VLOGAN_INCLUDES) $(VLOGAN_SOURCES)
-
-$(BSG_MACHINE_PATH)/$(BSG_PLATFORM):
-	mkdir -p $@
-
-$(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/synopsys_sim.setup: | $(BSG_MACHINE_PATH)/$(BSG_PLATFORM)
-	echo "replicant_tb_top : $(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/vcs_simlibs/replicant_tb_top/64" >> $@;
-
-# The SAIF-generation simulation and fast simulation (exec) turns off the profilers using macros
-# so it must be compiled into a separate library.
-$(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/synopsys_sim.saifgen: | $(BSG_MACHINE_PATH)/$(BSG_PLATFORM)
-	echo "replicant_tb_top : $(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/vcs_simlibs/replicant_tb_top_saifgen/64" >> $@;
-
-$(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/synopsys_sim.exec: | $(BSG_MACHINE_PATH)/$(BSG_PLATFORM)
-	echo "replicant_tb_top : $(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/vcs_simlibs/replicant_tb_top_exec/64" >> $@;
-
-$(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/vcs_simlibs/replicant_tb_top/AN.DB: $(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/synopsys_sim.setup $(VLOGAN_SOURCES)
-	SYNOPSYS_SIM_SETUP=$< vlogan -work replicant_tb_top $(VLOGAN_FLAGS) -l $(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/vlogan.log
-
-$(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/vcs_simlibs/replicant_tb_top_saifgen/AN.DB $(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/vcs_simlibs/replicant_tb_top_exec/AN.DB: VDEFINES += BSG_MACHINE_DISABLE_VCORE_PROFILING
-$(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/vcs_simlibs/replicant_tb_top_saifgen/AN.DB $(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/vcs_simlibs/replicant_tb_top_exec/AN.DB: VDEFINES += BSG_MACHINE_DISABLE_CACHE_PROFILING
-$(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/vcs_simlibs/replicant_tb_top_saifgen/AN.DB $(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/vcs_simlibs/replicant_tb_top_exec/AN.DB: VDEFINES += BSG_MACHINE_DISABLE_ROUTER_PROFILING
-
-$(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/vcs_simlibs/replicant_tb_top_saifgen/AN.DB: VDEFINES += BSG_MACHINE_ENABLE_SAIF
-$(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/vcs_simlibs/replicant_tb_top_saifgen/AN.DB: $(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/synopsys_sim.saifgen $(VLOGAN_SOURCES)
-	SYNOPSYS_SIM_SETUP=$< vlogan -work replicant_tb_top -debug_access+pp $(VLOGAN_FLAGS) -l $(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/vlogan.saifgen.log
-
-$(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/vcs_simlibs/replicant_tb_top_exec/AN.DB: $(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/synopsys_sim.exec $(VLOGAN_SOURCES)
-	SYNOPSYS_SIM_SETUP=$< vlogan -work replicant_tb_top $(VLOGAN_FLAGS) -l $(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/vlogan.exec.log
+# VLOGAN_VFLAGS   += +systemverilogext+.svh +systemverilogext+.sv
+# VLOGAN_VFLAGS   += +libext+.sv +libext+.v +libext+.vh +libext+.svh
 
 # libbsg_manycore_runtime will be compiled in $(BSG_PLATFORM_PATH)
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -Wl,-rpath=$(BSG_PLATFORM_PATH)
-LDFLAGS += -lbsg_manycore_regression -lbsg_manycore_runtime -lm
-
-VCS_LDFLAGS += $(foreach def,$(LDFLAGS),-LDFLAGS "$(def)")
+VLDFLAGS += -L$(BSG_PLATFORM_PATH) -Wl,-rpath=$(BSG_PLATFORM_PATH)
+VLDFLAGS += -lbsg_manycore_regression -lbsg_manycore_runtime -lm
+VCS_LDFLAGS += $(foreach def,$(VLDFLAGS),-LDFLAGS "$(def)")
 VCS_VFLAGS  += -M -L -ntb_opts tb_timescale=1ps/1ps -lca
 VCS_VFLAGS  += -timescale=1ps/1ps -sverilog -full64 -licqueue -q
+VCS_VFLAGS  += -assert svaext -undef_vcs_macro
 VCS_VFLAGS  += +warn=noLCA_FEATURES_ENABLED
 VCS_VFLAGS  += +warn=noMC-FCNAFTMI
 VCS_VFLAGS  += +lint=all,TFIPC-L,noSVA-UA,noSVA-NSVU,noVCDE,noSVA-AECASR
-VCS_FLAGS   = $(VCS_LDFLAGS) $(VCS_VFLAGS)
+VCS_INCLUDES += $(foreach inc,$(VINCLUDES),+incdir+"$(inc)")
+VCS_DEFINES  += $(foreach def,$(VDEFINES),+define+"$(def)")
+VCS_FLAGS   = $(VCS_LDFLAGS) $(VCS_VFLAGS) $(VCS_INCLUDES) $(VCS_DEFINES)
+VCS_VSOURCES = $(VHEADERS) $(VSOURCES)
 
-TEST_CSOURCES   += $(filter %.c,$(TEST_SOURCES))
-TEST_CXXSOURCES += $(filter %.cpp,$(TEST_SOURCES))
-TEST_OBJECTS    += $(TEST_CXXSOURCES:.cpp=.o)
-TEST_OBJECTS    += $(TEST_CSOURCES:.c=.o)
+$(BSG_MACHINExPLATFORM_PATH)/debug/simv: VCS_VFLAGS += +plusarg_save +vcs+vcdpluson +vcs+vcdplusmemon +memcbk -debug_pp
 
-# VCS Generates an executable file by linking the TEST_OBJECTS with
-# the the VCS work libraries for the design, and the runtime shared
-# libraries
+$(BSG_MACHINExPLATFORM_PATH)/saifgen/simv $(BSG_MACHINExPLATFORM_PATH)/exec/simv: VDEFINES += BSG_MACHINE_DISABLE_VCORE_PROFILING
+$(BSG_MACHINExPLATFORM_PATH)/saifgen/simv $(BSG_MACHINExPLATFORM_PATH)/exec/simv: VDEFINES += BSG_MACHINE_DISABLE_CACHE_PROFILING
+$(BSG_MACHINExPLATFORM_PATH)/saifgen/simv $(BSG_MACHINExPLATFORM_PATH)/exec/simv: VDEFINES += BSG_MACHINE_DISABLE_ROUTER_PROFILING
 
-%.saifgen %.debug: VCS_VFLAGS += -debug_pp
-%.debug: VCS_VFLAGS += +plusarg_save +vcs+vcdpluson +vcs+vcdplusmemon +memcbk
+$(BSG_MACHINExPLATFORM_PATH)/saifgen/simv: VDEFINES += BSG_MACHINE_ENABLE_SAIF
+$(BSG_MACHINExPLATFORM_PATH)/saifgen/simv: VCS_VFLAGS += -debug_pp
 
-%.debug %.profile: $(TEST_OBJECTS) $(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/vcs_simlibs/replicant_tb_top/AN.DB $(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so $(BSG_PLATFORM_PATH)/libbsgmc_cuda_legacy_pod_repl.so $(BSG_PLATFORM_PATH)/libbsg_manycore_regression.so
-	SYNOPSYS_SIM_SETUP=$(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/synopsys_sim.setup \
-	vcs -top replicant_tb_top $(TEST_OBJECTS) $(VCS_FLAGS) -Mdirectory=$@.tmp -l $@.vcs.log -o $@
+$(BSG_MACHINExPLATFORM_PATH)/exec $(BSG_MACHINExPLATFORM_PATH)/debug $(BSG_MACHINExPLATFORM_PATH)/saifgen $(BSG_MACHINExPLATFORM_PATH)/profile:
+	mkdir -p $@
 
-%.saifgen: $(TEST_OBJECTS) $(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/vcs_simlibs/replicant_tb_top_saifgen/AN.DB $(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so $(BSG_PLATFORM_PATH)/libbsgmc_cuda_legacy_pod_repl.so $(BSG_PLATFORM_PATH)/libbsg_manycore_regression.so
-	SYNOPSYS_SIM_SETUP=$(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/synopsys_sim.saifgen \
-	vcs -top replicant_tb_top $(TEST_OBJECTS) $(VCS_FLAGS) -Mdirectory=$@.tmp -l $@.vcs.log -o $@
+%/simv: $(VCS_VSOURCES) | $(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so $(BSG_PLATFORM_PATH)/libbsgmc_cuda_legacy_pod_repl.so $(BSG_PLATFORM_PATH)/libbsg_manycore_regression.so %
+	vcs -top replicant_tb_top $(VCS_VSOURCES) $(VCS_FLAGS) -Mdirectory=$@.tmp -l $@.vcs.log -o $@
 
-%.exec: $(TEST_OBJECTS) $(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/vcs_simlibs/replicant_tb_top_exec/AN.DB $(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so $(BSG_PLATFORM_PATH)/libbsgmc_cuda_legacy_pod_repl.so $(BSG_PLATFORM_PATH)/libbsg_manycore_regression.so
-	SYNOPSYS_SIM_SETUP=$(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/synopsys_sim.exec \
-	vcs -top replicant_tb_top $(TEST_OBJECTS) $(VCS_FLAGS) -Mdirectory=$@.tmp -l $@.vcs.log -o $@
-
-.PRECIOUS:%.debug %.profile %.saifgen %.exec
+.PRECIOUS:$(BSG_MACHINExPLATFORM_PATH)/exec/simv
+.PRECIOUS:$(BSG_MACHINExPLATFORM_PATH)/debug/simv
+.PRECIOUS:$(BSG_MACHINExPLATFORM_PATH)/proile/simv
+.PRECIOUS:$(BSG_MACHINExPLATFORM_PATH)/saifgen/simv
 
 # When running recursive regression, make is launched in independent,
 # non-communicating parallel processes that try to build these objects
-# in parallel. That is no-bueno. We define REGRESSION_PREBUILD so that
-# regression tests can build them before launching parallel
-# compilation and execution
-REGRESSION_PREBUILD += $(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/vcs_simlibs/replicant_tb_top/AN.DB
-REGRESSION_PREBUILD += $(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/vcs_simlibs/replicant_tb_top_exec/AN.DB
-REGRESSION_PREBUILD += $(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/vcs_simlibs/replicant_tb_top_saifgen/AN.DB
+# in parallel. That can lead to processes stomping on each other. We
+# define REGRESSION_PREBUILD so that regression tests can build them
+# before launching parallel execution
+REGRESSION_PREBUILD += $(BSG_MACHINExPLATFORM_PATH)/exec/simv
+REGRESSION_PREBUILD += $(BSG_MACHINExPLATFORM_PATH)/debug/simv
+REGRESSION_PREBUILD += $(BSG_MACHINExPLATFORM_PATH)/profile/simv
+REGRESSION_PREBUILD += $(BSG_MACHINExPLATFORM_PATH)/saifgen/simv
 REGRESSION_PREBUILD += $(BSG_PLATFORM_PATH)/libbsgmc_cuda_legacy_pod_repl.so
 REGRESSION_PREBUILD += $(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so
 REGRESSION_PREBUILD += $(BSG_PLATFORM_PATH)/libbsg_manycore_regression.so
 
 .PHONY: platform.link.clean
 platform.link.clean:
-	rm -rf $(BSG_MACHINE_PATH)/$(BSG_PLATFORM)/
-	rm -rf $(BSG_PLATFORM_PATH)/msg_config
+	rm -rf $(BSG_MACHINExPLATFORM_PATH)
 	rm -rf ucli.key
 	rm -rf .cxl* *.jou
 	rm -rf *.daidir *.tmp

--- a/libraries/platforms/tapeout-vcs/execution.mk
+++ b/libraries/platforms/tapeout-vcs/execution.mk
@@ -71,3 +71,10 @@ platform.execution.clean:
 	rm -rf dramsim3.json dramsim3.tag.json dramsim3.txt dramsim3epoch.json
 
 execution.clean: platform.execution.clean
+
+help:
+	@echo "Usage:"
+	@echo "make {clean | exec.log | debug.log | debug.vpd}"
+	@echo "      exec.log: Run program with SAIF, profilers, and waveform generation disabled (Fastest)"
+	@echo "      debug.log debug.vpd: Run program with waveform and profiles enabled, SAIF generation disabled"
+	@echo "      clean: Remove all subdirectory-specific outputs"


### PR DESCRIPTION
Changed bigblade-vcs to the shared object flow used during tapeout. This reduces compilation cycles and (vastly) simplifies the makefiles.

* Output logs names are now standardized (exec.log, saifgen.log, debug.log, profile.log)
* Moved help rule into execution.mk to describe above (and make platform dependent)
* Removed TEST_NAME since it is no longer used