### PR TITLE
Add print statement to stat snoop module

### DIFF
--- a/libraries/platforms/aws-vcs/hardware/bsg_print_stat_snoop.v
+++ b/libraries/platforms/aws-vcs/hardware/bsg_print_stat_snoop.v
@@ -1,24 +1,30 @@
 module bsg_print_stat_snoop
   import bsg_manycore_pkg::*;
   import bsg_manycore_addr_pkg::*;
+  import bsg_manycore_profile_pkg::*;
   #(parameter data_width_p="inv"
     , parameter addr_width_p="inv"
     , parameter x_cord_width_p="inv"
     , parameter y_cord_width_p="inv"
+    , parameter enable_vcore_profiling_p="inv"
 
     , parameter link_sif_width_lp=
       `bsg_manycore_link_sif_width(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p)
-    
   )
   (
+   input clk_i
+   , input reset_i
     // manycore side
-    input [link_sif_width_lp-1:0] loader_link_sif_in_i
-    , input [link_sif_width_lp-1:0] loader_link_sif_out_i
+   , input [link_sif_width_lp-1:0] loader_link_sif_in_i
+   , input [link_sif_width_lp-1:0] loader_link_sif_out_i
+   , input [31:0] global_ctr_i
 
-    // snoop signals
-    , output logic print_stat_v_o
-    , output logic [data_width_p-1:0] print_stat_tag_o
+   // snoop signals
+   , output logic print_stat_v_o
+   , output logic [data_width_p-1:0] print_stat_tag_o
   );
+
+  localparam logfile_lp = "simple_stats.csv";
 
   `declare_bsg_manycore_link_sif_s(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p);
 
@@ -38,9 +44,27 @@ module bsg_print_stat_snoop
     & (fwd_pkt.addr == (bsg_print_stat_epa_gp >> 2)) & loader_link_sif_out.fwd.ready_and_rev;
   assign print_stat_tag_o = fwd_pkt.payload.data;
 
-  
+  bsg_manycore_vanilla_core_stat_tag_s print_stat_tag;
+  assign print_stat_tag = print_stat_tag_o;
 
+  // Only print simple stats if profiling is disabled, so that exec
+  // and profile runs don't stomp on eachother.
+  if(enable_vcore_profiling_p == 0) begin
+    integer fd;
 
-  
+    always @(negedge reset_i) begin
+       fd = $fopen(logfile_lp, "w");
+       $fwrite(fd, "time, cycle, y, x, tag\n");
+       $fclose(fd);
+    end
 
+    always @(negedge clk_i)  begin
+      // stat printing
+      if (~reset_i & print_stat_v_o) begin
+        fd = $fopen(logfile_lp, "a");
+        $fwrite(fd, "%0d,%0d,%0d,%0d,%0x\n", $time, global_ctr_i, fwd_pkt.src_y_cord, fwd_pkt.src_x_cord, print_stat_tag);
+        $fclose(fd);
+      end
+    end
+  end
 endmodule

--- a/libraries/platforms/bigblade-vcs/hardware/dpi_top.sv
+++ b/libraries/platforms/bigblade-vcs/hardware/dpi_top.sv
@@ -342,10 +342,15 @@ module replicant_tb_top
        ,.addr_width_p(bsg_machine_noc_epa_width_gp)
        ,.x_cord_width_p(bsg_machine_noc_coord_x_width_gp)
        ,.y_cord_width_p(bsg_machine_noc_coord_y_width_gp)
+       ,.enable_vcore_profiling_p(bsg_machine_enable_vcore_profiling_lp)
        )
    print_stat_snoop
      (
-      .loader_link_sif_in_i(host_link_sif_lo) // output from manycore
+      .clk_i(core_clk)
+      ,.reset_i(core_reset)
+      ,.global_ctr_i(global_ctr)
+
+      ,.loader_link_sif_in_i(host_link_sif_lo) // output from manycore
       ,.loader_link_sif_out_i(host_link_sif_li) // output from host
 
       ,.print_stat_v_o(print_stat_v)


### PR DESCRIPTION
One of the more annoying aspects of the profiler is that it runs _very_ slowly compared to non-profiled mode, and even pc-histogram mode. This is a problem, because the profiler is also a good way to get accurate execution timing for HB kernels.

The intent of this PR is to create a "simple stats" file that gets generated during non-profiling runs. All it does is emit the arrival times and tags of statistics packets that arrive at the host interface. This can be parsed (separate script, still in development) to provide accurate timing information of kernels, without the performance hit of the profiler.

My rough estimate is that this is 4-5x faster for long-running kernels. This will be especially helpful for obtaining results in minimal time.

* Use to get profiling-like timing information when running in exec mode
* generates simple_stats.csv