### PR TITLE
Update .gitmodules to use HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "examples/cuda/aes/tiny-AES-c"]
 	path = examples/apps/aes/tiny-AES-c
-	url = git@github.com:bespoke-silicon-group/tiny-AES-c.git
+	url = https://github.com/bespoke-silicon-group/tiny-AES-c.git
         update = none


### PR DESCRIPTION
This allows users without GitHub accounts to clone