### PR TITLE
Fix c++ initializer in GCC version >=11

### DIFF
--- a/libraries/bsg_manycore_request_packet_id.h
+++ b/libraries/bsg_manycore_request_packet_id.h
@@ -95,18 +95,33 @@ extern "C" {
         } hb_mc_request_packet_id_t;
 
         /* this is used to match an address under a mask */
+#ifdef __cplusplus
+#define RQST_ID_ADDR_UNDER_MASK(addr, mask)     \
+        {addr, mask}
+
+#define RQST_ID_ADDR(addr)                      \
+        {addr, UINT32_MAX}
+#else
 #define RQST_ID_ADDR_UNDER_MASK(addr, mask)     \
         {.a_value = addr, .a_mask = mask}
 
 #define RQST_ID_ADDR(addr)                      \
         {.a_value = addr, .a_mask = UINT32_MAX}
+#endif
 
 
         /* these are used to match INCLUSIVE ranges */
+#ifdef __cplusplus
+#define RQST_ID_RANGE_X(lo, hi)                 \
+        {lo, hi}
+#define RQST_ID_RANGE_Y(lo, hi)                 \
+        {lo, hi}
+#else
 #define RQST_ID_RANGE_X(lo, hi)                 \
         {.x_lo = lo, .x_hi = hi}
 #define RQST_ID_RANGE_Y(lo, hi)                 \
         {.y_lo = lo, .y_hi = hi}
+#endif
 
         /* these are used to match any coordinate */
 #define RQST_ID_ANY_X                           \

--- a/libraries/bsg_manycore_request_packet_id.h
+++ b/libraries/bsg_manycore_request_packet_id.h
@@ -137,7 +137,7 @@ extern "C" {
 
 #ifdef __cplusplus
 #define RQST_ID(x, y, addr)                     \
-        request_packet_id(addr, x, y, 1)
+        request_packet_id({addr, x, y, 1})
 #else
 #define RQST_ID(x, y, addr)                                             \
         { .init = 1, .id_x_src = x, .id_y_src = y, .id_addr = addr }

--- a/libraries/bsg_manycore_request_packet_id.h
+++ b/libraries/bsg_manycore_request_packet_id.h
@@ -137,7 +137,7 @@ extern "C" {
 
 #ifdef __cplusplus
 #define RQST_ID(x, y, addr)                     \
-        request_packet_id({addr, x, y, 1})
+        request_packet_id{addr, x, y, 1}
 #else
 #define RQST_ID(x, y, addr)                                             \
         { .init = 1, .id_x_src = x, .id_y_src = y, .id_addr = addr }


### PR DESCRIPTION
Currently when compiling the libraries with GCC version >=11, it shows the following error:

```
bsg_bladerunner/bsg_replicant/libraries/bsg_manycore_request_packet_id.h:125:40: error: no matching function for call to ?request_packet_id::request_packet_id(<brace-enclosed initializer list>, <brace-enclosed initializer list>, <brace-enclosed initializer list>, int)?
  125 |         request_packet_id(addr, x, y, 1)
```

I tested the fix (c++11 uniform initialization) on CentOS 7, Rocky 8 and 9, with GCC 4, 7, 8, 9 ,10, 11, 12 and 13, fine with c++11, 14, 17 and 20

This fix would be helpful when porting our flow onto Rocky 9 in the future