### PR TITLE
Moved all CUDA source files from Manycore to Replicant

### DIFF
--- a/examples/cuda/group_stride/Makefile
+++ b/examples/cuda/group_stride/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel

--- a/examples/cuda/latency/Makefile
+++ b/examples/cuda/latency/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel

--- a/examples/cuda/sgemm_data_parallel/Makefile
+++ b/examples/cuda/sgemm_data_parallel/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel

--- a/examples/cuda/sgemm_group_cooperative/Makefile
+++ b/examples/cuda/sgemm_group_cooperative/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel

--- a/examples/cuda/test_binary_load_buffer/Makefile
+++ b/examples/cuda/test_binary_load_buffer/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # TEST_NAME is the basename of the executable
 TEST_NAME = main
@@ -83,21 +82,19 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_CCPPFLAGS += -O3 -std=c++14
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -126,11 +123,4 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
-
+	rm -rf *.ld

--- a/examples/cuda/test_binary_load_buffer/kernel.cpp
+++ b/examples/cuda/test_binary_load_buffer/kernel.cpp
@@ -1,0 +1,9 @@
+//This is an empty kernel 
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+extern "C" __attribute__ ((noinline))
+int kernel_binary_load_buffer() {
+  return 0;
+}

--- a/examples/cuda/test_conv1d/Makefile
+++ b/examples/cuda/test_conv1d/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = conv1d
@@ -81,21 +80,19 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_CCPPFLAGS += -std=c++14
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +121,4 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
-
+	rm -rf *.ld

--- a/examples/cuda/test_conv1d/kernel.cpp
+++ b/examples/cuda/test_conv1d/kernel.cpp
@@ -1,0 +1,57 @@
+
+/*!
+  Takes a vector A of length N and a 1D filter of size F, padding size P, and stride S.
+  Performs 1D convolution of A with the filter and stores the result in a vector B
+  of size M = 1 + (N - F + 2P) / S.
+*/
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "math.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+extern "C" __attribute__((noinline))
+int kernel_conv1d(const float *A,
+                  const int N,
+                  const float *filter,
+                  const int F,
+                  const int P,
+                  float *B,
+                  const int S,
+                  const int block_size)
+{
+        /*
+          Recall the organization of a kernel being executed: Cores are in tilegroups, and tile groups
+          are in a grid. Since this is a 1D convolution, we need to flatten everyting to 1D. So we compute
+          our tile group index as though it were a 1D grid. Each tile group is responsible for computing
+          block_size many elements, so we compute our start index of our tilegroup as simply the product
+          of our tile group index and block_size. The end index is consequently start + block_size.
+          Since each index in the output vector is independent from the other indices, the tiles
+          step through their assigned indices, computung the result.
+        */
+        const int tile_group_idx = __bsg_grid_dim_x * __bsg_tile_group_id_y + __bsg_tile_group_id_x;
+        const int start = tile_group_idx * block_size;
+        const int end = start + block_size;
+        const int M = 1 + (N - F + 2 * P) / S;
+        const int num_cores = bsg_tiles_X * bsg_tiles_Y;
+        for(int i = start + __bsg_id; i < end; i += num_cores)
+        {
+                int window_idx = i * S;
+                float res = 0;
+                for(int j = 0; j < F; j++)
+                {
+                        int a_idx = window_idx - P + j;
+                        float a = 0;
+                        if(0 <= a_idx && a_idx < N)
+                                a = A[a_idx];
+
+                        res += filter[j] * a;
+                }
+                B[i] = res;
+        }
+        barrier.sync();
+        return 0;
+}

--- a/examples/cuda/test_conv1d/main.c
+++ b/examples/cuda/test_conv1d/main.c
@@ -221,19 +221,11 @@ int kernel_conv1d(int argc, char **argv)
         int mismatches = 0;
 
         bsg_pr_info("(N, F, P, S, M) = (%d, %d, %d, %d, %d)\n", N, F, P, S, M);
+        double err;
         for(int i = 0; i < M; i++)
-                if(!hb_mc_floats_match(B_actual[i], B_expected[i]))
-                {
-                        bsg_pr_err(BSG_RED("Mismatch: ") "B[%d] = %.9f = 0x%x \t Expected: %.9f = 0x%x\n",
-                                   i,
-                                   B_actual[i],
-                                   *((uint32_t *)(B_actual + i)),
-                                   B_expected[i],
-                                   *((uint32_t *)(B_expected + i)));
-                        mismatches++;
-                }
+                err += (B_actual[i] - B_expected[i]) *(B_actual[i] - B_expected[i]);
 
-        if(!mismatches)
+        if(err > .001)
         {
                 bsg_pr_test_info(BSG_GREEN("Vectors match!\n"));
                 return HB_MC_SUCCESS;

--- a/examples/cuda/test_conv2d/Makefile
+++ b/examples/cuda/test_conv2d/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = conv2d
@@ -81,21 +80,19 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_CCPPFLAGS += -std=c++14
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +121,4 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
-
+	rm -rf *.ld

--- a/examples/cuda/test_conv2d/kernel.cpp
+++ b/examples/cuda/test_conv2d/kernel.cpp
@@ -1,0 +1,60 @@
+
+/*!
+  Takes an MxN matrix A and an HxW filter, padding P, vertical stride Sy,
+  and horizontal stride Sx. Performs a 2D convolution and outputs into a
+  matrix B. 
+*/
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "math.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+int output_dim(int N, int F, int P, int S)
+{
+        return 1 + (N - F + 2 * P) / S;
+}
+
+extern "C" __attribute__((noinline))
+int kernel_conv2d(const float *A,
+                  const int M,
+                  const int N,
+                  const float *filter,
+                  const int H,
+                  const int W,
+                  const int P,
+                  float *B,
+                  const int Sy,
+                  const int Sx)
+{
+        int result_h = output_dim(M, H, P, Sy);
+        int result_w = output_dim(N, W, P, Sx);
+
+        for(int by = __bsg_y; by < result_h; by += bsg_tiles_Y)
+                for(int bx = __bsg_x; bx < result_w; bx += bsg_tiles_X)
+                {
+                        int window_y = by * Sy;
+                        int window_x = bx * Sx;
+                        
+                        float res = 0;
+                        for(int fy = 0; fy < H; fy++)
+                                for(int fx = 0; fx < W; fx++)
+                                {
+                                        int ay = window_y - P + fy;
+                                        int ax = window_x - P + fx;
+                                        float a = 0;
+                                        
+                                        if((0 <= ay && ay < M) &&
+                                           (0 <= ax && ax < N))
+                                                a = A[ay * N + ax];
+                                        res += filter[fy * W + fx] * a;
+                                }
+                        B[by * result_w + bx] = res;
+                }
+
+	barrier.sync();
+        return 0;
+}

--- a/examples/cuda/test_credit_csr_tile/Makefile
+++ b/examples/cuda/test_credit_csr_tile/Makefile
@@ -43,11 +43,10 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
-KERNEL_NAME = vec_add_parallel
+KERNEL_NAME = credit_csr_tile
 
 ###############################################################################
 # Host code compilation flags and flow

--- a/examples/cuda/test_device_memcpy/Makefile
+++ b/examples/cuda/test_device_memcpy/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = device_memcpy
@@ -81,21 +80,20 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_CCPPFLAGS += -O3 -std=c++14
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+RISCV_DEFINES += -DBLOCK_DIM=$(BLOCK_DIM)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +122,4 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
-
+	rm -rf *.ld

--- a/examples/cuda/test_device_memcpy/kernel.cpp
+++ b/examples/cuda/test_device_memcpy/kernel.cpp
@@ -1,0 +1,28 @@
+// This kernel performs a memcpy from arrya src to 
+// array dst in DRAM with the given size (in words)
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+extern "C" __attribute__ ((noinline)) 
+int kernel_device_memcpy(int *dst, const int *src, const int size) {
+
+	int __bsg_tile_group_id = (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x);
+	int __bsg_tile_group_size = (bsg_tiles_X * bsg_tiles_Y);
+	int block_size_x = size / (__bsg_grid_dim_y * __bsg_grid_dim_x);
+	
+	int start_x = block_size_x * __bsg_tile_group_id;
+	int end_x = start_x + block_size_x;
+
+	for (int iter_x = start_x + __bsg_id; iter_x < end_x; iter_x += __bsg_tile_group_size) {
+		dst[iter_x] = src[iter_x];
+	}
+
+	barrier.sync();
+
+  return 0;
+}

--- a/examples/cuda/test_device_memset/Makefile
+++ b/examples/cuda/test_device_memset/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = device_memset
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_device_memset/kernel.cpp
+++ b/examples/cuda/test_device_memset/kernel.cpp
@@ -1,0 +1,28 @@
+// This kernel performs a memset on an array in DRAM 
+// With the given size (in words) and value
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+extern "C" __attribute__ ((noinline))
+int kernel_device_memset(int *dst, const int val, const int size) {
+
+	int __bsg_tile_group_id = (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x);
+	int __bsg_tile_group_size = (bsg_tiles_X * bsg_tiles_Y);
+	int block_size_x = size / (__bsg_grid_dim_y * __bsg_grid_dim_x);
+	
+	int start_x = block_size_x * __bsg_tile_group_id;
+	int end_x = start_x + block_size_x;
+
+	for (int iter_x = start_x + __bsg_id; iter_x < end_x; iter_x += __bsg_tile_group_size) {
+		dst[iter_x] = val;
+	}
+
+	barrier.sync();
+
+  return 0;
+}

--- a/examples/cuda/test_dma/Makefile
+++ b/examples/cuda/test_dma/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = dma
@@ -79,21 +78,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -122,11 +118,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_dma/kernel.cpp
+++ b/examples/cuda/test_dma/kernel.cpp
@@ -1,0 +1,15 @@
+//This is an empty kernel
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+extern "C" __attribute__ ((noinline))
+int kernel_dma(int *A, int *B, int n) {
+
+    if (__bsg_id == 0) {
+        for (int i = 0; i < n; i++)
+            B[i] = A[i];
+    }
+
+    return 0;
+}

--- a/examples/cuda/test_dma_valid_invalid/Makefile
+++ b/examples/cuda/test_dma_valid_invalid/Makefile
@@ -43,10 +43,9 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
-KERNEL_NAME = dma
+KERNEL_NAME = dma_valid_invalid
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -79,21 +78,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -122,11 +118,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_dma_valid_invalid/kernel.cpp
+++ b/examples/cuda/test_dma_valid_invalid/kernel.cpp
@@ -1,0 +1,15 @@
+//This is an empty kernel
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+extern "C" __attribute__ ((noinline))
+int kernel_dma(int *A, int *B, int n) {
+
+    if (__bsg_id == 0) {
+        for (int i = 0; i < n; i++)
+            B[i] = A[i];
+    }
+
+    return 0;
+}

--- a/examples/cuda/test_dram_device_allocated/Makefile
+++ b/examples/cuda/test_dram_device_allocated/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = dram_device_allocated
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_dram_device_allocated/kernel.cpp
+++ b/examples/cuda/test_dram_device_allocated/kernel.cpp
@@ -1,0 +1,27 @@
+//This kernel define an array on the DRAM and fills it, then stores the pointer to that array in *addr and kicks it back to host. 
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+#define N 1024
+
+volatile int A[N] __attribute__((section(".dram")));
+
+extern "C" __attribute__ ((noinline))
+int kernel_dram_device_allocated(int *addr, int block_size_x) {
+
+	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
+	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
+		A[start_x + iter_x] = start_x + iter_x;
+	}
+
+	*addr = (int) &A[0];
+
+	barrier.sync();
+
+  return 0;
+}

