### PR TITLE
Call top->finish() during program exit

### DIFF
--- a/libraries/platforms/bigblade-verilator/bsg_manycore_platform.cpp
+++ b/libraries/platforms/bigblade-verilator/bsg_manycore_platform.cpp
@@ -162,6 +162,15 @@ void hb_mc_platform_cleanup(hb_mc_manycore_t *mc)
         auto key = active_ids.find(platform->id);
         active_ids.erase(key);
 
+        delete platform->top;
+        auto m = machines.find(platform->id);
+        if(m != machines.end()){
+                machines.erase(m);
+        } else {
+                // Whoa, this would be an error condition but there's really no good way to handle it.
+                // Possible causes: Cleanup before init, memory corruption
+                manycore_pr_err(mc, "Machine ID %d was not found during platform cleanup. Memory corruption?", platform->id);
+        }
         platform->id = 0;
 
         // Ideally, we would clean up each platform in

--- a/libraries/platforms/bigblade-verilator/bsg_manycore_simulator.cpp
+++ b/libraries/platforms/bigblade-verilator/bsg_manycore_simulator.cpp
@@ -69,6 +69,7 @@ std::string SimulationWrapper::getRoot(){
 
 SimulationWrapper::~SimulationWrapper(){
         Vreplicant_tb_top *top = reinterpret_cast<Vreplicant_tb_top *>(this->top);
+        top->final();
         delete top;
         this->top = nullptr;
 }


### PR DESCRIPTION
There were two issues:

1. top->finish() wasn't being called to trigger final blocks in Verilator
2. the deconstructor for SimulationWrapper wasn't being called, so the call site for adding top->finish() wasn't reached