### PR TITLE
Adding object disassembly code

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -26,3 +26,5 @@ ucli.key
 dramsim3.txt
 *.a
 *.d
+*.dis
+*.diso

--- a/examples/cuda/riscv.mk
+++ b/examples/cuda/riscv.mk
@@ -400,7 +400,10 @@ RISCV_LDFLAGS += -Wl,--no-check-sections
 	$(RISCV_LD) -T $(RISCV_LINK_SCRIPT) $(filter %.rvo,$^) $(RISCV_LDFLAGS) -o $@
 
 %.dis: %.riscv
-	$(RISCV_OBJDUMP) -dS $<
+	$(RISCV_OBJDUMP) -dS $< > $@
+
+%.diso: %.rvo
+	$(RISCV_OBJDUMP) -dS $< > $@
 
 stats: profile.log
 	PYTHONPATH=$(BSG_MANYCORE_DIR)/software/py/ python3 -m vanilla_parser --only stats_parser --stats vanilla_stats.csv --vcache-stats vcache_stats.csv --tile-group --tile


### PR DESCRIPTION
Changing disassembly target to dump to a file, which seems to be more useful. Also adding a target for dumping raw object files, which is useful for if you're terrible with debugging compilation flows like me