--- a/examples/cuda/test_dram_host_allocated/Makefile
+++ b/examples/cuda/test_dram_host_allocated/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = dram_host_allocated
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_dram_host_allocated/kernel.cpp
+++ b/examples/cuda/test_dram_host_allocated/kernel.cpp
@@ -1,0 +1,18 @@
+//This kernel takes a pointer to a location in DRAM, and fills it with an arbitrary value 
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+extern "C" __attribute__ ((noinline))
+int kernel_dram_host_allocated(int *addr) {
+
+	*addr = 0x1234;
+
+	barrier.sync();
+
+  return 0;
+}

--- a/examples/cuda/test_dram_load_store/Makefile
+++ b/examples/cuda/test_dram_load_store/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = dram_load_store
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_dram_load_store/kernel.cpp
+++ b/examples/cuda/test_dram_load_store/kernel.cpp
@@ -1,0 +1,9 @@
+//This is an empty kernel 
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+extern "C" __attribute__ ((noinline))
+int kernel_dram_load_store() {
+  return 0;
+}

--- a/examples/cuda/test_empty_parallel/Makefile
+++ b/examples/cuda/test_empty_parallel/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = empty_parallel
@@ -79,21 +78,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -122,11 +118,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_empty_parallel/kernel.cpp
+++ b/examples/cuda/test_empty_parallel/kernel.cpp
@@ -1,0 +1,9 @@
+//This is an empty kernel 
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+extern "C" __attribute__ ((noinline))
+int kernel_empty() {
+  return 0;
+}

--- a/examples/cuda/test_float_all_ops/Makefile
+++ b/examples/cuda/test_float_all_ops/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = float_all_ops
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_float_all_ops/kernel.cpp
+++ b/examples/cuda/test_float_all_ops/kernel.cpp
@@ -1,0 +1,45 @@
+//This kernel performs a list of operations on two float vectors
+//Operatiosn incluce <add, sub, mul, div, compare, convert> 
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+typedef union data_t {
+	int hb_mc_int;
+	float hb_mc_float;
+} hb_mc_data_t;
+
+
+extern "C" __attribute__ ((noinline))
+int kernel_float_all_ops(float *A, float *B,
+                         float *res_add, float *res_sub,
+                         float *res_mul, float *res_div,
+                         float *res_compare, float *res_convert,
+                         int N, int block_size_x) {
+
+	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
+	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
+		int i = start_x + iter_x;
+		res_add[i] = A[i] + B[i];
+		res_sub[i] = A[i] - B[i];
+		res_mul[i] = A[i] * B[i];
+		res_div[i] = A[i] / B[i];
+		if (A[i] >= B[i]) {
+			res_compare[i] = 1.0;
+		}
+		else { 
+			res_compare[i] = 0.0;
+		}
+		hb_mc_data_t data;
+		data.hb_mc_float = A[i]; 
+		res_convert[i] = (float) data.hb_mc_int;
+	}
+
+	barrier.sync();
+
+  return 0;
+}

--- a/examples/cuda/test_float_matrix_mul/Makefile
+++ b/examples/cuda/test_float_matrix_mul/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = float_matrix_mul
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_float_matrix_mul/kernel.cpp
+++ b/examples/cuda/test_float_matrix_mul/kernel.cpp
@@ -1,0 +1,37 @@
+/*!
+ * This kernel performs matrix multiplication 
+ * For now the matrices are assumed to have the same X/Y dimension n.
+ */
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+extern "C" __attribute__ ((noinline))
+int kernel_float_matrix_mul(float *A, float *B, float *C, int M, int N, int P, int block_size_y, int block_size_x) {
+
+
+	int start_y = __bsg_tile_group_id_y * block_size_y;
+	int start_x = __bsg_tile_group_id_x * block_size_x;
+	int end_y = start_y + block_size_y;
+	int end_x = start_x + block_size_x;
+	//int end_y = M < (start_y + block_size_y) ? M : (start_y + block_size_y);
+	//int end_x = P < (start_x + block_size_x) ? P : (start_x + block_size_x);
+	
+	for (int iter_y = start_y + __bsg_y; iter_y < end_y; iter_y += bsg_tiles_Y) { 
+		for (int iter_x = start_x + __bsg_x; iter_x < end_x; iter_x += bsg_tiles_X) { 
+			float sum = 0; 
+			for (int k = 0; k < N; k ++) { 
+				sum += A[iter_y * N + k] * B[k * P + iter_x];
+			}
+			C[iter_y * P + iter_x] = sum;
+		}
+	}
+
+	barrier.sync();
+
+	return 0;
+}

--- a/examples/cuda/test_float_matrix_mul_shared_mem/Makefile
+++ b/examples/cuda/test_float_matrix_mul_shared_mem/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = float_matrix_mul_shared_mem
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_float_matrix_mul_shared_mem/kernel.cpp
+++ b/examples/cuda/test_float_matrix_mul_shared_mem/kernel.cpp
@@ -1,0 +1,128 @@
+/*!
+ * This kernel performs tiled matrix multiplication with use of tile-group-shared memory
+ */
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+#define BLOCK_WIDTH 4
+
+
+
+void __attribute__ ((noinline)) subblock2shmem (float *A, float *sh_dest, int M, int N, int block_size_y, int block_size_x, int sub_block_y, int sub_block_x) { 
+
+	int start_y = sub_block_y * block_size_y;
+	int start_x = sub_block_x * block_size_x;
+	
+	for (int iter_y = __bsg_y; iter_y < block_size_y; iter_y += bsg_tiles_Y) { 
+		for (int iter_x = __bsg_x; iter_x < block_size_x; iter_x += bsg_tiles_X) { 
+			// sh_dest[iter_y][iter_x] <-- A[iter_y + start_y][iter_x + start_x]
+			bsg_tile_group_shared_store (float, sh_dest, (iter_y * block_size_x + iter_x), A[((iter_y + start_y) * N + iter_x + start_x)]);
+		}
+	}
+	return; 
+}
+
+
+void __attribute__ ((noinline)) subblock2shmem_xposed (float *A, float *sh_dest, int M, int N, int block_size_y, int block_size_x, int sub_block_y, int sub_block_x) { 
+
+	int start_y = sub_block_y * block_size_y;
+	int start_x = sub_block_x * block_size_x;
+	
+	for (int iter_y = __bsg_y; iter_y < block_size_y; iter_y += bsg_tiles_Y) { 
+		for (int iter_x = __bsg_x; iter_x < block_size_x; iter_x += bsg_tiles_X) { 
+			// sh_dest[iter_x][iter_y] <-- A[iter_y + start_y][iter_x + start_x]
+			bsg_tile_group_shared_store (float, sh_dest, (iter_x * block_size_y + iter_y), A[((iter_y + start_y) * N + iter_x + start_x)]);
+		}
+	}
+	return; 
+}
+
+
+void __attribute__ ((noinline)) shmem2subblock (float *A, float *sh_src, int M, int N, int block_size_y, int block_size_x, int sub_block_y, int sub_block_x) { 
+
+	int start_y = sub_block_y * block_size_y;
+	int start_x = sub_block_x * block_size_x;
+	
+	for (int iter_y = __bsg_y; iter_y < block_size_y; iter_y += bsg_tiles_Y) { 
+		for (int iter_x = __bsg_x; iter_x < block_size_x; iter_x += bsg_tiles_X) { 
+			// A[iter_y + start_y][iter_x + start_x] <-- sh_src[iter_y][iter_x]
+			bsg_tile_group_shared_load (float, sh_src, (iter_y * block_size_x + iter_x), A[((iter_y + start_y) * N + iter_x + start_x)]);
+		}
+	}
+	return; 
+}
+
+
+void __attribute__ ((noinline)) subblock_shmem_matrix_mul_xposed (float *sh_A, float *sh_B, float *sh_C, int M, int N, int P, int block_size_y, int block_size_x, int block_num) { 
+
+	
+	for (int iter_y = __bsg_y; iter_y < block_size_y; iter_y += bsg_tiles_Y) { 
+		for (int iter_x = __bsg_x; iter_x < block_size_x; iter_x += bsg_tiles_X) { 
+
+			float sum = 0; 
+			float lc_A, lc_B;
+			for (int k = 0; k < BLOCK_WIDTH; k ++) { 
+				// lc_A <-- sh_A[iter_y][iter_x]
+				bsg_tile_group_shared_load (float, sh_A, (iter_y * BLOCK_WIDTH + k), lc_A); 
+				// lc_B <-- sh_B[iter_y][iter_x]	remember B is transposed
+				bsg_tile_group_shared_load (float, sh_B, (iter_x * BLOCK_WIDTH + k), lc_B);
+				sum += lc_A * lc_B;
+			}
+
+			if (!block_num) { 
+				// sh_C[iter_y][iter_x] <-- sum
+				bsg_tile_group_shared_store (float, sh_C, (iter_y * block_size_x + iter_x), sum);
+			}
+			else { 
+				float lc_C;
+				// sh_C[iter_y][iter_x] += sum
+				bsg_tile_group_shared_load (float, sh_C, (iter_y * block_size_x + iter_x), lc_C);
+				bsg_tile_group_shared_store (float, sh_C, (iter_y * block_size_x + iter_x), lc_C + sum);
+			} 
+		}
+	}
+	return;
+}
+
+
+
+
+
+
+
+extern "C" __attribute__ ((noinline))
+int kernel_float_matrix_mul_shared_mem(float *A, float *B, float *C, int M, int N, int P, int block_size_y, int block_size_x) {
+
+	
+	// declare tile-group shared memory
+	bsg_tile_group_shared_mem (float, sh_A, (block_size_y * BLOCK_WIDTH));
+	bsg_tile_group_shared_mem (float, sh_B, (BLOCK_WIDTH * block_size_x));
+	bsg_tile_group_shared_mem (float, sh_C, (block_size_y * block_size_x));
+
+
+	int num_blocks = N / BLOCK_WIDTH;	// *** Must divide evenly
+
+	for (int block_num = 0; block_num < num_blocks; block_num ++) { 
+
+		subblock2shmem (       A, sh_A, M, N, block_size_y, BLOCK_WIDTH, __bsg_tile_group_id_y, block_num);
+ 
+		subblock2shmem_xposed (B, sh_B, N, P, BLOCK_WIDTH, block_size_x, block_num, __bsg_tile_group_id_x);
+
+		barrier.sync();
+		
+		subblock_shmem_matrix_mul_xposed (sh_A, sh_B, sh_C, M, N, P, block_size_y, block_size_x, block_num);
+		
+		barrier.sync();
+	}
+
+	shmem2subblock (C, sh_C, M, P, block_size_y, block_size_x, __bsg_tile_group_id_y, __bsg_tile_group_id_x); 
+
+	barrier.sync();
+
+	return 0;
+}

