### PR TITLE
Update documents and machine configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,62 @@
-# BSG Replicant: Cosimulation and Emulation Infrastructure for HammerBlade
+# BSG Replicant: Execution/Emulation Infrastructure for HammerBlade
+
+## Quickstart
+
+The simplest way to use this project is to clone its meta-project: [BSG Bladerunner](https://github.com/bespoke-silicon-group/bsg_bladerunner/). 
+
+BSG Bladerunner tracks this repository, BSG Manycore, and BaseJump STL
+repositories as submodules and maintains a monotonic versionining
+scheme. 
+
+Once the setup instructions in BSG Bladrunner have been completed, run:
+
+`make regression`
+
+This will run all of the example programs in [examples](examples). See
+the README.md file in that directory for more information. We make
+every attempt to ensure the examples there are working.
 
 ## Contents
 
 This repository contains the following folders: 
 
-- `build`: Vivado scripts for building FPGA Design Checkpoint Files to upload to AWS-F1
-- `hardware`: HDL sources, ROM scripts, and package files
-- `libraries`: C/C++ driver and CUDA-lite Runtime library sources
+- `hardware`: HDL sources, package files, and ROM scripts.
+- `libraries`: C/C++ driver and runtime library sources.
 - `examples`: Example C/C++ applications and regression tests.
-- `machines`: Customized `Makefile.machine.include` file for different HammerBlade designs.
+- `machines`: Customized `Makefile.machine.include` file for different HammerBlade designs and configurations.
+- `build`: Vivado scripts for building FPGA Design Checkpoint Files to upload to AWS-F1. **Currently stale/not actively supported**.
 
 This repository contains the following files:
 
-- `README.md`: This file
-- `Makefile`: Contains targets for Bitstream Generation, and Regression
-- `platform.mk`: Defines the path to the current exeuction Platform (BSG_PLATFORM_PATH)
-- `machine.mk`: Defines the path to the current Machine Configuration (BSG_MACHINE_PATH)
+- `README.md`: This file.
+- `Makefile`: Targets for Regression, and (stale) bitstream generation commands.
+- `platform.mk`: Defines the path to the current exeuction Platform (BSG_PLATFORM_PATH).
+- `machine.mk`: Defines the path to the current Machine Configuration (BSG_MACHINE_PATH).
 - `environment.mk`: A makefile fragment for deducing the build environment.
-- `cadenv.mk`: A makefile fragment for deducing the CAD tool environment (e.g. VCS_HOME)
-- `hdk.mk`: A makefile fragment for deducing the AWS-FPGA HDK build environment.
+- `cadenv.mk`: A makefile fragment for deducing the CAD tool environment (e.g. VCS_HOME).
+- `hdk.mk`: A makefile fragment for deducing the AWS-FPGA HDK build environment (stale).
 
 ## Platforms
 
 HammerBlade applications can be run on multiple platforms. These
-platforms could simulate the manycore and run the host code natively
-(VCS, Verilator), emuate the manycore (AWS F1) and run the host code
-natively, or simulate the manycore and host (coming soon!).
+platforms could simulate the architecture (VCS, Verilator), emulate
+it, or run natively.
 
-We currently support four platforms:
+We currently support one platforms:
 
-- `aws-fpga`: Native (x86) host execution, Emulated Manycore (with an FPGA), 
-- `aws-vcs`: Native (x86) host execution, Simulated Manycore (with VCS, on a simulated FPGA)
-- `dpi-verilator`: Native (x86) host execution, Simulated Manycore (with Verilator, using DPI for IO)
-- `dpi-vcs`: Native (x86) host execution, Simulated Manycore (with VCS, using DPI for IO)
+- `bigblade-vcs`: Native (x86) host execution, simulated HammerBlade (with VCS, using Verilog DPI for IO)
+
+Support for verilator will be re-added in the future.
 
 Each platform has different advantages and drawbacks. Simulated
 platforms support an in-depth profiling infrastructure and emulated
 memory systems via non-synthesizable constructs. VCS is a 4-state
 simulator, but requires Synopsys and VCS licenses. Verilator does not
 require licenses, but it cannot simulated an FPGA system with
-encrypted HDL. The `aws-fpga` systems is much faster, but has a
-limited size, and no introspection or profiling tools.
+encrypted HDL.
 
 To select the execution platform, set the `BSG_PLATFORM` variable in
-[platform.mk](platform.mk). Most users will use `dpi-vcs` or
-`dpi-verilator`. Users with Vivado installed can use `aws-vcs`. Users
-with access to AWS F1 images should use `aws-fpga`.
+[platform.mk](platform.mk). Most users will use `bigblade-vcs`.
 
 ## Machines
 
@@ -61,41 +72,18 @@ directory.
 
 See [machines/README.md](machines/README.md) for more documentation.
 
-# Quick-Start
-
-The simplest way to use this project is to clone its meta-project: [BSG Bladerunner](https://github.com/bespoke-silicon-group/bsg_bladerunner/). 
-
-BSG Bladerunner tracks this repository, BSG Manycore, and BaseJump STL
-repositories as submodules and maintains a monotonic versionining
-scheme. 
-
-Once the setup instructions in BSG Bladrunner have been completed, run:
-
-`make regression`
-
-This will run all of the example programs in [examples](examples). See
-the README in that directory for more information.
-
 ## Dependencies
 
-To use the `aws-vcs` platform, users will need: 
+To use VCS Platforms, users will need: 
 
-   1. Vivado 2019.1
-   2. A clone of aws-fpga (Cloned by bsg_bladerunner)
-   3. Synopsys VCS (We use O-2018.09-SP2, but others would work)
+   1. Synopsys VCS (We use O-2018.09-SP2, but others would work)
 
-To use the `dpi-verilator` platform, users will need: 
+To use Verilator platforms, users will need: 
 
    1. A recent version of Verilator
 
 Users should use the Verilator installation provided by
 bsg_bladerunner.
-
-This repository depends on the following repositories: 
-
-   1. [BSG Manycore](https://github.com/bespoke-silicon-group/bsg_manycore)
-   2. [BaseJump STL](https://github.com/bespoke-silicon-group/basejump_stl)
-   3. [AWS FPGA](https://github.com/aws/aws-fpga)
 
 
 

--- a/machines/README.md
+++ b/machines/README.md
@@ -42,7 +42,9 @@ is for Vanilla Core (RV32), and anything else should be described in
 the relevant Makefile.machine.include file.
 
 ### Network Parameters
-- `BSG_MACHINE_RUCHE_FACTOR_X`: X-dimension ruche factor
+- `BSG_MACHINE_NETWORK_CFG`: Network configuration. Valid values are : e_network_mesh, e_network_crossbar, and e_network_half_ruche_x
+valid values are defined in [bsg_machine_network_cfg_pkg.v](https://github.com/bespoke-silicon-group/bsg_manycore/blob/master/testbenches/common/v/bsg_manycore_network_cfg_pkg.v)
+- `BSG_MACHINE_RUCHE_FACTOR_X`: X-dimension ruche factor. Only applies when `BSG_MACHINE_NETWORK_CFG` is `e_network_half_ruche_x`
 
 ### Memory System Parameters
 - `BSG_MACHINE_MEM_CFG`: Defines memory system configuration as a triple (Cache, Interface, Type). Values are defined and explained in (bsg_bladerunner_mem_cfg_pkg.v)[https://github.com/bespoke-silicon-group/bsg_replicant/blob/master/hardware/bsg_bladerunner_mem_cfg_pkg.v].

--- a/machines/README.md
+++ b/machines/README.md
@@ -16,9 +16,10 @@ All machines are currently supported by the `bigblade-vcs`
 platform. These simulate the current state-of-the-art HammerBlade
 pod-based architecture.
 
-- pod_X1_Y1_ruche_X16Y8_hbm: HammerBlade architecture with 1 Manycore pod, with 128 RISC-V tiles arranged in a 16 x 8 grid (W x H), and connected to an and an HBM2 memory system.
-- pod_X2_Y2_ruche_X16Y8_hbm: HammerBlade architecture with 4 Manycore pods arranged in a 2 x 2 grid, each with 128 RISC-V tiles arranged in a 16 x 8 grid (W x H), and connected to an and an HBM2 memory system.
-- pod_X4_Y4_ruche_X16Y8_hbm: HammerBlade architecture with 16 Manycore pods arranged in a 4 x 4 grid, each with 128 RISC-V tiles arranged in a 16 x 8 grid (W x H), and connected to an and an HBM2 memory system.
+- pod_X1Y1_ruche_X16Y8_hbm_one_pseudo_channel: HammerBlade architecture with 1 Manycore pod, with 128 RISC-V tiles arranged in a 16 x 8 grid (W x H), and connected to a single HBM2 pseudochannel.
+- pod_X1_Y1_ruche_X16Y8_hbm: HammerBlade architecture with 1 Manycore pod, with 128 RISC-V tiles arranged in a 16 x 8 grid (W x H), and connected to two HBM channels.
+- pod_X2_Y2_ruche_X16Y8_hbm: HammerBlade architecture with 4 Manycore pods arranged in a 2 x 2 grid, each with 128 RISC-V tiles arranged in a 16 x 8 grid (W x H), and connected to eight HBM channels.
+- pod_X4_Y4_ruche_X16Y8_hbm: HammerBlade architecture with 16 Manycore pods arranged in a 4 x 4 grid, each with 128 RISC-V tiles arranged in a 16 x 8 grid (W x H), and connected to thirty-two HBM cxhannels.
 
 - bigblade_pod_X1_Y1_ruche_X16Y8_hbm: HammerBlade architecture with 1 Manycore pod arrange, with 128 RISC-V tiles arranged in a 16 x 8 grid (W x H), and connected to an and an HBM2 memory system that mimics the Bigblade memory system.
 

--- a/machines/README.md
+++ b/machines/README.md
@@ -2,8 +2,8 @@
 
 This directory contains a variety of target machine configurations for
 HammerBlade. Each sub-directory is a target with a valid
-Makefile.machine.include file. The Makefile.machine.include specifies
-the machine configuration.
+Makefile.machine.include file that specifies the machine
+configuration.
 
 To use a specific machine, change BSG_MACHINE_PATH to specify one of
 the following directories in
@@ -12,75 +12,26 @@ Makefile.machine.include file.
 
 ## Machines and Platforms
 
-These machines are supported by the `dpi-verilator` and `dpi-vcs` platform:
+All machines are currently supported by the `bigblade-vcs`
+platform. These simulate the current state-of-the-art HammerBlade
+pod-based architecture.
 
-- timing_*
-- baseline_*
-- infinite_*
+- pod_X1_Y1_ruche_X16Y8_hbm: HammerBlade architecture with 1 Manycore pod, with 128 RISC-V tiles arranged in a 16 x 8 grid (W x H), and connected to an and an HBM2 memory system.
+- pod_X2_Y2_ruche_X16Y8_hbm: HammerBlade architecture with 4 Manycore pods arranged in a 2 x 2 grid, each with 128 RISC-V tiles arranged in a 16 x 8 grid (W x H), and connected to an and an HBM2 memory system.
+- pod_X4_Y4_ruche_X16Y8_hbm: HammerBlade architecture with 16 Manycore pods arranged in a 4 x 4 grid, each with 128 RISC-V tiles arranged in a 16 x 8 grid (W x H), and connected to an and an HBM2 memory system.
 
-The `aws-fpga` and `aws-vcs` platform only supports the
-4x4_blocking_vcache_f1_model  4x4_blocking_vcache_f1_dram
-
-## Performance Metric Machines
-
-- timing_* machines: Manycore pod with caches on top and bottom. There
-  are 16 caches per HBM channel. Each cache is mapped to a separate
-  channel bank within its respective channel. 
-
-  ruche indicates a _ruched_ mesh network. Mesh indicates a
-  traditional 2-D mesh network.
-
-  *This configuration should be the default for taking performance
-  measurements and making decisions based on them.*
-
-- infinite_* machines: Manycore pod with infinite, single-cycle
-  memories on top and bottom of each row. 
-
-  ruche indicates a _ruched_ mesh network. Mesh indicates a
-  traditional 2-D mesh network.
-
-  *This configuration should be used to estimate the impact of memory
-  latency.*
-
-- baseline_* machines: Manycore pod with infinite, single-cycle
-  memories on top and bottom of each row. 
-
-  The baseline designs use a crossbar network.
-
-  *This configuration should be used to estimate the impact of an
-  ideal network*
-
-## Correctness Machines
-
-**DO NOT USE THESE MACHINES FOR PERFORMANCE METRICS**
-
-- 4x4_blocking_vcache_f1_model: This is a 4x4 array of RISC-V Vanilla
-  Cores with 1 FAKE DRAM DIM with bounded/low latency attached through
-  an AXI-4 interface to the top and bottom of the array. This models
-  the configuration on F1 and is used to build the F1 image. 
-
-- 4x4_amo_support: Same as 4x4_blocking_vcache_f1_model
-
-- 4x4_blocking_vcache_f1_dram: This is a 4x4 array of RISC-V Vanilla
-  Cores with 1 DRAM DIM with bounded/low latency attached through an
-  AXI-4 interface to the top and bottom of the array. The DRAM is a
-  Micron model provided by Xilinx. This models the configuration on F1
-  and is used to build the F1 image. *This machine simulates very
-  slowly*
-
-## Legacy Machines
-
-**DO NOT USE THESE MACHINES**
-
+- bigblade_pod_X1_Y1_ruche_X16Y8_hbm: HammerBlade architecture with 1 Manycore pod arrange, with 128 RISC-V tiles arranged in a 16 x 8 grid (W x H), and connected to an and an HBM2 memory system that mimics the Bigblade memory system.
 
 ## Parameters:
 
 The following parameters in each Makefile.machine.include file can be changed:
 
-
 ### Core Configurations
-- `BSG_MACHINE_NUM_CORES_X`: Number of RV32 Cores in the X dimension (width)
-- `BSG_MACHINE_NUM_CORES_Y`: Number of RV32 Cores in the Y dimension (height)
+- `BSG_MACHINE_PODS_X`: Number of HammerBlade Pods in the X dimension (width)
+- `BSG_MACHINE_PODS_Y`: Number of HammerBlade Pods in the Y dimension (height)
+
+- `BSG_MACHINE_POD_TILES_X`: Number of RV32 Cores in the X dimension (width)
+- `BSG_MACHINE_POD_TILES_Y`: Number of RV32 Cores in the Y dimension (height)
 
 - `BSG_MACHINE_HETERO_TYPE_VEC`: Heterogeneous tile composition. Must
 be a 1-d array equal to the number of tiles, or shorthand
@@ -90,12 +41,9 @@ is for Vanilla Core (RV32), and anything else should be described in
 the relevant Makefile.machine.include file.
 
 ### Network Parameters
-- `BSG_MACHINE_NETWORK_CFG`: Network configuration. Valid values are : e_network_mesh, e_network_crossbar, and e_network_half_ruche_x
-valid values are defined in [bsg_machine_network_cfg_pkg.v](https://github.com/bespoke-silicon-group/bsg_manycore/blob/master/testbenches/common/v/bsg_manycore_network_cfg_pkg.v)
-- `BSG_MACHINE_RUCHE_FACTOR_X`: X-dimension ruche factor. Only applies when `BSG_MACHINE_NETWORK_CFG` is `e_network_half_ruche_x`
+- `BSG_MACHINE_RUCHE_FACTOR_X`: X-dimension ruche factor
 
 ### Memory System Parameters
-- `BSG_MACHINE_DRAM_INCLUDED`: Defines whether the DRAM interface is used. Default is 1. 
 - `BSG_MACHINE_MEM_CFG`: Defines memory system configuration as a triple (Cache, Interface, Type). Values are defined and explained in (bsg_bladerunner_mem_cfg_pkg.v)[https://github.com/bespoke-silicon-group/bsg_replicant/blob/master/hardware/bsg_bladerunner_mem_cfg_pkg.v].
 
 - `BSG_MACHINE_VCACHE_PER_DRAM_CHANNEL`: Defines number of Last-Level Caches per DRAM channel.

--- a/machines/bigblade_pod_X1Y1_ruche_X16Y8_hbm/Makefile.machine.include
+++ b/machines/bigblade_pod_X1Y1_ruche_X16Y8_hbm/Makefile.machine.include
@@ -55,7 +55,7 @@ BSG_MACHINE_HETERO_TYPE_VEC           = default:0
 
 # Network Parameters
 # BSG_MACHINE_NETWORK_CFG longer has an effect, fixed at e_network_half_ruche_x
-# BSG_MACHINE_NETWORK_CFG               = e_network_half_ruche_x
+BSG_MACHINE_NETWORK_CFG               = e_network_half_ruche_x
 BSG_MACHINE_RUCHE_FACTOR_X            = 3
 
 # Memory System Parameters

--- a/machines/bigblade_pod_X1Y1_ruche_X16Y8_hbm/Makefile.machine.include
+++ b/machines/bigblade_pod_X1Y1_ruche_X16Y8_hbm/Makefile.machine.include
@@ -26,12 +26,14 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ############################################################################################
-# TIMING_MESH_8_4: this is a 8x4 array with v-caches on top and bottom (a “8x4 pod”).      #
-# Each v-cache is mapped to a separate HBM bank.                                           #
-# There is one HBM channel.                                                                #
-# There is a vanilla, 2D mesh network (no ruche links)                                     #
-# This is probably not a sensible configuration, as the tile to channel ratio is very low. #
-# But for memory bound benchmarks, it may be reasonable to use for iteration.              #
+# bigblade_pod_X1Y1_ruche_X16Y8_hbm                                                        #
+# 1 pod                                                                                    #
+# 128 RISC-V Tiles per pod, 16 tiles wide, 8 tiles tall                                    # 
+# Last level caches on the top and bottom of each column                                   #
+# Each last-level cache is mapped to a separate HBM bank                                   #
+# There are two HBM channels.                                                              #
+# There is a vanilla, 2D mesh network augmented with Ruche links                           #
+# This configuration mimics the bigblade chip memory configuration. See the mem sys params #
 ############################################################################################
 
 # Change these parameters to define your machine. All other parameters should remain constant.
@@ -52,11 +54,11 @@ BSG_MACHINE_DRAM_CYCLE_TIME_PS         = 1000
 BSG_MACHINE_HETERO_TYPE_VEC           = default:0
 
 # Network Parameters
-BSG_MACHINE_NETWORK_CFG               = e_network_half_ruche_x
+# BSG_MACHINE_NETWORK_CFG longer has an effect, fixed at e_network_half_ruche_x
+# BSG_MACHINE_NETWORK_CFG               = e_network_half_ruche_x
 BSG_MACHINE_RUCHE_FACTOR_X            = 3
 
 # Memory System Parameters
-BSG_MACHINE_DRAM_INCLUDED             = 1
 BSG_MACHINE_MEM_DRAMSIM3_PKG          = bsg_dramsim3_hbm2_8gb_x128_pkg
 BSG_MACHINE_MEM_CFG                   = e_vcache_hbm2
 

--- a/machines/pod_X1Y1_ruche_X16Y8_hbm/Makefile.machine.include
+++ b/machines/pod_X1Y1_ruche_X16Y8_hbm/Makefile.machine.include
@@ -25,6 +25,19 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+<<<<<<< HEAD
+=======
+############################################################################################
+# pod_X1Y1_ruche_X16Y8_hbm                                                                 #
+# 1 pod                                                                                    #
+# 128 RISC-V Tiles per pod, 16 tiles wide, 8 tiles tall                                    # 
+# Last level caches on the top and bottom of each column                                   #
+# Each last-level cache is mapped to a separate HBM bank                                   #
+# There are two HBM channels.                                                              #
+# There is a vanilla, 2D mesh network augmented with Ruche links                           #
+############################################################################################
+
+>>>>>>> b665274d... Update documents and machine configurations
 # Change these parameters to define your machine. All other parameters should remain constant.
 
 # Chip Pod Dimensions
@@ -41,12 +54,12 @@ BSG_MACHINE_PODS_CYCLE_TIME_PS         = 1000
 BSG_MACHINE_HETERO_TYPE_VEC           = default:0
 
 # Network Parameters
-BSG_MACHINE_NETWORK_CFG               = e_network_half_ruche_x
+# BSG_MACHINE_NETWORK_CFG longer has an effect, fixed at e_network_half_ruche_x
+# BSG_MACHINE_NETWORK_CFG               = e_network_half_ruche_x
 BSG_MACHINE_RUCHE_FACTOR_X            = 3
 BSG_MACHINE_BARRIER_RUCHE_FACTOR_X    = 3
 
 # Memory System Parameters
-BSG_MACHINE_DRAM_INCLUDED             = 1
 BSG_MACHINE_MEM_DRAMSIM3_PKG          = bsg_dramsim3_hbm2_8gb_x128_pkg
 BSG_MACHINE_MEM_CFG                   = e_vcache_hbm2
 

--- a/machines/pod_X1Y1_ruche_X16Y8_hbm/Makefile.machine.include
+++ b/machines/pod_X1Y1_ruche_X16Y8_hbm/Makefile.machine.include
@@ -25,8 +25,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-<<<<<<< HEAD
-=======
 ############################################################################################
 # pod_X1Y1_ruche_X16Y8_hbm                                                                 #
 # 1 pod                                                                                    #
@@ -37,7 +35,6 @@
 # There is a vanilla, 2D mesh network augmented with Ruche links                           #
 ############################################################################################
 
->>>>>>> b665274d... Update documents and machine configurations
 # Change these parameters to define your machine. All other parameters should remain constant.
 
 # Chip Pod Dimensions
@@ -55,7 +52,7 @@ BSG_MACHINE_HETERO_TYPE_VEC           = default:0
 
 # Network Parameters
 # BSG_MACHINE_NETWORK_CFG longer has an effect, fixed at e_network_half_ruche_x
-# BSG_MACHINE_NETWORK_CFG               = e_network_half_ruche_x
+BSG_MACHINE_NETWORK_CFG               = e_network_half_ruche_x
 BSG_MACHINE_RUCHE_FACTOR_X            = 3
 BSG_MACHINE_BARRIER_RUCHE_FACTOR_X    = 3
 

--- a/machines/pod_X1Y1_ruche_X16Y8_hbm_one_pseudo_channel/Makefile.machine.include
+++ b/machines/pod_X1Y1_ruche_X16Y8_hbm_one_pseudo_channel/Makefile.machine.include
@@ -54,7 +54,7 @@ BSG_MACHINE_HETERO_TYPE_VEC           = default:0
 
 # Network Parameters
 # BSG_MACHINE_NETWORK_CFG longer has an effect, fixed at e_network_half_ruche_x
-# BSG_MACHINE_NETWORK_CFG               = e_network_half_ruche_x
+BSG_MACHINE_NETWORK_CFG               = e_network_half_ruche_x
 BSG_MACHINE_RUCHE_FACTOR_X            = 3
 BSG_MACHINE_BARRIER_RUCHE_FACTOR_X    = 3
 

--- a/machines/pod_X1Y1_ruche_X16Y8_hbm_one_pseudo_channel/Makefile.machine.include
+++ b/machines/pod_X1Y1_ruche_X16Y8_hbm_one_pseudo_channel/Makefile.machine.include
@@ -25,7 +25,16 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# Models one 16x8 pod with one HBM pseudo-channel and 32 banks
+############################################################################################
+# pod_X1Y1_ruche_X16Y8_hbm_one_pseudo_channel                                              #
+# 1 pod                                                                                    #
+# 128 RISC-V Tiles per pod, 16 tiles wide, 8 tiles tall                                    # 
+# Last level caches on the top and bottom of each column                                   #
+# Each last-level cache is mapped to a separate HBM bank                                   #
+# There is one HBM Pseudochannel channel per pod.                                          #
+# There is a vanilla, 2D mesh network augmented with Ruche links                           #
+# This configuration mimics a GPU. See the mem sys params                                  #
+############################################################################################
 
 # Change these parameters to define your machine. All other parameters should remain constant.
 BSG_MACHINE_CHIP_ID		      = 15ca2022
@@ -44,12 +53,12 @@ BSG_MACHINE_PODS_CYCLE_TIME_PS         = 667
 BSG_MACHINE_HETERO_TYPE_VEC           = default:0
 
 # Network Parameters
-BSG_MACHINE_NETWORK_CFG               = e_network_half_ruche_x
+# BSG_MACHINE_NETWORK_CFG longer has an effect, fixed at e_network_half_ruche_x
+# BSG_MACHINE_NETWORK_CFG               = e_network_half_ruche_x
 BSG_MACHINE_RUCHE_FACTOR_X            = 3
 BSG_MACHINE_BARRIER_RUCHE_FACTOR_X    = 3
 
 # Memory System Parameters
-BSG_MACHINE_DRAM_INCLUDED             = 1
 BSG_MACHINE_MEM_DRAMSIM3_PKG          = bsg_dramsim3_hbm2_1gb_x64_32ba_pkg
 BSG_MACHINE_MEM_CFG                   = e_vcache_hbm2
 

--- a/machines/pod_X2Y2_ruche_X16Y8_hbm/Makefile.machine.include
+++ b/machines/pod_X2Y2_ruche_X16Y8_hbm/Makefile.machine.include
@@ -25,6 +25,19 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+<<<<<<< HEAD
+=======
+############################################################################################
+# pod_X2Y2_ruche_X16Y8_hbm                                                                 #
+# 4 pods (2 pods high, 2 pods wide)                                                        #
+# 128 RISC-V Tiles per pod, 16 tiles wide, 8 tiles tall                                    # 
+# Last level caches on the top and bottom of each column                                   #
+# Each last-level cache is mapped to a separate HBM bank                                   #
+# There are two HBM channels.                                                              #
+# There is a vanilla, 2D mesh network augmented with Ruche links                           #
+############################################################################################
+
+>>>>>>> b665274d... Update documents and machine configurations
 # Change these parameters to define your machine. All other parameters should remain constant.
 
 # Chip Pod Dimensions
@@ -41,12 +54,12 @@ BSG_MACHINE_PODS_CYCLE_TIME_PS         = 1000
 BSG_MACHINE_HETERO_TYPE_VEC           = default:0
 
 # Network Parameters
-BSG_MACHINE_NETWORK_CFG               = e_network_half_ruche_x
+# BSG_MACHINE_NETWORK_CFG longer has an effect, fixed at e_network_half_ruche_x
+# BSG_MACHINE_NETWORK_CFG               = e_network_half_ruche_x
 BSG_MACHINE_RUCHE_FACTOR_X            = 3
 BSG_MACHINE_BARRIER_RUCHE_FACTOR_X    = 3
 
 # Memory System Parameters
-BSG_MACHINE_DRAM_INCLUDED             = 1
 BSG_MACHINE_MEM_DRAMSIM3_PKG          = bsg_dramsim3_hbm2_8gb_x128_pkg
 BSG_MACHINE_MEM_CFG                   = e_vcache_hbm2
 

--- a/machines/pod_X2Y2_ruche_X16Y8_hbm/Makefile.machine.include
+++ b/machines/pod_X2Y2_ruche_X16Y8_hbm/Makefile.machine.include
@@ -25,8 +25,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-<<<<<<< HEAD
-=======
 ############################################################################################
 # pod_X2Y2_ruche_X16Y8_hbm                                                                 #
 # 4 pods (2 pods high, 2 pods wide)                                                        #
@@ -37,7 +35,6 @@
 # There is a vanilla, 2D mesh network augmented with Ruche links                           #
 ############################################################################################
 
->>>>>>> b665274d... Update documents and machine configurations
 # Change these parameters to define your machine. All other parameters should remain constant.
 
 # Chip Pod Dimensions
@@ -55,7 +52,7 @@ BSG_MACHINE_HETERO_TYPE_VEC           = default:0
 
 # Network Parameters
 # BSG_MACHINE_NETWORK_CFG longer has an effect, fixed at e_network_half_ruche_x
-# BSG_MACHINE_NETWORK_CFG               = e_network_half_ruche_x
+BSG_MACHINE_NETWORK_CFG               = e_network_half_ruche_x
 BSG_MACHINE_RUCHE_FACTOR_X            = 3
 BSG_MACHINE_BARRIER_RUCHE_FACTOR_X    = 3
 

--- a/machines/pod_X4Y4_ruche_X16Y8_hbm/Makefile.machine.include
+++ b/machines/pod_X4Y4_ruche_X16Y8_hbm/Makefile.machine.include
@@ -25,8 +25,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-<<<<<<< HEAD
-=======
 ############################################################################################
 # pod_X4Y4_ruche_X16Y8_hbm                                                                 #
 # 16 pods (4 pods high, 4 pods wide)                                                       #
@@ -37,7 +35,6 @@
 # There is a vanilla, 2D mesh network augmented with Ruche links                           #
 ############################################################################################
 
->>>>>>> b665274d... Update documents and machine configurations
 # Change these parameters to define your machine. All other parameters should remain constant.
 
 # Chip Pod Dimensions
@@ -55,7 +52,7 @@ BSG_MACHINE_HETERO_TYPE_VEC           = default:0
 
 # Network Parameters
 # BSG_MACHINE_NETWORK_CFG longer has an effect, fixed at e_network_half_ruche_x
-# BSG_MACHINE_NETWORK_CFG               = e_network_half_ruche_x
+BSG_MACHINE_NETWORK_CFG               = e_network_half_ruche_x
 BSG_MACHINE_RUCHE_FACTOR_X            = 3
 BSG_MACHINE_BARRIER_RUCHE_FACTOR_X    = 3
 

--- a/machines/pod_X4Y4_ruche_X16Y8_hbm/Makefile.machine.include
+++ b/machines/pod_X4Y4_ruche_X16Y8_hbm/Makefile.machine.include
@@ -25,6 +25,19 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+<<<<<<< HEAD
+=======
+############################################################################################
+# pod_X4Y4_ruche_X16Y8_hbm                                                                 #
+# 16 pods (4 pods high, 4 pods wide)                                                       #
+# 128 RISC-V Tiles per pod, 16 tiles wide, 8 tiles tall                                    # 
+# Last level caches on the top and bottom of each column                                   #
+# Each last-level cache is mapped to a separate HBM bank                                   #
+# There are two HBM channels.                                                              #
+# There is a vanilla, 2D mesh network augmented with Ruche links                           #
+############################################################################################
+
+>>>>>>> b665274d... Update documents and machine configurations
 # Change these parameters to define your machine. All other parameters should remain constant.
 
 # Chip Pod Dimensions
@@ -41,12 +54,12 @@ BSG_MACHINE_PODS_CYCLE_TIME_PS         = 1000
 BSG_MACHINE_HETERO_TYPE_VEC           = default:0
 
 # Network Parameters
-BSG_MACHINE_NETWORK_CFG               = e_network_half_ruche_x
+# BSG_MACHINE_NETWORK_CFG longer has an effect, fixed at e_network_half_ruche_x
+# BSG_MACHINE_NETWORK_CFG               = e_network_half_ruche_x
 BSG_MACHINE_RUCHE_FACTOR_X            = 3
 BSG_MACHINE_BARRIER_RUCHE_FACTOR_X    = 3
 
 # Memory System Parameters
-BSG_MACHINE_DRAM_INCLUDED             = 1
 BSG_MACHINE_MEM_DRAMSIM3_PKG          = bsg_dramsim3_hbm2_8gb_x128_pkg
 BSG_MACHINE_MEM_CFG                   = e_vcache_hbm2
 


### PR DESCRIPTION
Update READMEs to remove AWS instructions, describe available simulation machines.

At the moment AWS simulation and compilation is not supported. The recommended development path is VCS + DPI simulation for now. 

Thinking through the problem, AWS simulation will require a couple of new features in the top level: 
1. AXI-Wormhole connections for memory. This is how the caches communicate with DDR.
2. Updating the RTL and platform C++ for the changes to the credit interface (See #698)

I would recommend starting with a new top level that mimics (or uses?) the code in https://github.com/bespoke-silicon-group/bsg_manycore/blob/master/testbenches/common/v/bsg_nonsynth_manycore_testbench.v but without the non-synthesizable bits (DRAMSim3, infinite test memories, etc)