### PR TITLE
DIV2 clock period

### DIFF
--- a/machines/pod_X1Y1_ruche_X16Y8_hbm_one_pseudo_channel/Makefile.machine.include
+++ b/machines/pod_X1Y1_ruche_X16Y8_hbm_one_pseudo_channel/Makefile.machine.include
@@ -44,7 +44,7 @@ BSG_MACHINE_PODS_X                    = 1
 BSG_MACHINE_PODS_Y                    = 1
 
 # 1.5 GHz Core Clock
-BSG_MACHINE_PODS_CYCLE_TIME_PS         = 667
+BSG_MACHINE_PODS_CYCLE_TIME_PS         = 666
 
 # Heterogeneous tile composition. Must be a 1-d array equal to the
 # number of tiles, or shorthand (default:0)


### PR DESCRIPTION
WARNING: EXTREMELY CONTROVERSIAL CHANGE.

bsg_nonsynth_dpi_clock_gen requires even clock period to function properly. Let's be nice to verilator