--- a/examples/cuda/test_float_vec_add/Makefile
+++ b/examples/cuda/test_float_vec_add/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = float_vec_add
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_float_vec_add/kernel.cpp
+++ b/examples/cuda/test_float_vec_add/kernel.cpp
@@ -1,0 +1,23 @@
+//This kernel adds 2 vectors 
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+
+
+extern "C" __attribute__ ((noinline))
+int kernel_float_vec_add(float *A, float *B, float *C, int N, int block_size_x) {
+
+	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
+	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
+		C[start_x + iter_x] = A[start_x + iter_x] + B[start_x + iter_x];
+	}
+
+	barrier.sync();
+
+  return 0;
+}

--- a/examples/cuda/test_float_vec_add_shared_mem/Makefile
+++ b/examples/cuda/test_float_vec_add_shared_mem/Makefile
@@ -43,10 +43,9 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
-KERNEL_NAME = float_vec_add_shared_mem
+KERNEL_NAME = vec_add_shared_mem
 
 ###############################################################################
 # Host code compilation flags and flow
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_float_vec_add_shared_mem/kernel.cpp
+++ b/examples/cuda/test_float_vec_add_shared_mem/kernel.cpp
@@ -1,0 +1,60 @@
+//This kernel adds two floating point vectors using
+// shared memory, each tile group loads a block into
+// shared memory and performs addition, and stores it back. 
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+
+extern "C"  __attribute__ ((noinline))
+int kernel_float_vec_add_shared_mem(float *A, float *B, float *C, int N, int block_size_x) {
+
+	// Declare tile-group shared memroy with specific size
+	bsg_tile_group_shared_mem (float, sh_A, block_size_x);
+	bsg_tile_group_shared_mem (float, sh_B, block_size_x); 
+	bsg_tile_group_shared_mem (float, sh_C, block_size_x); 
+
+
+	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
+
+
+	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
+		// Store from DRAM into tile-group shared memory
+		bsg_tile_group_shared_store(float, sh_A, iter_x, A[start_x + iter_x]); 
+		bsg_tile_group_shared_store(float, sh_B, iter_x, B[start_x + iter_x]); 
+		
+	}
+
+
+	barrier.sync(); 
+
+
+	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
+		float lc_A, lc_B;
+		// Load from tile group shared memory and store into local variable lc_A & lc_B
+		bsg_tile_group_shared_load (float, sh_A, iter_x, lc_A);
+		bsg_tile_group_shared_load (float, sh_B, iter_x, lc_B);
+
+		// Store the sum of lc_A and lc_B into tile-group shared memroy sh_C
+		bsg_tile_group_shared_store (float, sh_C, iter_x, (lc_A + lc_B));
+	}
+
+	
+	barrier.sync(); 
+
+
+	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
+		// Load from tile-group shared memory lc_C and store the result into DRAM 
+		bsg_tile_group_shared_load(float, sh_C, iter_x, C[start_x + iter_x]); 
+	}
+
+
+	barrier.sync(); 
+
+
+  return 0;
+}

--- a/examples/cuda/test_float_vec_div/Makefile
+++ b/examples/cuda/test_float_vec_div/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = float_vec_div
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_float_vec_div/kernel.cpp
+++ b/examples/cuda/test_float_vec_div/kernel.cpp
@@ -1,0 +1,21 @@
+//This kernel divides the first vector by the second and stores the results in the thrid vector 
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+extern "C" __attribute__ ((noinline))
+int kernel_float_vec_div(float *A, float *B, float *C, int N, int block_size_x) {
+
+	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
+	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
+		C[start_x + iter_x] = A[start_x + iter_x] / B[start_x + iter_x];
+	}
+
+	barrier.sync();
+
+  return 0;
+}

--- a/examples/cuda/test_float_vec_exp/Makefile
+++ b/examples/cuda/test_float_vec_exp/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = float_vec_exp
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,21 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
+
+# Remove nostdlib
+kernel.riscv: RISCV_LDFLAGS := $(filter-out -nostdlib,$(RISCV_LDFLAGS))
 
 ###############################################################################
 # Execution flow
@@ -124,11 +123,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_float_vec_exp/kernel.cpp
+++ b/examples/cuda/test_float_vec_exp/kernel.cpp
@@ -1,0 +1,23 @@
+//This kernel stores the exponential of the elements in the first vector into the second  
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "math.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+
+extern "C" __attribute__ ((noinline))
+int kernel_float_vec_exp(float *A, float *B, int N, int block_size_x) {
+
+	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
+	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
+		B[start_x + iter_x] = expf(A[start_x + iter_x]);
+	}
+
+	barrier.sync();
+
+  return 0;
+}

--- a/examples/cuda/test_float_vec_log/Makefile
+++ b/examples/cuda/test_float_vec_log/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = float_vec_log
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,21 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
+
+# Remove nostdlib
+kernel.riscv: RISCV_LDFLAGS := $(filter-out -nostdlib,$(RISCV_LDFLAGS))
 
 ###############################################################################
 # Execution flow
@@ -124,11 +123,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_float_vec_log/kernel.cpp
+++ b/examples/cuda/test_float_vec_log/kernel.cpp
@@ -1,0 +1,23 @@
+//This kernel stores the logarithmic of the elements in the first vector into the second  
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "math.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+
+extern "C" __attribute__ ((noinline))
+int kernel_float_vec_log(float *A, float *B, int N, int block_size_x) {
+
+	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
+	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
+		B[start_x + iter_x] = logf(A[start_x + iter_x]);
+	}
+
+	barrier.sync();
+
+  return 0;
+}

--- a/examples/cuda/test_float_vec_mul/Makefile
+++ b/examples/cuda/test_float_vec_mul/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = float_vec_mul
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_float_vec_mul/kernel.cpp
+++ b/examples/cuda/test_float_vec_mul/kernel.cpp
@@ -1,0 +1,22 @@
+//This kernel multiplies 2 vectors and stores the result in the thrid
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+
+extern "C" __attribute__ ((noinline))
+int kernel_float_vec_mul(float *A, float *B, float *C, int N, int block_size_x) {
+
+	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
+	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
+		C[start_x + iter_x] = A[start_x + iter_x] * B[start_x + iter_x];
+	}
+
+	barrier.sync();
+
+  return 0;
+}

--- a/examples/cuda/test_float_vec_sqrt/Makefile
+++ b/examples/cuda/test_float_vec_sqrt/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = float_vec_sqrt
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_float_vec_sqrt/kernel.cpp
+++ b/examples/cuda/test_float_vec_sqrt/kernel.cpp
@@ -1,0 +1,23 @@
+//This kernel stores the square root of the elements in the first vector into the second  
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "math.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+
+extern "C" __attribute__ ((noinline))
+int kernel_float_vec_sqrt(float *A, float *B, int N, int block_size_x) {
+
+	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
+	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
+		B[start_x + iter_x] = sqrtf(A[start_x + iter_x]);
+	}
+
+	barrier.sync();
+
+  return 0;
+}

