### PR TITLE
Adding atomic packet example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ machines/*/obj_dir/
 xcelium.d/
 blood_detailed.png
 key_detailed.png
+*.vpd

--- a/examples/library/test_manycore_atomic_packets/Makefile
+++ b/examples/library/test_manycore_atomic_packets/Makefile
@@ -1,0 +1,105 @@
+# Copyright (c) 2021, University of Washington All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This Makefile compiles, links, and executes examples Run `make help`
+# to see the available targets for the selected platform.
+
+################################################################################
+# environment.mk verifies the build environment and sets the following
+# makefile variables:
+#
+# LIBRAIRES_PATH: The path to the libraries directory
+# HARDWARE_PATH: The path to the hardware directory
+# EXAMPLES_PATH: The path to the examples directory
+# BASEJUMP_STL_DIR: Path to a clone of BaseJump STL
+# BSG_MANYCORE_DIR: Path to a clone of BSG Manycore
+###############################################################################
+
+REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
+
+include $(REPLICANT_PATH)/environment.mk
+
+
+###############################################################################
+# Host code compilation flags and flow
+###############################################################################
+
+# TEST_SOURCES is a list of source files that need to be compiled
+TEST_SOURCES = main.c
+
+DEFINES += -D_XOPEN_SOURCE=500 -D_BSD_SOURCE -D_DEFAULT_SOURCE
+CDEFINES += 
+CXXDEFINES += 
+
+FLAGS     = -g -Wall -Wno-unused-function -Wno-unused-variable
+CFLAGS   += -std=c99 $(FLAGS)
+CXXFLAGS += -std=c++11 $(FLAGS)
+
+# compilation.mk defines rules for compilation of C/C++
+include $(EXAMPLES_PATH)/compilation.mk
+
+# Specify any header file dependencies
+main.o: INCLUDES += -I$(EXAMPLES_PATH)/library
+
+###############################################################################
+# Host code link flags and flow
+###############################################################################
+
+LDFLAGS += 
+
+# link.mk defines rules for linking of the final execution binary.
+include $(EXAMPLES_PATH)/link.mk
+
+###############################################################################
+# Execution flow
+#
+# C_ARGS: Use this to pass arguments that you want to appear in argv
+#
+# SIM_ARGS: Use this to pass arguments to the simulator
+###############################################################################
+C_ARGS ?=
+
+SIM_ARGS ?=
+
+# Include platform-specific execution rules
+include $(EXAMPLES_PATH)/execution.mk
+
+###############################################################################
+# Regression Flow
+###############################################################################
+
+regression: exec.log
+	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
+
+.DEFAULT_GOAL := help
+
+.PHONY: clean
+
+clean:
+
+
+

--- a/examples/library/test_manycore_atomic_packets/Makefile
+++ b/examples/library/test_manycore_atomic_packets/Makefile
@@ -62,9 +62,6 @@ CXXFLAGS += -std=c++11 $(FLAGS)
 # compilation.mk defines rules for compilation of C/C++
 include $(EXAMPLES_PATH)/compilation.mk
 
-# Specify any header file dependencies
-main.o: INCLUDES += -I$(EXAMPLES_PATH)/library
-
 ###############################################################################
 # Host code link flags and flow
 ###############################################################################

--- a/examples/library/test_manycore_atomic_packets/main.c
+++ b/examples/library/test_manycore_atomic_packets/main.c
@@ -118,7 +118,7 @@ int test_manycore_atomic_packets(int argc, char *argv[]) {
 
         bsg_pr_test_info("Sending %d auto amo packets\n", n);
         for (int i = 0; i < n; i++) {
-            BSG_CUDA_CALL(hb_mc_manycore_amoadd(mc, &npa, 1, &data));
+            BSG_CUDA_CALL(hb_mc_manycore_amoadd32(mc, &npa, 1, &data));
             bsg_pr_test_info("Data received: %d\n", data);
             if (data != n+i) {
                 bsg_pr_test_err("Data mismatch: %d != %d", data, n+i);

--- a/examples/library/test_manycore_atomic_packets/main.c
+++ b/examples/library/test_manycore_atomic_packets/main.c
@@ -1,0 +1,136 @@
+// Copyright (c) 2019, University of Washington All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// 
+// Redistributions of source code must retain the above copyright notice, this list
+// of conditions and the following disclaimer.
+// 
+// Redistributions in binary form must reproduce the above copyright notice, this
+// list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+// 
+// Neither the name of the copyright holder nor the names of its contributors may
+// be used to endorse or promote products derived from this software without
+// specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <inttypes.h>
+#include <libgen.h>
+#include <bsg_manycore.h>
+#include <bsg_manycore_cuda.h>
+#include <bsg_manycore_tile.h>
+#include <bsg_manycore_printing.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <time.h>
+#include <stdlib.h>
+#include <bsg_manycore_loader.h>
+#include <bsg_manycore_errno.h>
+#include <bsg_manycore_printing.h>
+
+#include <bsg_manycore_regression.h>
+
+
+int test_manycore_atomic_packets(int argc, char *argv[]) {
+        hb_mc_manycore_t manycore = {0}, *mc = &manycore;
+        int err;
+
+        /*****************************/
+        /* Initializing the manycore */
+        /*****************************/
+        BSG_CUDA_CALL(hb_mc_manycore_init(mc, "test_manycore_atomic_packets", 0));
+
+        /*************************/
+        /* Seeding the test data */
+        /*************************/
+        srand(time(0));
+       
+        hb_mc_coordinate_t host = hb_mc_manycore_get_host_coordinate(mc);
+        uint32_t host_x = hb_mc_coordinate_get_x(host);
+        uint32_t host_y = hb_mc_coordinate_get_y(host);
+
+        const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
+        hb_mc_coordinate_t vcore_base = hb_mc_config_get_origin_vcore(cfg);
+        uint8_t target_x = vcore_base.x;
+        uint8_t target_y = vcore_base.y - 1;
+        uint32_t addr = 0xbee0;
+        uint32_t data  = 1;
+        uint32_t load_id = 31;
+
+        hb_mc_request_packet_t req;
+        hb_mc_response_packet_t res;
+
+        /**************************/
+        /* Test packet formatting */
+        /**************************/
+        bsg_pr_test_info("Manually formatting packet\n");
+        hb_mc_request_packet_set_x_dst(&req, target_x);
+        hb_mc_request_packet_set_y_dst(&req, target_y);
+        hb_mc_request_packet_set_x_src(&req, host_x);
+        hb_mc_request_packet_set_y_src(&req, host_y);
+        hb_mc_request_packet_set_data (&req, data);
+        hb_mc_request_packet_set_load_id(&req, load_id);
+        hb_mc_request_packet_set_op   (&req, HB_MC_PACKET_OP_REMOTE_AMOADD);
+        hb_mc_request_packet_set_addr (&req, addr);
+
+        /****************************************************/
+        /* Test transmitting a manually formatted AMO packet */
+        /****************************************************/
+        uint32_t n = 8;
+        bsg_pr_test_info("Sending %d manual amo packets to tile (%d, %d)\n", n, target_x, target_y);
+        for (int i = 0; i < n; i++) {
+            BSG_CUDA_CALL(hb_mc_manycore_packet_tx(mc, (hb_mc_packet_t*)&req, HB_MC_MMIO_FIFO_TO_DEVICE, -1));
+        }
+        
+        bsg_pr_test_info(BSG_GREEN("Succesfully Wrote packet to FIFO (%s)") "\n",
+                         hb_mc_direction_to_string(HB_MC_MMIO_FIFO_TO_DEVICE));
+
+        bsg_pr_test_info("Reading %d amo responses from tile\n", n);
+        for (int i = 0; i < n; i++) {
+            BSG_CUDA_CALL(hb_mc_manycore_packet_rx(mc, (hb_mc_packet_t*)&res, HB_MC_MMIO_FIFO_TO_DEVICE, -1));
+            data = hb_mc_response_packet_get_data(&res);
+            bsg_pr_test_info("Data received: %d\n", data);
+            if (data != i) {
+                bsg_pr_test_err("Data mismatch: %d != %d", data, i);
+                return HB_MC_FAIL;
+            }
+        }
+
+        /****************************************************/
+        /* Test transmitting an automatically formatted AMO packet */
+        /****************************************************/
+        hb_mc_coordinate_t dram_coord;
+        dram_coord.x = target_x;
+        dram_coord.y = target_y;
+        hb_mc_npa_t npa = hb_mc_npa(dram_coord, addr<<2);
+
+        bsg_pr_test_info("Sending %d auto amo packets\n", n);
+        for (int i = 0; i < n; i++) {
+            BSG_CUDA_CALL(hb_mc_manycore_amoadd(mc, &npa, 1, &data));
+            bsg_pr_test_info("Data received: %d\n", data);
+            if (data != n+i) {
+                bsg_pr_test_err("Data mismatch: %d != %d", data, n+i);
+                return HB_MC_FAIL;
+            }
+        }
+
+        /*******/
+        /* END */
+        /*******/
+        BSG_CUDA_CALL(hb_mc_manycore_exit(mc));
+        return HB_MC_SUCCESS;   
+}
+
+declare_program_main(basename(__FILE__), test_manycore_atomic_packets);

