### PR TITLE
Revert removal of DRAM INCLUDED

### DIFF
--- a/machines/README.md
+++ b/machines/README.md
@@ -47,6 +47,7 @@ valid values are defined in [bsg_machine_network_cfg_pkg.v](https://github.com/b
 - `BSG_MACHINE_RUCHE_FACTOR_X`: X-dimension ruche factor. Only applies when `BSG_MACHINE_NETWORK_CFG` is `e_network_half_ruche_x`
 
 ### Memory System Parameters
+- `BSG_MACHINE_DRAM_INCLUDED`: Defines whether the DRAM interface is used. Default is 1. 
 - `BSG_MACHINE_MEM_CFG`: Defines memory system configuration as a triple (Cache, Interface, Type). Values are defined and explained in (bsg_bladerunner_mem_cfg_pkg.v)[https://github.com/bespoke-silicon-group/bsg_replicant/blob/master/hardware/bsg_bladerunner_mem_cfg_pkg.v].
 
 - `BSG_MACHINE_VCACHE_PER_DRAM_CHANNEL`: Defines number of Last-Level Caches per DRAM channel.

--- a/machines/bigblade_pod_X1Y1_ruche_X16Y8_hbm/Makefile.machine.include
+++ b/machines/bigblade_pod_X1Y1_ruche_X16Y8_hbm/Makefile.machine.include
@@ -59,6 +59,7 @@ BSG_MACHINE_NETWORK_CFG               = e_network_half_ruche_x
 BSG_MACHINE_RUCHE_FACTOR_X            = 3
 
 # Memory System Parameters
+BSG_MACHINE_DRAM_INCLUDED             = 1
 BSG_MACHINE_MEM_DRAMSIM3_PKG          = bsg_dramsim3_hbm2_8gb_x128_pkg
 BSG_MACHINE_MEM_CFG                   = e_vcache_hbm2
 

--- a/machines/pod_X1Y1_ruche_X16Y8_hbm/Makefile.machine.include
+++ b/machines/pod_X1Y1_ruche_X16Y8_hbm/Makefile.machine.include
@@ -57,6 +57,7 @@ BSG_MACHINE_RUCHE_FACTOR_X            = 3
 BSG_MACHINE_BARRIER_RUCHE_FACTOR_X    = 3
 
 # Memory System Parameters
+BSG_MACHINE_DRAM_INCLUDED             = 1
 BSG_MACHINE_MEM_DRAMSIM3_PKG          = bsg_dramsim3_hbm2_8gb_x128_pkg
 BSG_MACHINE_MEM_CFG                   = e_vcache_hbm2
 

--- a/machines/pod_X1Y1_ruche_X16Y8_hbm_one_pseudo_channel/Makefile.machine.include
+++ b/machines/pod_X1Y1_ruche_X16Y8_hbm_one_pseudo_channel/Makefile.machine.include
@@ -59,6 +59,7 @@ BSG_MACHINE_RUCHE_FACTOR_X            = 3
 BSG_MACHINE_BARRIER_RUCHE_FACTOR_X    = 3
 
 # Memory System Parameters
+BSG_MACHINE_DRAM_INCLUDED             = 1
 BSG_MACHINE_MEM_DRAMSIM3_PKG          = bsg_dramsim3_hbm2_1gb_x64_32ba_pkg
 BSG_MACHINE_MEM_CFG                   = e_vcache_hbm2
 

--- a/machines/pod_X2Y2_ruche_X16Y8_hbm/Makefile.machine.include
+++ b/machines/pod_X2Y2_ruche_X16Y8_hbm/Makefile.machine.include
@@ -57,6 +57,7 @@ BSG_MACHINE_RUCHE_FACTOR_X            = 3
 BSG_MACHINE_BARRIER_RUCHE_FACTOR_X    = 3
 
 # Memory System Parameters
+BSG_MACHINE_DRAM_INCLUDED             = 1
 BSG_MACHINE_MEM_DRAMSIM3_PKG          = bsg_dramsim3_hbm2_8gb_x128_pkg
 BSG_MACHINE_MEM_CFG                   = e_vcache_hbm2
 

--- a/machines/pod_X4Y4_ruche_X16Y8_hbm/Makefile.machine.include
+++ b/machines/pod_X4Y4_ruche_X16Y8_hbm/Makefile.machine.include
@@ -57,6 +57,7 @@ BSG_MACHINE_RUCHE_FACTOR_X            = 3
 BSG_MACHINE_BARRIER_RUCHE_FACTOR_X    = 3
 
 # Memory System Parameters
+BSG_MACHINE_DRAM_INCLUDED             = 1
 BSG_MACHINE_MEM_DRAMSIM3_PKG          = bsg_dramsim3_hbm2_8gb_x128_pkg
 BSG_MACHINE_MEM_CFG                   = e_vcache_hbm2
 


### PR DESCRIPTION
Needed for RISCV compilation. This snuck through in the docs update.