--- a/examples/cuda/test_hammer_cache/Makefile
+++ b/examples/cuda/test_hammer_cache/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = hammer_cache
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_hammer_cache/kernel.cpp
+++ b/examples/cuda/test_hammer_cache/kernel.cpp
@@ -1,0 +1,50 @@
+/*******************************************************************/
+/* This kernel is designed to overload the memory system.          */
+/* It forces cache evictions by striding to the line in the        */
+/* same set of the same cache and doing a single store.            */
+/* It then stores a word to an address maping to the evicted line. */
+/*******************************************************************/
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#define bsg_n (bsg_tiles_X * bsg_tiles_Y)
+
+static
+int hammer_cache(int *dram_cache_aligned,
+                 int cache_line_size_words,
+                 int n_caches,
+                 int n_ways,
+                 int n_sets)
+{
+    int *base = &dram_cache_aligned[cache_line_size_words*bsg_id];
+    int *baddr = base;
+    base[1] = 0xdeadbeef;
+    for (int i = 0; i < n_ways+1; i++) {
+        *baddr = i;
+        // get next address that maps to the same set
+        baddr = &baddr[cache_line_size_words * n_caches * n_sets];
+    }
+    // load from the original line - should have been evicted
+    return base[1] == 0xdeadbeef;
+}
+
+extern "C" __attribute__ ((noinline))
+int kernel_hammer_cache(
+    int * dram_cache_aligned,
+    int   cache_line_size_words,
+    int   n_caches,
+    int   n_ways,
+    int   n_sets,
+    int   n_hammers
+    ) {
+
+    int *base = dram_cache_aligned;
+    for (int i = 0; i < n_hammers; i++) {
+        hammer_cache(base, cache_line_size_words, n_caches, n_ways, n_sets);
+        // shift up bsg_n caches
+        base = &base[cache_line_size_words * bsg_n];
+    }
+
+    return 0;
+}

--- a/examples/cuda/test_high_mem/Makefile
+++ b/examples/cuda/test_high_mem/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = high_mem
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS +=
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_high_mem/kernel.cpp
+++ b/examples/cuda/test_high_mem/kernel.cpp
@@ -1,0 +1,10 @@
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+extern "C" __attribute__ ((noinline))
+int kernel_high_mem(unsigned *A, unsigned *B, int N) {
+    for (int i = 0; i < N; ++i) {
+        B[i] = A[i];
+    }
+    return 0;
+}

--- a/examples/cuda/test_host_memset/Makefile
+++ b/examples/cuda/test_host_memset/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = host_memset
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_host_memset/kernel.cpp
+++ b/examples/cuda/test_host_memset/kernel.cpp
@@ -1,0 +1,16 @@
+//This kernel performs a barrier among all tiles in tile group 
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+
+extern "C" __attribute__ ((noinline))
+int kernel_host_memset() {
+	barrier.sync();
+	return 0;
+}

--- a/examples/cuda/test_log_softmax/Makefile
+++ b/examples/cuda/test_log_softmax/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = log_softmax
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,21 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
+
+# Remove nostdlib
+kernel.riscv: RISCV_LDFLAGS := $(filter-out -nostdlib,$(RISCV_LDFLAGS))
 
 ###############################################################################
 # Execution flow
@@ -124,11 +123,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_log_softmax/kernel.cpp
+++ b/examples/cuda/test_log_softmax/kernel.cpp
@@ -1,0 +1,151 @@
+
+/*!
+ * This kernel computes LogSoftmax of a matrix A with dimensions MxN and stores the result in B:
+ * LogSoftmax(A) = A - log(sum(exp(A))) (with division done element-wise).
+ * The algorithm works in 3 phases:
+ *      1) Compute max by doing a reduction in a shared array, store in variable m
+ *      2) Compute sum(exp(A - m)), and store exp(A - m) into B while computing sum,
+ *         then finally compute log(sum)
+ *      3) Make B equal to A - log(sum) elementwise
+ */
+
+/*
+  Description of reduction:
+  If we want to compute an aggregator function F (in this kernel, sum and max), we do it as follows:
+        1) Allocate a shared array with one element for each tile in tilegroup
+        2) Each tile aggregates elements belonging to it
+        3) Tiles in the top row aggregate their column
+        4) Tile at (0, 0) aggregates row 0
+        At the end, element (0, 0) stores the result of the aggregate.
+ */
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "math.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+
+#define max(x, y) (((x) > (y)) ? (x) : (y))
+
+float compute_max(const float *A, float *agg, int M, int N, int block_size_y, int block_size_x)
+{
+        int start_y = __bsg_tile_group_id_y * block_size_y;
+        int start_x = __bsg_tile_group_id_x * block_size_x;
+        int end_y = start_y + block_size_y;
+        int end_x = start_x + block_size_x;
+
+        float partial_max = -INFINITY;
+        // Compute max(B) for each element belonging to a tile in the tilegroup
+        for(int y = start_y + __bsg_y; y < end_y; y += bsg_tiles_Y)
+        {
+                for(int x = start_x + __bsg_x; x < end_x; x += bsg_tiles_X)
+                {
+                        partial_max = max(A[y * N + x], partial_max);
+                }
+        }
+        bsg_tile_group_shared_store(float, agg, __bsg_y * bsg_tiles_X + __bsg_x, partial_max);
+	barrier.sync();
+
+        // Compute max of the columns of the aggregator matrix
+        if(__bsg_y == 0)
+        {
+                for(int y = 1; y < bsg_tiles_Y; y++)
+                {
+                        float other;
+                        bsg_tile_group_shared_load(float, agg, y * bsg_tiles_X + __bsg_x, other);
+                        partial_max = max(partial_max, other);
+                }
+                bsg_tile_group_shared_store(float, agg, __bsg_x, partial_max);
+        }
+	barrier.sync();
+        // Compute max of row 0 of the row matrix
+        if(__bsg_y == 0 && __bsg_x == 0)
+        {
+                for(int x = 1; x < bsg_tiles_X; x++)
+                {
+                        float other;
+                        bsg_tile_group_shared_load(float, agg, x, other);
+                        partial_max = max(partial_max, other);
+                }
+                bsg_tile_group_shared_store(float, agg, 0, partial_max);
+        }
+        float result;
+	barrier.sync();
+        bsg_tile_group_shared_load(float, agg, 0, result);
+	barrier.sync();
+        return result;
+}
+
+extern "C" __attribute__((noinline))
+int kernel_log_softmax(const float *A, float *B, int M, int N, int block_size_y, int block_size_x)
+{
+        // Array for aggregations
+        bsg_tile_group_shared_mem(float, agg, bsg_tiles_X * bsg_tiles_Y);
+        float m = compute_max(A, agg, M, N, block_size_y, block_size_x);
+        int start_y = __bsg_tile_group_id_y * block_size_y;
+        int start_x = __bsg_tile_group_id_x * block_size_x;
+        int end_y = start_y + block_size_y;
+        int end_x = start_x + block_size_x;
+
+        // Compute B = exp(A - m)
+        for(int y = start_y + __bsg_y; y < end_y; y += bsg_tiles_Y)
+        {
+                for(int x = start_x + __bsg_x; x < end_x; x += bsg_tiles_X)
+                {
+                        B[y * N + x] = expf(A[y * N + x] - m);
+                }
+        }
+	barrier.sync();
+
+        float partial_sum = 0;
+        // Compute sum(B) for each element belonging to a tile in the tilegroup
+        for(int y = start_y + __bsg_y; y < end_y; y += bsg_tiles_Y)
+        {
+                for(int x = start_x + __bsg_x; x < end_x; x += bsg_tiles_X)
+                {
+                        partial_sum += B[y * N + x];
+                }
+        }
+        bsg_tile_group_shared_store(float, agg, __bsg_y * bsg_tiles_X + __bsg_x, partial_sum);
+	barrier.sync();
+
+        // Compute sum of the columns of the sum matrix
+        if(__bsg_y == 0)
+        {
+                for(int y = 1; y < bsg_tiles_Y; y++)
+                {
+                        float other;
+                        bsg_tile_group_shared_load(float, agg, y * bsg_tiles_X + __bsg_x, other);
+                        partial_sum += other;
+                }
+                bsg_tile_group_shared_store(float, agg, __bsg_x, partial_sum);
+        }
+	barrier.sync();
+        // Compute sum of row 0 of the row matrix
+        if(__bsg_y == 0 && __bsg_x == 0)
+        {
+                for(int x = 1; x < bsg_tiles_X; x++)
+                {
+                        float other;
+                        bsg_tile_group_shared_load(float, agg, x, other);
+                        partial_sum += other;
+                }
+                partial_sum = logf(partial_sum);
+                bsg_tile_group_shared_store(float, agg, 0, partial_sum);
+        }
+	barrier.sync();
+        float sum;
+        bsg_tile_group_shared_load(float, agg, 0, sum);
+        for(int y = start_y + __bsg_y; y < end_y; y += bsg_tiles_Y)
+        {
+                for(int x = start_x + __bsg_x; x < end_x; x += bsg_tiles_X)
+                {
+                        B[y * N + x] = A[y * N + x] - sum;
+                }
+        }
+	barrier.sync();
+        return 0;
+}

--- a/examples/cuda/test_matrix_mul/Makefile
+++ b/examples/cuda/test_matrix_mul/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = matrix_mul
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_matrix_mul/kernel.cpp
+++ b/examples/cuda/test_matrix_mul/kernel.cpp
@@ -1,0 +1,37 @@
+/*!
+ * This kernel performs matrix multiplication 
+ * For now the matrices are assumed to have the same X/Y dimension n.
+ */
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+extern "C" __attribute__ ((noinline))
+int kernel_matrix_mul(int *A, int *B, int *C, int M, int N, int P, int block_size_y, int block_size_x) {
+
+
+	int start_y = __bsg_tile_group_id_y * block_size_y;
+	int start_x = __bsg_tile_group_id_x * block_size_x;
+	int end_y = start_y + block_size_y;
+	int end_x = start_x + block_size_x;
+	//int end_y = M < (start_y + block_size_y) ? M : (start_y + block_size_y);
+	//int end_x = P < (start_x + block_size_x) ? P : (start_x + block_size_x);
+
+	for (int iter_y = start_y + __bsg_y; iter_y < end_y; iter_y += bsg_tiles_Y) { 
+		for (int iter_x = start_x + __bsg_x; iter_x < end_x; iter_x += bsg_tiles_X) { 
+			int sum = 0; 
+			for (int k = 0; k < N; k ++) { 
+				sum += A[iter_y * N + k] * B[k * P + iter_x];
+			}
+			C[iter_y * P + iter_x] = sum;
+		}
+	}
+
+	barrier.sync();
+
+	return 0;
+}