--- a/libraries/bsg_manycore.cpp
+++ b/libraries/bsg_manycore.cpp
@@ -1310,6 +1310,10 @@ int hb_mc_manycore_amoadd(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa, const ui
         if (err != HB_MC_SUCCESS)
                 return err;
 
+        // AMO are only supported on DRAM regions
+        if (hb_mc_config_is_dram(hb_mc_manycore_get_config(mc), hb_mc_npa_get_xy(npa)) == 0)
+            return HB_MC_INVALID;
+
         hb_mc_request_packet_set_op(&rqst.request, HB_MC_PACKET_OP_REMOTE_AMOADD);
         hb_mc_request_packet_set_data(&rqst.request, v);
 

--- a/libraries/bsg_manycore.cpp
+++ b/libraries/bsg_manycore.cpp
@@ -1332,7 +1332,8 @@ int hb_mc_manycore_amoadd(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa, const ui
         if (err != HB_MC_SUCCESS)
                 return err;
 
-        *vpo = load_data;
+        if (vpo != NULL)
+                *vpo = load_data;
         return HB_MC_SUCCESS;
 }
 

--- a/libraries/bsg_manycore.cpp
+++ b/libraries/bsg_manycore.cpp
@@ -1292,7 +1292,7 @@ int hb_mc_manycore_write32(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa, uint32_
  * @param[out] vpo    The previous value at the NPA
  * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
  */
-int hb_mc_manycore_amoadd(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa, const uint32_t v, uint32_t *vpo)
+int hb_mc_manycore_amoadd32(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa, const uint32_t v, uint32_t *vpo)
 {
         int err;
         hb_mc_packet_t rqst;

--- a/libraries/bsg_manycore.h
+++ b/libraries/bsg_manycore.h
@@ -254,6 +254,17 @@ extern "C" {
         int hb_mc_manycore_write32(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa, uint32_t v);
 
         /**
+         * Do a 32-bit amoadd to manycore hardware at a given NPA (must be a DRAM address)
+         * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+         * @param[in]  npa    A valid hb_mc_npa_t aligned to a four byte boundary
+         * @param[in]  v      A word value to be added to the NPA
+         * @param[out] vpo    Pointer to the previous value at the NPA
+         * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+         */
+        __attribute__((warn_unused_result))
+        int hb_mc_manycore_amoadd(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa, uint32_t vpi, uint32_t *vpo);
+
+        /**
          * Set memory to a given value starting at a given NPA
          * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
          * @param[in]  npa    A valid hb_mc_npa_t

--- a/libraries/bsg_manycore.h
+++ b/libraries/bsg_manycore.h
@@ -262,7 +262,7 @@ extern "C" {
          * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
          */
         __attribute__((warn_unused_result))
-        int hb_mc_manycore_amoadd(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa, uint32_t vpi, uint32_t *vpo);
+        int hb_mc_manycore_amoadd32(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa, uint32_t vpi, uint32_t *vpo);
 
         /**
          * Set memory to a given value starting at a given NPA


### PR DESCRIPTION
This PR adds the ability to do AMO.ADDs from host to manycore DRAM space. This can be useful for synchronization between host and device

Question: Is there a low-overhead function to detect that an NPA is a DRAM address? Would like to add the check to amoadd because I believe sending an AMOADD to a vcore tile could cause a hang. 