### PR TITLE
Adding mulh inference test

### DIFF
--- a/examples/cuda/test_mulh_inference/Makefile
+++ b/examples/cuda/test_mulh_inference/Makefile
@@ -1,0 +1,126 @@
+# Copyright (c) 2021, University of Washington All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This Makefile compiles, links, and executes examples Run `make help`
+# to see the available targets for the selected platform.
+
+################################################################################
+# environment.mk verifies the build environment and sets the following
+# makefile variables:
+#
+# LIBRAIRES_PATH: The path to the libraries directory
+# HARDWARE_PATH: The path to the hardware directory
+# EXAMPLES_PATH: The path to the examples directory
+# BASEJUMP_STL_DIR: Path to a clone of BaseJump STL
+# BSG_MANYCORE_DIR: Path to a clone of BSG Manycore
+###############################################################################
+
+REPLICANT_PATH:=$(shell git rev-parse --show-toplevel)
+
+include $(REPLICANT_PATH)/environment.mk
+SPMD_SRC_PATH = $(BSG_MANYCORE_DIR)/software/spmd
+
+# KERNEL_NAME is the name of the CUDA-Lite Kernel
+KERNEL_NAME = vanilla_core_error
+
+###############################################################################
+# Host code compilation flags and flow
+###############################################################################
+
+# TEST_SOURCES is a list of source files that need to be compiled
+TEST_SOURCES = main.c
+
+DEFINES += -D_XOPEN_SOURCE=500 -D_BSD_SOURCE -D_DEFAULT_SOURCE
+CDEFINES += 
+CXXDEFINES += 
+
+FLAGS     = -g -Wall -Wno-unused-function -Wno-unused-variable
+CFLAGS   += -std=c99 $(FLAGS)
+CXXFLAGS += -std=c++11 $(FLAGS)
+
+# compilation.mk defines rules for compilation of C/C++
+include $(EXAMPLES_PATH)/compilation.mk
+
+###############################################################################
+# Host code link flags and flow
+###############################################################################
+
+LDFLAGS +=
+
+# link.mk defines rules for linking of the final execution binary.
+include $(EXAMPLES_PATH)/link.mk
+
+###############################################################################
+# Device code compilation flow
+###############################################################################
+
+# BSG_MANYCORE_KERNELS is a list of manycore executables that should
+# be built before executing.
+BSG_MANYCORE_KERNELS = kernel.riscv
+
+# CLANG does not deschedule MULH* instructions, so this test will only pass with GCC
+kernel.rvo: RISCV_CXX = $(RISCV_GXX)
+#kernel.rvo: RISCV_CXX = $(RISCV_CLANGXX)
+kernel.riscv: kernel.rvo
+
+# Tile Group Dimensions
+TILE_GROUP_DIM_X = 3
+TILE_GROUP_DIM_Y = 1
+RISCV_DEFINES += -Dbsg_tiles_X=$(TILE_GROUP_DIM_X)
+RISCV_DEFINES += -Dbsg_tiles_Y=$(TILE_GROUP_DIM_Y)
+
+include $(EXAMPLES_PATH)/cuda/riscv.mk
+
+###############################################################################
+# Execution flow
+#
+# C_ARGS: Use this to pass arguments that you want to appear in argv
+#         For SPMD tests C arguments are: <Path to RISC-V Binary> <Test Name>
+#
+# SIM_ARGS: Use this to pass arguments to the simulator
+###############################################################################
+C_ARGS ?= $(BSG_MANYCORE_KERNELS) $(KERNEL_NAME)
+
+SIM_ARGS ?=
+
+# Include platform-specific execution rules
+include $(EXAMPLES_PATH)/execution.mk
+
+###############################################################################
+# Regression Flow
+###############################################################################
+
+regression: exec.log
+	@grep "BSG REGRESSION TEST .*PASSED.*" $< > /dev/null
+
+.DEFAULT_GOAL := help
+
+.PHONY: clean
+
+clean:
+
+