--- a/examples/cuda/test_matrix_mul_shared_mem/Makefile
+++ b/examples/cuda/test_matrix_mul_shared_mem/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = matrix_mul_shared_mem
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_matrix_mul_shared_mem/kernel.cpp
+++ b/examples/cuda/test_matrix_mul_shared_mem/kernel.cpp
@@ -1,0 +1,124 @@
+/*!
+ * This kernel performs tiled matrix multiplication with use of tile-group-shared memory
+ */
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+#define BLOCK_WIDTH 4
+
+
+void __attribute__ ((noinline)) subblock2shmem (int *A, int *sh_dest, int M, int N, int block_size_y, int block_size_x, int sub_block_y, int sub_block_x) { 
+
+	int start_y = sub_block_y * block_size_y;
+	int start_x = sub_block_x * block_size_x;
+	
+	for (int iter_y = __bsg_y; iter_y < block_size_y; iter_y += bsg_tiles_Y) { 
+		for (int iter_x = __bsg_x; iter_x < block_size_x; iter_x += bsg_tiles_X) { 
+			// sh_dest[iter_y][iter_x] <-- A[iter_y + start_y][iter_x + start_x]
+			bsg_tile_group_shared_store (int, sh_dest, (iter_y * block_size_x + iter_x), A[((iter_y + start_y) * N + iter_x + start_x)]);
+		}
+	}
+	return; 
+}
+
+
+void __attribute__ ((noinline)) subblock2shmem_xposed (int *A, int *sh_dest, int M, int N, int block_size_y, int block_size_x, int sub_block_y, int sub_block_x) { 
+
+	int start_y = sub_block_y * block_size_y;
+	int start_x = sub_block_x * block_size_x;
+	
+	for (int iter_y = __bsg_y; iter_y < block_size_y; iter_y += bsg_tiles_Y) { 
+		for (int iter_x = __bsg_x; iter_x < block_size_x; iter_x += bsg_tiles_X) { 
+			// sh_dest[iter_x][iter_y] <-- A[iter_y + start_y][iter_x + start_x]
+			bsg_tile_group_shared_store (int, sh_dest, (iter_x * block_size_y + iter_y), A[((iter_y + start_y) * N + iter_x + start_x)]);
+		}
+	}
+	return; 
+}
+
+
+void __attribute__ ((noinline)) shmem2subblock (int *A, int *sh_src, int M, int N, int block_size_y, int block_size_x, int sub_block_y, int sub_block_x) { 
+
+	int start_y = sub_block_y * block_size_y;
+	int start_x = sub_block_x * block_size_x;
+	
+	for (int iter_y = __bsg_y; iter_y < block_size_y; iter_y += bsg_tiles_Y) { 
+		for (int iter_x = __bsg_x; iter_x < block_size_x; iter_x += bsg_tiles_X) { 
+			// A[iter_y + start_y][iter_x + start_x] <-- sh_src[iter_y][iter_x]
+			bsg_tile_group_shared_load (int, sh_src, (iter_y * block_size_x + iter_x), A[((iter_y + start_y) * N + iter_x + start_x)]);
+		}
+	}
+	return; 
+}
+
+
+void __attribute__ ((noinline)) subblock_shmem_matrix_mul_xposed (int *sh_A, int *sh_B, int *sh_C, int M, int N, int P, int block_size_y, int block_size_x, int block_num) { 
+
+	
+	for (int iter_y = __bsg_y; iter_y < block_size_y; iter_y += bsg_tiles_Y) { 
+		for (int iter_x = __bsg_x; iter_x < block_size_x; iter_x += bsg_tiles_X) { 
+
+			int sum = 0; 
+			int lc_A, lc_B;
+			for (int k = 0; k < BLOCK_WIDTH; k ++) { 
+				// lc_A <-- sh_A[iter_y][iter_x]
+				bsg_tile_group_shared_load (int, sh_A, (iter_y * BLOCK_WIDTH + k), lc_A); 
+				// lc_B <-- sh_B[iter_y][iter_x]	remember B is transposed
+				bsg_tile_group_shared_load (int, sh_B, (iter_x * BLOCK_WIDTH + k), lc_B);
+				sum += lc_A * lc_B;
+			}
+
+			if (!block_num) { 
+				// sh_C[iter_y][iter_x] <-- sum
+				bsg_tile_group_shared_store (int, sh_C, (iter_y * block_size_x + iter_x), sum);
+			}
+			else { 
+				int lc_C;
+				// sh_C[iter_y][iter_x] += sum
+				bsg_tile_group_shared_load (int, sh_C, (iter_y * block_size_x + iter_x), lc_C);
+				bsg_tile_group_shared_store (int, sh_C, (iter_y * block_size_x + iter_x), lc_C + sum);
+			} 
+		}
+	}
+	return;
+}
+
+
+
+extern "C" __attribute__ ((noinline))
+int kernel_matrix_mul_shared_mem(int *A, int *B, int *C, int M, int N, int P, int block_size_y, int block_size_x) {
+
+
+	// declare tile-group shared memory
+	bsg_tile_group_shared_mem (int, sh_A, (block_size_y * BLOCK_WIDTH));
+	bsg_tile_group_shared_mem (int, sh_B, (BLOCK_WIDTH * block_size_x));
+	bsg_tile_group_shared_mem (int, sh_C, (block_size_y * block_size_x));
+
+
+	int num_blocks = N / BLOCK_WIDTH;	// *** Must divide evenly
+
+	for (int block_num = 0; block_num < num_blocks; block_num ++) { 
+
+		subblock2shmem (       A, sh_A, M, N, block_size_y, BLOCK_WIDTH, __bsg_tile_group_id_y, block_num);
+ 
+		subblock2shmem_xposed (B, sh_B, N, P, BLOCK_WIDTH, block_size_x, block_num, __bsg_tile_group_id_x);
+
+		barrier.sync();
+		
+		subblock_shmem_matrix_mul_xposed (sh_A, sh_B, sh_C, M, N, P, block_size_y, block_size_x, block_num);
+		
+		barrier.sync();
+	}
+
+	shmem2subblock (C, sh_C, M, P, block_size_y, block_size_x, __bsg_tile_group_id_y, __bsg_tile_group_id_x); 
+
+	barrier.sync();
+
+	return 0;
+}
+
+

--- a/examples/cuda/test_max_pool2d/Makefile
+++ b/examples/cuda/test_max_pool2d/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = max_pool2d
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_max_pool2d/kernel.cpp
+++ b/examples/cuda/test_max_pool2d/kernel.cpp
@@ -1,0 +1,50 @@
+/*!
+ * This kernel performs max pool 2d 
+ * Takes in a MxN matrix and stores the maximum of each sub matrix
+ * Inside one element in the PxW result matrix
+ * M and N should divide evenly by P and W, respectively.
+ */
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+extern "C" __attribute__ ((noinline))
+int kernel_max_pool2d(int *A, int *B, int M, int N, int P, int W, int block_size_y, int block_size_x) {
+
+	int sub_block_y = M / P; // Should divide evenly	
+	int sub_block_x = N / W; // Should divide evenly	
+	int start_y = __bsg_tile_group_id_y * block_size_y;
+	int start_x = __bsg_tile_group_id_x * block_size_x;
+	int end_y = start_y + block_size_y;
+	int end_x = start_x + block_size_x;
+
+	for (int iter_y = start_y + __bsg_y; iter_y < end_y; iter_y += bsg_tiles_Y) { 
+		for (int iter_x = start_x + __bsg_x; iter_x < end_x; iter_x += bsg_tiles_X) { 
+
+			int src_start_y = iter_y * sub_block_y;
+			int src_start_x = iter_x * sub_block_x;
+			int src_end_y = src_start_y + sub_block_y;
+			int src_end_x = src_start_x + sub_block_x;
+		
+			int sub_max = A[src_start_y * N + src_start_x]; 
+
+			for (int y = src_start_y; y < src_end_y; y ++) { 
+				for (int x = src_start_x; x < src_end_x; x ++) { 
+					if (A[y * N + x] > sub_max) { 
+						sub_max = A[y * N + x];
+					}
+				}
+			}
+
+			B[iter_y * W + iter_x] = sub_max;
+		}
+	}
+
+	barrier.sync();
+
+	return 0;
+}

--- a/examples/cuda/test_memory_leak/Makefile
+++ b/examples/cuda/test_memory_leak/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = memory_leak
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_memory_leak/kernel.cpp
+++ b/examples/cuda/test_memory_leak/kernel.cpp
@@ -1,0 +1,15 @@
+// This is an empty kernel that takes in 8 very large chunks of data
+// as input arguments. It is used to check for any memory leaks on the 
+// host side.
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+extern "C" int  __attribute__ ((noinline)) kernel_memory_leak(int *A, int *B, int *C, int *D) {
+
+    barrier.sync();
+    return 0;
+}

--- a/examples/cuda/test_multiple_binary_load/Makefile
+++ b/examples/cuda/test_multiple_binary_load/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = multiple_binary_load
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_multiple_binary_load/kernel.cpp
+++ b/examples/cuda/test_multiple_binary_load/kernel.cpp
@@ -1,0 +1,9 @@
+//This is an empty kernel 
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+extern "C" __attribute__ ((noinline))
+int kernel_empty() {
+  return 0;
+}

--- a/examples/cuda/test_profiler/Makefile
+++ b/examples/cuda/test_profiler/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = profiler
@@ -61,7 +60,7 @@ CXXDEFINES +=
 
 FLAGS     = -g -Wall -Wno-unused-function -Wno-unused-variable
 CFLAGS   += -std=c99 $(FLAGS)
-CXXFLAGS += -std=gnu++11 $(FLAGS)
+CXXFLAGS += -std=c++11 $(FLAGS)
 
 # compilation.mk defines rules for compilation of C/C++
 include $(EXAMPLES_PATH)/compilation.mk
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -116,7 +112,7 @@ include $(EXAMPLES_PATH)/execution.mk
 # Regression Flow
 ###############################################################################
 
-regression: exec.log
+regression: profile.log
 	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
 
 .DEFAULT_GOAL := help
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_profiler/kernel.cpp
+++ b/examples/cuda/test_profiler/kernel.cpp
@@ -1,0 +1,281 @@
+/*
+ * This kernel performs matrix multiplication. 
+ * 
+ */
+// BSG_TILE_GROUP_X_DIM and BSG_TILE_GROUP_Y_DIM must be defined
+// before bsg_manycore.h and bsg_tile_group_barrier.h are
+// included. bsg_tiles_X and bsg_tiles_Y must also be defined for
+// legacy reasons, but they are deprecated.
+#include <bsg_manycore.h>
+#include <bsg_set_tile_x_y.h>
+#include <cstdint>
+#include <cstring>
+
+/*
+ * This is a naive implementation of matrix multiplication that
+ * multiplies the two matricies A and B and stores the result in C.
+ *
+ * NOTE: Compiler is optimizing multiplies for indexing
+ */
+template <typename TA, typename TB, typename TC>
+int __attribute__ ((noinline)) template_kernel_matrix_multiply_noopt(TA *A, TB *B, TC *C,
+                      uint32_t A_HEIGHT, uint32_t A_WIDTH,
+                      uint32_t B_WIDTH) {
+        TC sum;
+        for (uint32_t y = 0; y < A_HEIGHT; ++y) {
+                for (uint32_t x = 0; x < B_WIDTH; ++x){
+                        sum = static_cast<TC>(0);
+                        for (uint32_t k = 0; k < A_WIDTH; k ++) {
+                                sum += A[y * A_WIDTH + k] * B[k * B_WIDTH + x];
+                        }
+                        C[y * B_WIDTH + x] = sum;
+                }
+        }
+        return 0;
+}
+
+extern "C" int  __attribute__ ((noinline)) kernel_matrix_multiply_noopt(
+              float *A, float *B, float *C,
+              uint32_t A_HEIGHT, uint32_t A_WIDTH,
+              uint32_t B_WIDTH, uint32_t iter) {
+        int rc;
+
+        for(int i = 0; i <= iter; ++i){
+                rc = template_kernel_matrix_multiply_noopt(A, B, C, A_HEIGHT, A_WIDTH, B_WIDTH);
+        }
+
+        return rc;
+}
+
+/*
+ * This is a slightly-smarter implementation of matrix multiplication
+ * that multiplies the two matricies A and B and stores the result in
+ * C. In this implementation, B is transposed into BT prior to calling
+ * the kernel.
+ *
+ * NOTE: Compiler is optimizing multiplies for indexing
+ */
+template <typename TA, typename TB, typename TC>
+int __attribute__ ((noinline)) template_kernel_matrix_multiply_transpose(
+                      TA *A, TB *BT, TC *C,
+                      uint32_t A_HEIGHT, uint32_t A_WIDTH,
+                      uint32_t B_WIDTH) {
+
+        TC sum;
+        for (uint32_t y = 0; y < A_HEIGHT; ++y) {
+                for (uint32_t x = 0; x < B_WIDTH; ++x){
+                        sum = static_cast<TC>(0);
+                        for (uint32_t k = 0; k < A_WIDTH; ++k) {
+                                sum += A[y * A_WIDTH + k] * 
+                                        BT[x * A_WIDTH + k];
+                        }
+                        C[y * B_WIDTH + x] = sum;
+                }
+        }
+
+        return 0;
+}
+
+extern "C" int  __attribute__ ((noinline)) kernel_matrix_multiply_transpose(
+              float *A, float *B, float *C,
+              uint32_t A_HEIGHT, uint32_t A_WIDTH,
+              uint32_t B_WIDTH, uint32_t iter) {
+        int rc;
+
+        for(int i = 0; i <= iter; ++i){
+                rc = template_kernel_matrix_multiply_transpose(A, B, C, A_HEIGHT, A_WIDTH, B_WIDTH);
+        }
+
+        return rc;
+}
+
+/*
+ * This is a smarter implementation of matrix multiplication that
+ * multiplies the two matricies A and B and stores the result in C. In
+ * this implementation, B is transposed into BT prior to calling the
+ * kernel and all multiplies used to index the A, B and
+ * C arrays are transformed into additions (nomul).
+ */
+template <typename TA, typename TB, typename TC>
+int __attribute__ ((noinline)) template_kernel_matrix_multiply_transpose_nomul(
+                      TA *A, TB *BT, TC *C,
+                      uint32_t A_HEIGHT, uint32_t A_WIDTH,
+                      uint32_t B_WIDTH) {
+
+        TC sum;
+        for (uint32_t y = 0, ayoff = 0, boff, coff = 0; y < A_HEIGHT; ++y, ayoff += A_WIDTH) {
+                boff = 0;
+                for (uint32_t x = 0; x < B_WIDTH; x++, coff++){
+                        sum = static_cast<TC>(0);
+                        for (uint32_t aoff = ayoff; 
+                             aoff < ayoff + A_WIDTH; 
+                             ++aoff, ++boff) {
+                                sum += A[aoff] * BT[boff];
+                        }
+                        C[coff] = sum;
+                }
+        }
+
+        return 0;
+}
+
+extern "C" int  __attribute__ ((noinline)) kernel_matrix_multiply_transpose_nomul(
+              float *A, float *B, float *C,
+              uint32_t A_HEIGHT, uint32_t A_WIDTH,
+              uint32_t B_WIDTH, uint32_t iter) {
+        int rc;
+
+        for(int i = 0; i <= iter; ++i){
+                rc = template_kernel_matrix_multiply_transpose_nomul(A, B, C, A_HEIGHT, A_WIDTH, B_WIDTH);
+        }
+
+        return rc;
+}
+
+/*
+ * This is a smarter implementation of matrix multiplication that
+ * multiplies the two matricies A and B and stores the result in C. In
+ * this implementation, B is transposed into BT prior to calling the
+ * kernel and all multiplies used to index the A, B and C arrays are
+ * transformed into additions (nomul). The row-column dot product is
+ * unrolled by a factor of F (a template parameter)
+ */
+template <unsigned int F, typename TA, typename TB, typename TC>
+int __attribute__ ((noinline)) template_kernel_matrix_multiply_transpose_nomul_unroll (
+                      TA *A, TB *BT, TC *C,
+                      uint32_t A_HEIGHT, uint32_t A_WIDTH,
+                      uint32_t B_WIDTH) {
+
+        uint32_t incr = A_WIDTH * (F-1);
+        for (uint32_t y = 0, ayoff = 0, boff = 0, coff = 0; y < A_HEIGHT; y ++, ayoff += A_WIDTH) {
+                boff = 0;
+                for (uint32_t x = 0; x < B_WIDTH; x += F) {
+                        uint32_t bofff = 0;
+                        TC sum[F] = {{static_cast<TC>(0)}};
+                        for (uint32_t aoff = ayoff; aoff < ayoff + A_WIDTH; aoff++, ++boff) {
+                                bofff = boff;
+#pragma GCC unroll 8 // Does this unroll correctly when F < 4?
+                                for (uint32_t f = 0; f < F; ++f, bofff += A_WIDTH){
+                                        sum[f] += A[aoff] * BT[bofff];
+                                }
+                        }
+
+#pragma GCC unroll 8
+                        for (uint32_t f = 0; f < F; f++){
+                                C[coff + f] = sum[f];
+                        }
+                        boff += incr;
+                        coff += F;
+                }
+        }
+        return 0;
+}
+
+extern "C" int  __attribute__ ((noinline)) kernel_matrix_multiply_transpose_nomul_unroll(
+              float *A, float *B, float *C,
+              uint32_t A_HEIGHT, uint32_t A_WIDTH,
+              uint32_t B_WIDTH, uint32_t iter) {
+        int rc;
+
+        for(int i = 0; i <= iter; ++i){
+                rc = template_kernel_matrix_multiply_transpose_nomul_unroll<8>(A, B, C, A_HEIGHT, A_WIDTH, B_WIDTH);
+        }
+
+        return rc;
+}
+
+/*
+ * This is a smarter implementation of matrix multiplication that
+ * multiplies the two matricies A and B and stores the result in C. In
+ * this implementation, B is transposed into BT prior to calling the
+ * kernel and all multiplies used to index the A, B and C arrays are
+ * transformed into additions (nomul). The row-column dot product is
+ * unrolled by a factor of F (a template parameter)
+ *
+ *
+ * This implementation differs from above because it avoids an
+ * 0-ing/initialization hazard. The Manycore FPU pipeline is a 3-cycle
+ * pipeline without hazard forwarding. When registers are initialized,
+ * GCC assumes that moves are 1 cycle latency (or have fowarding) so
+ * it does an fcvt from x0 to the first floating-point destination
+ * register, and then copies that destination register into the other registers.
+ *
+ * This causes a ton of avoidable dependency stalls. So we use some inline assembly.
+ */
+template <unsigned int F, typename TA, typename TB>
+int __attribute__ ((noinline)) template_kernel_matrix_multiply_transpose_nomul_unroll_init (
+                      TA *A, TB *BT, float *C,
+                      uint32_t A_HEIGHT, uint32_t A_WIDTH,
+                      uint32_t B_WIDTH) {
+        uint32_t incr = A_WIDTH * (F-1);
+        for (uint32_t y = 0, ayoff = 0, boff = 0, coff = 0; y < A_HEIGHT; y ++, ayoff += A_WIDTH) {
+                boff = 0;
+                for (uint32_t x = 0; x < B_WIDTH; x += F) {
+                        
+                        uint32_t bofff = 0;
+                        float sum[F];
+#pragma GCC unroll 8
+                        for (uint32_t f = 0; f < F; ++f){
+                                asm volatile ("fmv.s.x %0,zero\n\t" : "=f" (sum[f]));
+                        }
+
+                        for (uint32_t aoff = ayoff; aoff < ayoff + A_WIDTH; aoff++, ++boff) {
+                                bofff = boff;
+#pragma GCC unroll 8
+                                for (uint32_t f = 0; f < F; ++f, bofff += A_WIDTH){
+                                        sum[f] += A[aoff] * BT[bofff];
+                                }
+                        }
+
+#pragma GCC unroll 8
+                        for (uint32_t f = 0; f < F; f++){
+                                C[coff + f] = sum[f];
+                        }
+                        boff += incr;
+                        coff += F;
+                }
+        }
+        return 0;
+}
+
+extern "C" int  __attribute__ ((noinline)) kernel_matrix_multiply_transpose_nomul_unroll_init(
+              float *A, float *B, float *C,
+              uint32_t A_HEIGHT, uint32_t A_WIDTH,
+              uint32_t B_WIDTH, uint32_t iter) {
+        int rc;
+
+        for(int i = 0; i <= iter; ++i){
+                rc = template_kernel_matrix_multiply_transpose_nomul_unroll_init<8>(A, B, C, A_HEIGHT, A_WIDTH, B_WIDTH);
+        }
+
+        return rc;
+}
+
+
+/**
+ * The only difference here, is that the data is copied into DMEM before computation.
+ */
+extern "C" int  __attribute__ ((noinline)) kernel_matrix_multiply_transpose_nomul_unroll_init_local(
+              float *A, float *B, float *C,
+              uint32_t A_HEIGHT, uint32_t A_WIDTH,
+              uint32_t B_WIDTH, uint32_t iter) {
+        int rc;
+
+        // These arrays are resident in DMEM
+        float A_local[A_HEIGHT * A_WIDTH];
+        float B_local[A_WIDTH * B_WIDTH];
+        float C_local[A_HEIGHT * B_WIDTH];
+
+        memcpy (A_local, A, sizeof(A[0])*A_HEIGHT*A_WIDTH);
+        memcpy (B_local, B, sizeof(B[0])*A_WIDTH*B_WIDTH);
+
+        bsg_cuda_print_stat_kernel_start();
+        for(int i = 0; i <= iter; ++i){
+                rc = template_kernel_matrix_multiply_transpose_nomul_unroll_init<8>(A_local, B_local, C_local, A_HEIGHT, A_WIDTH, B_WIDTH);
+        }
+        bsg_cuda_print_stat_kernel_end();
+
+        memcpy (C, C_local, sizeof(C[0])*A_HEIGHT*B_WIDTH);
+
+        return rc;
+}