--- a/examples/cuda/test_mulh_inference/kernel.cpp
+++ b/examples/cuda/test_mulh_inference/kernel.cpp
@@ -1,0 +1,18 @@
+#include <bsg_manycore.h>
+#include <bsg_set_tile_x_y.h>
+#include <bsg_tile_group_barrier.hpp>
+
+#define LUT_LENGTH 16
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+bsg_tile_group_shared_mem(uint16_t, LUT, LUT_LENGTH);
+
+extern "C" __attribute__ ((noinline))
+int kernel_mulh_inference() {
+    for(uint8_t i=0; i<LUT_LENGTH; i++) { 
+        bsg_tile_group_shared_store(uint16, LUT, i, i);
+    }
+    barrier.sync();
+
+    return 0;
+}

--- a/examples/cuda/test_mulh_inference/main.c
+++ b/examples/cuda/test_mulh_inference/main.c
@@ -1,0 +1,102 @@
+// Copyright (c) 2019, University of Washington All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// 
+// Redistributions of source code must retain the above copyright notice, this list
+// of conditions and the following disclaimer.
+// 
+// Redistributions in binary form must reproduce the above copyright notice, this
+// list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+// 
+// Neither the name of the copyright holder nor the names of its contributors may
+// be used to endorse or promote products derived from this software without
+// specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <bsg_manycore_tile.h>
+#include <bsg_manycore_errno.h>
+#include <bsg_manycore_tile.h>
+#include <bsg_manycore_loader.h>
+#include <bsg_manycore_cuda.h>
+#include <stdlib.h>
+#include <time.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <stdio.h>
+#include <bsg_manycore_regression.h>
+
+#define ALLOC_NAME "default_allocator"
+#define N 15
+
+int kernel_mulh_inference (int argc, char **argv) {
+        int rc;
+        char *bin_path, *test_name;
+        struct arguments_path args = {NULL, NULL};
+
+        argp_parse (&argp_path, argc, argv, 0, 0, &args);
+        bin_path = args.path;
+        test_name = args.name;
+
+        bsg_pr_test_info("Running the CUDA Vector Addition Kernel on a grid of 2x2 tile groups.\n\n");
+
+        srand(time); 
+
+        /*********************/
+        /* Initialize device */
+        /*********************/
+        hb_mc_device_t device;
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, 0));
+
+        hb_mc_pod_id_t pod;
+        hb_mc_device_foreach_pod_id(&device, pod)
+        {
+                /**********************************************************************/
+                /* Define path to binary.                                             */
+                /* Initialize device, load binary and unfreeze tiles.                 */
+                /**********************************************************************/
+                bsg_pr_test_info("Loading program for %s onto pod %d\n",
+                                 test_name, pod);
+
+                BSG_CUDA_CALL(hb_mc_device_set_default_pod(&device, pod));
+                BSG_CUDA_CALL(hb_mc_device_program_init(&device, bin_path, ALLOC_NAME, 0));
+
+                hb_mc_dimension_t tg_dim = { .x = 3, .y = 1 };
+                hb_mc_dimension_t grid_dim = { .x = 1, .y = 1 };
+
+                eva_t argv; // Empty argument (none needed for this error)
+                int cuda_argv[1] = {argv};
+                /*****************************************************************************************************************
+                 * Enquque grid of tile groups, pass in grid and tile group dimensions, kernel name, number and list of input arguments
+                 ******************************************************************************************************************/
+                BSG_CUDA_CALL(hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_mulh_inference", 1, cuda_argv));
+
+                /*****************************************************************************************************************
+                 * Launch and execute all tile groups on device and wait for all to finish.
+                 ******************************************************************************************************************/
+                BSG_CUDA_CALL(hb_mc_device_tile_groups_execute(&device));
+
+                /*****************************************************************************************************************
+                 * Freeze the tiles and memory manager cleanup.
+                 ******************************************************************************************************************/
+                BSG_CUDA_CALL(hb_mc_device_program_finish(&device));
+        }
+
+        BSG_CUDA_CALL(hb_mc_device_finish(&device));
+
+        return HB_MC_SUCCESS;
+}
+
+declare_program_main("Test MULH Inference", kernel_mulh_inference);


### PR DESCRIPTION
This test causes GCC to infer MULH instructions, resulting in: TOP.replicant_tb_top.testbench.DUT.py[0].podrow.px[0].pod.mc_y[0].mc_x[0].mc.y[0].x[0].tile.proc.h.z.vcore: Unsupported instruction: 03f5b4b3"

With updated GCC from: https://github.com/bespoke-silicon-group/riscv-gcc/pull/3