--- a/examples/cuda/test_shared_mem/Makefile
+++ b/examples/cuda/test_shared_mem/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = shared_mem
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_shared_mem/kernel.cpp
+++ b/examples/cuda/test_shared_mem/kernel.cpp
@@ -1,0 +1,32 @@
+// This kernel declares a tile group shared memory, stores and loads to test the barrier and shared memory functionality 
+// The test uses two different stripes for storing to shared mem and loading from it. 
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+extern "C" __attribute__ ((noinline))
+int kernel_shared_mem (int *A, int N) {
+
+
+	bsg_tile_group_shared_mem (int, sh_arr, N); 
+
+	for (int iter_x = __bsg_id; iter_x < N; iter_x += bsg_tiles_X * bsg_tiles_Y) {
+		bsg_tile_group_shared_store(int, sh_arr, iter_x, iter_x);
+	}
+
+
+	barrier.sync();
+
+	int block_size = N / (bsg_tiles_X * bsg_tiles_Y);
+	for (int iter_x = __bsg_id * block_size; iter_x < (__bsg_id + 1) * block_size; iter_x ++) { 
+		bsg_tile_group_shared_load(int, sh_arr, iter_x, A[iter_x]);
+	}
+
+	barrier.sync();
+
+
+  return 0;
+}

--- a/examples/cuda/test_shared_mem_load_store/Makefile
+++ b/examples/cuda/test_shared_mem_load_store/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = shared_mem_load_store
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_shared_mem_load_store/kernel.cpp
+++ b/examples/cuda/test_shared_mem_load_store/kernel.cpp
@@ -1,0 +1,41 @@
+/*!
+ * This kernel loads input array into shared memory and stores it back to another location to test the functionality of tile group shared memory and barrier
+ */
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+extern "C" __attribute__ ((noinline))
+int kernel_shared_mem_load_store(int *A_in, int *A_out, int M, int N, int block_size_y, int block_size_x) {
+
+	
+	// declare tile-group shared memory
+	bsg_tile_group_shared_mem (int, sh_A, (block_size_y * block_size_x));
+
+	int start_y = __bsg_tile_group_id_y * block_size_y;
+	int start_x = __bsg_tile_group_id_x * block_size_x;
+
+	// Load a (block_size_y * block_size_x) block of A_in into tile_group_shared memory 
+	for (int iter_y = __bsg_y; iter_y < block_size_y; iter_y += bsg_tiles_Y) { 
+		for (int iter_x = __bsg_x; iter_x < block_size_x; iter_x += bsg_tiles_X) { 
+			bsg_tile_group_shared_store (int, sh_A, (iter_y * block_size_x + iter_x) , A_in[(start_y + iter_y) * N + (start_x + iter_x)]);
+		}
+	}
+
+	barrier.sync();
+
+	// Store the same (block_size_y * block_size_x) block of shared memory into A_out
+	for (int iter_y = __bsg_y; iter_y < block_size_y; iter_y += bsg_tiles_Y) { 
+		for (int iter_x = __bsg_x; iter_x < block_size_x; iter_x += bsg_tiles_X) { 
+			bsg_tile_group_shared_load (int, sh_A, (iter_y * block_size_x + iter_x) , A_out[(start_y + iter_y) * N + (start_x + iter_x)]);
+		}
+	}
+
+	barrier.sync();
+
+	return 0;
+}

--- a/examples/cuda/test_softmax/Makefile
+++ b/examples/cuda/test_softmax/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = softmax
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,21 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
+
+# Remove nostdlib
+kernel.riscv: RISCV_LDFLAGS := $(filter-out -nostdlib,$(RISCV_LDFLAGS))
 
 ###############################################################################
 # Execution flow
@@ -124,11 +123,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_softmax/kernel.cpp
+++ b/examples/cuda/test_softmax/kernel.cpp
@@ -1,0 +1,148 @@
+
+/*!
+ * This kernel computes Softmax of a matrix A with dimensions MxN and stores the result in B:
+ * Softmax(A) = exp(A) / sum(exp(A)) (with division done element-wise).
+ * The algorithm works in 3 phases:
+ *      1) Compute max by doing a reduction in a shared array, store in variable m
+ *      2) Compute sum(exp(A - m)), and store exp(A - m) into B while computing sum
+ *      3) Divide every element of B by sum
+ */
+
+/*
+  Description of reduction:
+  If we want to compute an aggregator function F (in this kernel, sum and max), we do it as follows:
+        1) Allocate a shared array with one element for each tile in tilegroup
+        2) Each tile aggregates elements belonging to it
+        3) Tiles in the top row aggregate their column
+        4) Tile at (0, 0) aggregates row 0
+        At the end, element (0, 0) stores the result of the aggregate.
+ */
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "math.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+#define max(x, y) (((x) > (y)) ? (x) : (y))
+
+float compute_max(const float *A, float *agg, int M, int N, int block_size_y, int block_size_x)
+{
+        int start_y = __bsg_tile_group_id_y * block_size_y;
+        int start_x = __bsg_tile_group_id_x * block_size_x;
+        int end_y = start_y + block_size_y;
+        int end_x = start_x + block_size_x;
+
+        float partial_max = -INFINITY;
+        // Compute max(B) for each element belonging to a tile in the tilegroup
+        for(int y = start_y + __bsg_y; y < end_y; y += bsg_tiles_Y)
+        {
+                for(int x = start_x + __bsg_x; x < end_x; x += bsg_tiles_X)
+                {
+                        partial_max = max(A[y * N + x], partial_max);
+                }
+        }
+        bsg_tile_group_shared_store(float, agg, __bsg_y * bsg_tiles_X + __bsg_x, partial_max);
+	barrier.sync(); 
+
+        // Compute max of the columns of the aggregator matrix
+        if(__bsg_y == 0)
+        {
+                for(int y = 1; y < bsg_tiles_Y; y++)
+                {
+                        float other;
+                        bsg_tile_group_shared_load(float, agg, y * bsg_tiles_X + __bsg_x, other);
+                        partial_max = max(partial_max, other);
+                }
+                bsg_tile_group_shared_store(float, agg, __bsg_x, partial_max);
+        }
+	barrier.sync();
+        // Compute max of row 0 of the row matrix
+        if(__bsg_y == 0 && __bsg_x == 0)
+        {
+                for(int x = 1; x < bsg_tiles_X; x++)
+                {
+                        float other;
+                        bsg_tile_group_shared_load(float, agg, x, other);
+                        partial_max = max(partial_max, other);
+                }
+                bsg_tile_group_shared_store(float, agg, 0, partial_max);
+        }
+        float result;
+	barrier.sync();
+        bsg_tile_group_shared_load(float, agg, 0, result);
+	barrier.sync();
+        return result;
+}
+
+extern "C" __attribute__((noinline))
+int kernel_softmax(const float *A, float *B, int M, int N, int block_size_y, int block_size_x)
+{
+        // Array for aggregations
+        bsg_tile_group_shared_mem(float, agg, bsg_tiles_X * bsg_tiles_Y);
+        float m = compute_max(A, agg, M, N, block_size_y, block_size_x);
+        int start_y = __bsg_tile_group_id_y * block_size_y;
+        int start_x = __bsg_tile_group_id_x * block_size_x;
+        int end_y = start_y + block_size_y;
+        int end_x = start_x + block_size_x;
+
+        // Compute B = exp(A - m)
+        for(int y = start_y + __bsg_y; y < end_y; y += bsg_tiles_Y)
+        {
+                for(int x = start_x + __bsg_x; x < end_x; x += bsg_tiles_X)
+                {
+                        B[y * N + x] = expf(A[y * N + x] - m);
+                }
+        }
+	barrier.sync();
+
+        float partial_sum = 0;
+        // Compute sum(B) for each element belonging to a tile in the tilegroup
+        for(int y = start_y + __bsg_y; y < end_y; y += bsg_tiles_Y)
+        {
+                for(int x = start_x + __bsg_x; x < end_x; x += bsg_tiles_X)
+                {
+                        partial_sum += B[y * N + x];
+                }
+        }
+        bsg_tile_group_shared_store(float, agg, __bsg_y * bsg_tiles_X + __bsg_x, partial_sum);
+	barrier.sync();
+
+        // Compute sum of the columns of the sum matrix
+        if(__bsg_y == 0)
+        {
+                for(int y = 1; y < bsg_tiles_Y; y++)
+                {
+                        float other;
+                        bsg_tile_group_shared_load(float, agg, y * bsg_tiles_X + __bsg_x, other);
+                        partial_sum += other;
+                }
+                bsg_tile_group_shared_store(float, agg, __bsg_x, partial_sum);
+        }
+	barrier.sync();
+        // Compute sum of row 0 of the row matrix
+        if(__bsg_y == 0 && __bsg_x == 0)
+        {
+                for(int x = 1; x < bsg_tiles_X; x++)
+                {
+                        float other;
+                        bsg_tile_group_shared_load(float, agg, x, other);
+                        partial_sum += other;
+                }
+                bsg_tile_group_shared_store(float, agg, 0, partial_sum);
+        }
+	barrier.sync();
+        float sum;
+        bsg_tile_group_shared_load(float, agg, 0, sum);
+        for(int y = start_y + __bsg_y; y < end_y; y += bsg_tiles_Y)
+        {
+                for(int x = start_x + __bsg_x; x < end_x; x += bsg_tiles_X)
+                {
+                        B[y * N + x] /= sum;
+                }
+        }
+	barrier.sync();
+        return 0;
+}

--- a/examples/cuda/test_stack_load/Makefile
+++ b/examples/cuda/test_stack_load/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = stack_load
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_stack_load/kernel.cpp
+++ b/examples/cuda/test_stack_load/kernel.cpp
@@ -1,0 +1,19 @@
+//This kernel tests to make sure elements loaded through stack are correct
+// Kernel takes in 15 elemtns and write the sum into an array -- each tile writes to one element of array
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+extern "C" __attribute__ ((noinline))
+int kernel_stack_load(int *sum, int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, int a11, int a12, int a13, int a14, int a15) {
+
+	int res = a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 + a10 + a11 + a12 + a13 + a14 + a15;
+	sum[__bsg_id] = res;
+        barrier.sync();
+	return 0;
+}

--- a/examples/cuda/test_tracer/Makefile
+++ b/examples/cuda/test_tracer/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = tracer
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_tracer/kernel.cpp
+++ b/examples/cuda/test_tracer/kernel.cpp
@@ -1,0 +1,21 @@
+//This kernel adds 2 vectors 
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+extern "C" __attribute__ ((noinline))
+int kernel_vec_add_parallel(int *A, int *B, int *C, int N, int block_size_x) {
+
+	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
+	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
+		C[start_x + iter_x] = A[start_x + iter_x] + B[start_x + iter_x];
+	}
+
+	barrier.sync();
+
+	return 0;
+}

--- a/examples/cuda/test_vec_add/Makefile
+++ b/examples/cuda/test_vec_add/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = vec_add
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS +=
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_vec_add/kernel.cpp
+++ b/examples/cuda/test_vec_add/kernel.cpp
@@ -1,0 +1,21 @@
+//This kernel adds 2 vectors 
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+extern "C" __attribute__ ((noinline))
+int kernel_vec_add(int *A, int *B, int *C, int N, int block_size_x) {
+
+	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
+	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
+		C[start_x + iter_x] = A[start_x + iter_x] + B[start_x + iter_x];
+	}
+
+	barrier.sync();
+
+	return 0;
+}

--- a/examples/cuda/test_vec_add_dma/Makefile
+++ b/examples/cuda/test_vec_add_dma/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = vec_add_dma
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS +=
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_vec_add_dma/kernel.cpp
+++ b/examples/cuda/test_vec_add_dma/kernel.cpp
@@ -1,0 +1,21 @@
+//This kernel adds 2 vectors 
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+extern "C" __attribute__ ((noinline))
+int kernel_vec_add(int *A, int *B, int *C, int N, int block_size_x) {
+
+	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
+	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
+		C[start_x + iter_x] = A[start_x + iter_x] + B[start_x + iter_x];
+	}
+
+	barrier.sync();
+
+  return 0;
+}

--- a/examples/cuda/test_vec_add_parallel/Makefile
+++ b/examples/cuda/test_vec_add_parallel/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = vec_add_parallel

--- a/examples/cuda/test_vec_add_parallel_multi_grid/Makefile
+++ b/examples/cuda/test_vec_add_parallel_multi_grid/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = vec_add_parallel_multi_grid
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_vec_add_parallel_multi_grid/kernel.cpp
+++ b/examples/cuda/test_vec_add_parallel_multi_grid/kernel.cpp
@@ -1,0 +1,21 @@
+//This kernel adds 2 vectors 
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+extern "C" __attribute__ ((noinline))
+int kernel_vec_add_parallel_multi_grid(int *A, int *B, int *C, int N, int block_size_x) {
+
+	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
+	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
+		C[start_x + iter_x] = A[start_x + iter_x] + B[start_x + iter_x];
+	}
+
+	barrier.sync();
+
+	return 0;
+}

--- a/examples/cuda/test_vec_add_serial_multi_grid/Makefile
+++ b/examples/cuda/test_vec_add_serial_multi_grid/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = vec_add_serial_multi_grid
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_vec_add_serial_multi_grid/kernel.cpp
+++ b/examples/cuda/test_vec_add_serial_multi_grid/kernel.cpp
@@ -1,0 +1,21 @@
+//This kernel adds 2 vectors 
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+extern "C" __attribute__ ((noinline))
+int kernel_vec_add_serial_multi_grid(int *A, int *B, int *C, int N, int block_size_x) {
+
+	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
+	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
+		C[start_x + iter_x] = A[start_x + iter_x] + B[start_x + iter_x];
+	}
+
+	barrier.sync();
+
+  return 0;
+}

--- a/examples/cuda/test_vec_add_shared_mem/Makefile
+++ b/examples/cuda/test_vec_add_shared_mem/Makefile
@@ -43,7 +43,6 @@ REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
 
 include $(REPLICANT_PATH)/environment.mk
 SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
-CUDALITE_SRC_PATH = $(SPMD_SRC_PATH)/bsg_cuda_lite_runtime
 
 # KERNEL_NAME is the name of the CUDA-Lite Kernel
 KERNEL_NAME = vec_add_shared_mem
@@ -70,7 +69,7 @@ include $(EXAMPLES_PATH)/compilation.mk
 # Host code link flags and flow
 ###############################################################################
 
-LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl 
+LDFLAGS += -L$(BSG_PLATFORM_PATH) -lbsgmc_cuda_legacy_pod_repl
 
 # link.mk defines rules for linking of the final execution binary.
 include $(EXAMPLES_PATH)/link.mk
@@ -81,21 +80,18 @@ include $(EXAMPLES_PATH)/link.mk
 
 # BSG_MANYCORE_KERNELS is a list of manycore executables that should
 # be built before executing.
-BSG_MANYCORE_KERNELS = $(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv
+BSG_MANYCORE_KERNELS = kernel.riscv
 
 # Tile Group Dimensions
 TILE_GROUP_DIM_X = 2
 TILE_GROUP_DIM_Y = 2
 
-$(CUDALITE_SRC_PATH)/$(KERNEL_NAME)/main.riscv: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	bsg_tiles_X=$(TILE_GROUP_DIM_X) \
-	bsg_tiles_Y=$(TILE_GROUP_DIM_Y) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean main.riscv
+kernel.riscv: kernel.rvo
+
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
 
 ###############################################################################
 # Execution flow
@@ -124,11 +120,5 @@ regression: exec.log
 .PHONY: clean
 
 clean:
-	BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
-	BASEJUMP_STL_DIR=$(BASEJUMP_STL_DIR) \
-	BSG_IP_CORES_DIR=$(BASEJUMP_STL_DIR) \
-	IGNORE_CADENV=1 \
-	BSG_MACHINE_PATH=$(BSG_MACHINE_PATH) \
-	$(MAKE) -j1 -C $(CUDALITE_SRC_PATH)/$(KERNEL_NAME) clean
-
+	rm -rf *.ld
 

--- a/examples/cuda/test_vec_add_shared_mem/kernel.cpp
+++ b/examples/cuda/test_vec_add_shared_mem/kernel.cpp
@@ -1,0 +1,57 @@
+//This kernel adds 2 vectors using shared memory, each tile group loads a block into shared memory and performs addition, and stores it back. 
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+extern "C" __attribute__ ((noinline))
+int kernel_vec_add_shared_mem(int *A, int *B, int *C, int N, int block_size_x) {
+
+	// Declare tile-group shared memroy with specific size
+	bsg_tile_group_shared_mem (int, sh_A, block_size_x);
+	bsg_tile_group_shared_mem (int, sh_B, block_size_x); 
+	bsg_tile_group_shared_mem (int, sh_C, block_size_x); 
+
+
+	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
+
+
+	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
+		// Store from DRAM into tile-group shared memory
+		bsg_tile_group_shared_store(int, sh_A, iter_x, A[start_x + iter_x]); 
+		bsg_tile_group_shared_store(int, sh_B, iter_x, B[start_x + iter_x]); 
+		
+	}
+
+
+	barrier.sync();
+
+
+	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
+		int lc_A, lc_B;
+		// Load from tile group shared memory and store into local variable lc_A & lc_B
+		bsg_tile_group_shared_load (int, sh_A, iter_x, lc_A);
+		bsg_tile_group_shared_load (int, sh_B, iter_x, lc_B);
+
+		// Store the sum of lc_A and lc_B into tile-group shared memroy sh_C
+		bsg_tile_group_shared_store (int, sh_C, iter_x, (lc_A + lc_B));
+	}
+
+
+	barrier.sync();	
+
+
+	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
+		// Load from tile-group shared memory lc_C and store the result into DRAM 
+		bsg_tile_group_shared_load(int, sh_C, iter_x, C[start_x + iter_x]); 
+	}
+
+
+	barrier.sync();
+
+
+  return 0;
+}


### PR DESCRIPTION
It seems like we're going to have an increase in users. Having the sources in two different repositories is a pain for demonstrating examples. We've known this for a long time.

This simply moves the existing CUDA source from manycore to here.