### PR TITLE
Device ID Support

### DIFF
--- a/examples/apps/aes/opt-single/main.cpp
+++ b/examples/apps/aes/opt-single/main.cpp
@@ -60,7 +60,7 @@ int kernel_aes (int argc, char **argv) {
         /* Initialize device */
         /*********************/
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID));
 
         hb_mc_pod_id_t pod;
         hb_mc_device_foreach_pod_id(&device, pod)

--- a/examples/apps/aes/opt-single/main.cpp
+++ b/examples/apps/aes/opt-single/main.cpp
@@ -60,7 +60,7 @@ int kernel_aes (int argc, char **argv) {
         /* Initialize device */
         /*********************/
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, 0));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
 
         hb_mc_pod_id_t pod;
         hb_mc_device_foreach_pod_id(&device, pod)

--- a/examples/apps/blackscholes/opt-single/main.cpp
+++ b/examples/apps/blackscholes/opt-single/main.cpp
@@ -131,7 +131,7 @@ int kernel_bs (int argc, char **argv) {
         /* Initialize device */
         /*********************/
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID));
 
         hb_mc_pod_id_t pod;
         hb_mc_device_foreach_pod_id(&device, pod)

--- a/examples/apps/blackscholes/opt-single/main.cpp
+++ b/examples/apps/blackscholes/opt-single/main.cpp
@@ -131,7 +131,7 @@ int kernel_bs (int argc, char **argv) {
         /* Initialize device */
         /*********************/
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, 0));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
 
         hb_mc_pod_id_t pod;
         hb_mc_device_foreach_pod_id(&device, pod)

--- a/examples/apps/blackscholes/unopt-single/main.cpp
+++ b/examples/apps/blackscholes/unopt-single/main.cpp
@@ -144,7 +144,7 @@ int kernel_bs (int argc, char **argv) {
         /* Initialize device */
         /*********************/
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, 0));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
 
 
         hb_mc_pod_id_t pod;

--- a/examples/apps/blackscholes/unopt-single/main.cpp
+++ b/examples/apps/blackscholes/unopt-single/main.cpp
@@ -144,7 +144,7 @@ int kernel_bs (int argc, char **argv) {
         /* Initialize device */
         /*********************/
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID));
 
 
         hb_mc_pod_id_t pod;

--- a/examples/compilation.mk
+++ b/examples/compilation.mk
@@ -36,9 +36,9 @@ RED=\033[0;31m
 NC=\033[0m
 
 # Default id is 0x0, user specified id should be digits-only integer
-DEVICE_ID  ?= 0x0
-CXXDEFINES += -DDEVICE_ID=$(DEVICE_ID)
-CDEFINES   += -DDEVICE_ID=$(DEVICE_ID)
+HB_MC_DEVICE_ID  ?= 0x0
+CXXDEFINES += -DHB_MC_DEVICE_ID=$(HB_MC_DEVICE_ID)
+CDEFINES   += -DHB_MC_DEVICE_ID=$(HB_MC_DEVICE_ID)
 
 # Include platform-specific compilation rules
 include $(BSG_PLATFORM_PATH)/compilation.mk

--- a/examples/compilation.mk
+++ b/examples/compilation.mk
@@ -35,6 +35,11 @@ ORANGE=\033[0;33m
 RED=\033[0;31m
 NC=\033[0m
 
+# Default id is 0x0, user specified id should be digits-only integer
+DEVICE_ID  ?= 0x0
+CXXDEFINES += -DDEVICE_ID=$(DEVICE_ID)
+CDEFINES   += -DDEVICE_ID=$(DEVICE_ID)
+
 # Include platform-specific compilation rules
 include $(BSG_PLATFORM_PATH)/compilation.mk
 

--- a/examples/cuda/group_stride/main.cpp
+++ b/examples/cuda/group_stride/main.cpp
@@ -54,7 +54,7 @@ int kernel_group_stride (int argc, char **argv) {
         // Initialize device, load binary and unfreeze tiles.
         //
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, 0));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
         BSG_CUDA_CALL(hb_mc_device_program_init(&device, bin_path, ALLOC_NAME, 0));
 
         //************************************************************

--- a/examples/cuda/group_stride/main.cpp
+++ b/examples/cuda/group_stride/main.cpp
@@ -54,7 +54,7 @@ int kernel_group_stride (int argc, char **argv) {
         // Initialize device, load binary and unfreeze tiles.
         //
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID));
         BSG_CUDA_CALL(hb_mc_device_program_init(&device, bin_path, ALLOC_NAME, 0));
 
         //************************************************************

--- a/examples/cuda/hw_barrier/main.cpp
+++ b/examples/cuda/hw_barrier/main.cpp
@@ -61,7 +61,7 @@ int barrier_test_main(int argc, char *argv[])
     }
 
     // initialize
-    BSG_CUDA_CALL(hb_mc_device_init(dev, "cuda hw barrier", DEVICE_ID));
+    BSG_CUDA_CALL(hb_mc_device_init(dev, "cuda hw barrier", HB_MC_DEVICE_ID));
     BSG_CUDA_CALL(hb_mc_device_program_init(dev, rvp, "baralloc", 0));
 
     // enque job and execute

--- a/examples/cuda/hw_barrier/main.cpp
+++ b/examples/cuda/hw_barrier/main.cpp
@@ -61,7 +61,7 @@ int barrier_test_main(int argc, char *argv[])
     }
 
     // initialize
-    BSG_CUDA_CALL(hb_mc_device_init(dev, "cuda hw barrier", 0));
+    BSG_CUDA_CALL(hb_mc_device_init(dev, "cuda hw barrier", DEVICE_ID));
     BSG_CUDA_CALL(hb_mc_device_program_init(dev, rvp, "baralloc", 0));
 
     // enque job and execute

--- a/examples/cuda/latency/main.c
+++ b/examples/cuda/latency/main.c
@@ -61,7 +61,7 @@ int kernel_latency (int argc, char **argv) {
         /* Initialize device */
         /*********************/
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, 0));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
 
 
         hb_mc_pod_id_t pod;

--- a/examples/cuda/latency/main.c
+++ b/examples/cuda/latency/main.c
@@ -61,7 +61,7 @@ int kernel_latency (int argc, char **argv) {
         /* Initialize device */
         /*********************/
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID));
 
 
         hb_mc_pod_id_t pod;

--- a/examples/cuda/sgemm_data_parallel/main.cpp
+++ b/examples/cuda/sgemm_data_parallel/main.cpp
@@ -87,7 +87,7 @@ int kernel_matrix_mul (int argc, char **argv) {
         // Initialize device, load binary and unfreeze tiles.
         //
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) {
                 bsg_pr_err("Failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/sgemm_data_parallel/main.cpp
+++ b/examples/cuda/sgemm_data_parallel/main.cpp
@@ -87,7 +87,7 @@ int kernel_matrix_mul (int argc, char **argv) {
         // Initialize device, load binary and unfreeze tiles.
         //
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) {
                 bsg_pr_err("Failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/sgemm_group_cooperative/main.cpp
+++ b/examples/cuda/sgemm_group_cooperative/main.cpp
@@ -87,7 +87,7 @@ int kernel_matrix_mul (int argc, char **argv) {
         // Initialize device, load binary and unfreeze tiles.
         //
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) {
                 bsg_pr_err("Failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/sgemm_group_cooperative/main.cpp
+++ b/examples/cuda/sgemm_group_cooperative/main.cpp
@@ -87,7 +87,7 @@ int kernel_matrix_mul (int argc, char **argv) {
         // Initialize device, load binary and unfreeze tiles.
         //
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) {
                 bsg_pr_err("Failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_binary_load_buffer/main.c
+++ b/examples/cuda/test_binary_load_buffer/main.c
@@ -76,7 +76,7 @@ int kernel_binary_load_buffer(int argc, char **argv) {
         /* a address to the binary.                                           */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_binary_load_buffer/main.c
+++ b/examples/cuda/test_binary_load_buffer/main.c
@@ -76,7 +76,7 @@ int kernel_binary_load_buffer(int argc, char **argv) {
         /* a address to the binary.                                           */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_conv1d/main.c
+++ b/examples/cuda/test_conv1d/main.c
@@ -103,7 +103,7 @@ int kernel_conv1d(int argc, char **argv)
         srand(42);
         int rc;
         hb_mc_device_t manycore, *mc = &manycore;
-        rc = hb_mc_device_init(mc, test_name, 0);
+        rc = hb_mc_device_init(mc, test_name, DEVICE_ID);
         if(rc != HB_MC_SUCCESS)
         {
                 bsg_pr_err("Failed to initialize device.\n");

--- a/examples/cuda/test_conv1d/main.c
+++ b/examples/cuda/test_conv1d/main.c
@@ -103,7 +103,7 @@ int kernel_conv1d(int argc, char **argv)
         srand(42);
         int rc;
         hb_mc_device_t manycore, *mc = &manycore;
-        rc = hb_mc_device_init(mc, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(mc, test_name, HB_MC_DEVICE_ID);
         if(rc != HB_MC_SUCCESS)
         {
                 bsg_pr_err("Failed to initialize device.\n");

--- a/examples/cuda/test_conv2d/main.c
+++ b/examples/cuda/test_conv2d/main.c
@@ -118,7 +118,7 @@ int kernel_conv2d(int argc, char **argv)
         srand(42);
         int rc;
         hb_mc_device_t manycore, *mc = &manycore;
-        rc = hb_mc_device_init(mc, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(mc, test_name, HB_MC_DEVICE_ID);
         if(rc != HB_MC_SUCCESS)
         {
                 bsg_pr_err("Failed to initialize device.\n");

--- a/examples/cuda/test_conv2d/main.c
+++ b/examples/cuda/test_conv2d/main.c
@@ -118,7 +118,7 @@ int kernel_conv2d(int argc, char **argv)
         srand(42);
         int rc;
         hb_mc_device_t manycore, *mc = &manycore;
-        rc = hb_mc_device_init(mc, test_name, 0);
+        rc = hb_mc_device_init(mc, test_name, DEVICE_ID);
         if(rc != HB_MC_SUCCESS)
         {
                 bsg_pr_err("Failed to initialize device.\n");

--- a/examples/cuda/test_credit_csr_tile/main.c
+++ b/examples/cuda/test_credit_csr_tile/main.c
@@ -71,7 +71,7 @@ int kernel_vec_add_parallel (int argc, char **argv) {
         /* Initialize device */
         /*********************/
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, 0));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
 
 
         hb_mc_pod_id_t pod;

--- a/examples/cuda/test_credit_csr_tile/main.c
+++ b/examples/cuda/test_credit_csr_tile/main.c
@@ -71,7 +71,7 @@ int kernel_vec_add_parallel (int argc, char **argv) {
         /* Initialize device */
         /*********************/
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID));
 
 
         hb_mc_pod_id_t pod;

--- a/examples/cuda/test_device_memcpy/main.c
+++ b/examples/cuda/test_device_memcpy/main.c
@@ -73,7 +73,7 @@ int kernel_device_memcpy (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_device_memcpy/main.c
+++ b/examples/cuda/test_device_memcpy/main.c
@@ -73,7 +73,7 @@ int kernel_device_memcpy (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_device_memset/main.c
+++ b/examples/cuda/test_device_memset/main.c
@@ -74,7 +74,7 @@ int kernel_device_memset (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_device_memset/main.c
+++ b/examples/cuda/test_device_memset/main.c
@@ -74,7 +74,7 @@ int kernel_device_memset (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_dma/main.c
+++ b/examples/cuda/test_dma/main.c
@@ -70,7 +70,7 @@ int test_dma (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init_custom_dimensions(&device, test_name, 0, tg_dim));
+        BSG_CUDA_CALL(hb_mc_device_init_custom_dimensions(&device, test_name, DEVICE_ID, tg_dim));
         const hb_mc_config_t *cfg = &device.mc->config;
         hb_mc_eva_t alignment
             = cfg->pod_shape.x

--- a/examples/cuda/test_dma/main.c
+++ b/examples/cuda/test_dma/main.c
@@ -70,7 +70,7 @@ int test_dma (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init_custom_dimensions(&device, test_name, DEVICE_ID, tg_dim));
+        BSG_CUDA_CALL(hb_mc_device_init_custom_dimensions(&device, test_name, HB_MC_DEVICE_ID, tg_dim));
         const hb_mc_config_t *cfg = &device.mc->config;
         hb_mc_eva_t alignment
             = cfg->pod_shape.x

--- a/examples/cuda/test_dma_valid_invalid/main.cpp
+++ b/examples/cuda/test_dma_valid_invalid/main.cpp
@@ -71,7 +71,7 @@ int test_dma (int argc, char **argv) {
 
         // Initialize device
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID));
 
         hb_mc_pod_id_t pod;
         hb_mc_device_foreach_pod_id(&device, pod)

--- a/examples/cuda/test_dma_valid_invalid/main.cpp
+++ b/examples/cuda/test_dma_valid_invalid/main.cpp
@@ -71,7 +71,7 @@ int test_dma (int argc, char **argv) {
 
         // Initialize device
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, 0));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
 
         hb_mc_pod_id_t pod;
         hb_mc_device_foreach_pod_id(&device, pod)

--- a/examples/cuda/test_dram_device_allocated/main.c
+++ b/examples/cuda/test_dram_device_allocated/main.c
@@ -73,7 +73,7 @@ int kernel_dram_device_allocated (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_dram_device_allocated/main.c
+++ b/examples/cuda/test_dram_device_allocated/main.c
@@ -73,7 +73,7 @@ int kernel_dram_device_allocated (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_dram_host_allocated/main.c
+++ b/examples/cuda/test_dram_host_allocated/main.c
@@ -74,7 +74,7 @@ int kernel_dram_host_allocated (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_dram_host_allocated/main.c
+++ b/examples/cuda/test_dram_host_allocated/main.c
@@ -74,7 +74,7 @@ int kernel_dram_host_allocated (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_dram_load_store/main.c
+++ b/examples/cuda/test_dram_load_store/main.c
@@ -69,7 +69,7 @@ int kernel_dram_load_store(int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_dram_load_store/main.c
+++ b/examples/cuda/test_dram_load_store/main.c
@@ -69,7 +69,7 @@ int kernel_dram_load_store(int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_empty_parallel/main.c
+++ b/examples/cuda/test_empty_parallel/main.c
@@ -62,7 +62,7 @@ int kernel_empty_parallel (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, 0));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
 
         hb_mc_pod_id_t pod;
         hb_mc_device_foreach_pod_id(&device, pod)

--- a/examples/cuda/test_empty_parallel/main.c
+++ b/examples/cuda/test_empty_parallel/main.c
@@ -62,7 +62,7 @@ int kernel_empty_parallel (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID));
 
         hb_mc_pod_id_t pod;
         hb_mc_device_foreach_pod_id(&device, pod)

--- a/examples/cuda/test_float_all_ops/main.c
+++ b/examples/cuda/test_float_all_ops/main.c
@@ -97,7 +97,7 @@ int kernel_float_all_ops (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_float_all_ops/main.c
+++ b/examples/cuda/test_float_all_ops/main.c
@@ -97,7 +97,7 @@ int kernel_float_all_ops (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_float_matrix_mul/main.c
+++ b/examples/cuda/test_float_matrix_mul/main.c
@@ -88,7 +88,7 @@ int kernel_float_matrix_mul (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_float_matrix_mul/main.c
+++ b/examples/cuda/test_float_matrix_mul/main.c
@@ -88,7 +88,7 @@ int kernel_float_matrix_mul (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_float_matrix_mul_shared_mem/main.c
+++ b/examples/cuda/test_float_matrix_mul_shared_mem/main.c
@@ -89,7 +89,7 @@ int kernel_float_matrix_mul_shared_mem (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_float_matrix_mul_shared_mem/main.c
+++ b/examples/cuda/test_float_matrix_mul_shared_mem/main.c
@@ -89,7 +89,7 @@ int kernel_float_matrix_mul_shared_mem (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_float_vec_add/main.c
+++ b/examples/cuda/test_float_vec_add/main.c
@@ -78,7 +78,7 @@ int kernel_float_vec_add (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_float_vec_add/main.c
+++ b/examples/cuda/test_float_vec_add/main.c
@@ -78,7 +78,7 @@ int kernel_float_vec_add (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_float_vec_add_shared_mem/main.c
+++ b/examples/cuda/test_float_vec_add_shared_mem/main.c
@@ -77,7 +77,7 @@ int kernel_float_vec_add_shared_mem (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_float_vec_add_shared_mem/main.c
+++ b/examples/cuda/test_float_vec_add_shared_mem/main.c
@@ -77,7 +77,7 @@ int kernel_float_vec_add_shared_mem (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_float_vec_div/main.c
+++ b/examples/cuda/test_float_vec_div/main.c
@@ -77,7 +77,7 @@ int kernel_float_vec_div (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_float_vec_div/main.c
+++ b/examples/cuda/test_float_vec_div/main.c
@@ -77,7 +77,7 @@ int kernel_float_vec_div (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_float_vec_exp/main.c
+++ b/examples/cuda/test_float_vec_exp/main.c
@@ -77,7 +77,7 @@ int kernel_float_vec_exp (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_float_vec_exp/main.c
+++ b/examples/cuda/test_float_vec_exp/main.c
@@ -77,7 +77,7 @@ int kernel_float_vec_exp (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_float_vec_log/main.c
+++ b/examples/cuda/test_float_vec_log/main.c
@@ -77,7 +77,7 @@ int kernel_float_vec_log (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_float_vec_log/main.c
+++ b/examples/cuda/test_float_vec_log/main.c
@@ -77,7 +77,7 @@ int kernel_float_vec_log (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_float_vec_mul/main.c
+++ b/examples/cuda/test_float_vec_mul/main.c
@@ -78,7 +78,7 @@ int kernel_float_vec_mul (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_float_vec_mul/main.c
+++ b/examples/cuda/test_float_vec_mul/main.c
@@ -78,7 +78,7 @@ int kernel_float_vec_mul (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_float_vec_sqrt/main.c
+++ b/examples/cuda/test_float_vec_sqrt/main.c
@@ -77,7 +77,7 @@ int kernel_float_vec_sqrt (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_float_vec_sqrt/main.c
+++ b/examples/cuda/test_float_vec_sqrt/main.c
@@ -77,7 +77,7 @@ int kernel_float_vec_sqrt (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_hammer_cache/main.cpp
+++ b/examples/cuda/test_hammer_cache/main.cpp
@@ -75,7 +75,7 @@ int test_loader (int argc, char **argv) {
 
         // init
         hb_mc_device_t device;
-        CUDA_CALL(hb_mc_device_init(&device, test_name, 0));
+        CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
         CUDA_CALL(hb_mc_device_program_init(&device, bin_path, ALLOC_NAME, 0));
 
         // config tg

--- a/examples/cuda/test_hammer_cache/main.cpp
+++ b/examples/cuda/test_hammer_cache/main.cpp
@@ -75,7 +75,7 @@ int test_loader (int argc, char **argv) {
 
         // init
         hb_mc_device_t device;
-        CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
+        CUDA_CALL(hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID));
         CUDA_CALL(hb_mc_device_program_init(&device, bin_path, ALLOC_NAME, 0));
 
         // config tg

--- a/examples/cuda/test_high_mem/main.c
+++ b/examples/cuda/test_high_mem/main.c
@@ -54,7 +54,7 @@ int kernel_vec_add (int argc, char **argv) {
         srand(time);
 
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID));
 
         int r = HB_MC_SUCCESS;
         hb_mc_pod_id_t pod;

--- a/examples/cuda/test_high_mem/main.c
+++ b/examples/cuda/test_high_mem/main.c
@@ -54,7 +54,7 @@ int kernel_vec_add (int argc, char **argv) {
         srand(time);
 
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, 0));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
 
         int r = HB_MC_SUCCESS;
         hb_mc_pod_id_t pod;

--- a/examples/cuda/test_host_memset/main.c
+++ b/examples/cuda/test_host_memset/main.c
@@ -65,7 +65,7 @@ int kernel_host_memset (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_host_memset/main.c
+++ b/examples/cuda/test_host_memset/main.c
@@ -65,7 +65,7 @@ int kernel_host_memset (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_loader/main.c
+++ b/examples/cuda/test_loader/main.c
@@ -59,7 +59,7 @@ int test_loader (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID));
 
         hb_mc_pod_id_t pod;
         hb_mc_device_foreach_pod_id(&device, pod)

--- a/examples/cuda/test_loader/main.c
+++ b/examples/cuda/test_loader/main.c
@@ -59,7 +59,7 @@ int test_loader (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, 0));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
 
         hb_mc_pod_id_t pod;
         hb_mc_device_foreach_pod_id(&device, pod)

--- a/examples/cuda/test_loader_pod/main.c
+++ b/examples/cuda/test_loader_pod/main.c
@@ -125,7 +125,7 @@ int test_loader (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, 0));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
 
         int r = test_loader_program_run(&args, &device);
 

--- a/examples/cuda/test_loader_pod/main.c
+++ b/examples/cuda/test_loader_pod/main.c
@@ -125,7 +125,7 @@ int test_loader (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID));
 
         int r = test_loader_program_run(&args, &device);
 

--- a/examples/cuda/test_log_softmax/main.c
+++ b/examples/cuda/test_log_softmax/main.c
@@ -70,7 +70,7 @@ int kernel_log_softmax(int argc, char **argv)
 
         int rc;
         hb_mc_device_t manycore, *mc = &manycore;
-        rc = hb_mc_device_init(mc, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(mc, test_name, HB_MC_DEVICE_ID);
         if(rc != HB_MC_SUCCESS)
         {
                 bsg_pr_err("Failed to initialize device.\n");

--- a/examples/cuda/test_log_softmax/main.c
+++ b/examples/cuda/test_log_softmax/main.c
@@ -70,7 +70,7 @@ int kernel_log_softmax(int argc, char **argv)
 
         int rc;
         hb_mc_device_t manycore, *mc = &manycore;
-        rc = hb_mc_device_init(mc, test_name, 0);
+        rc = hb_mc_device_init(mc, test_name, DEVICE_ID);
         if(rc != HB_MC_SUCCESS)
         {
                 bsg_pr_err("Failed to initialize device.\n");

--- a/examples/cuda/test_matrix_mul/main.c
+++ b/examples/cuda/test_matrix_mul/main.c
@@ -85,7 +85,7 @@ int kernel_matrix_mul (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_matrix_mul/main.c
+++ b/examples/cuda/test_matrix_mul/main.c
@@ -85,7 +85,7 @@ int kernel_matrix_mul (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_matrix_mul_shared_mem/main.c
+++ b/examples/cuda/test_matrix_mul_shared_mem/main.c
@@ -85,7 +85,7 @@ int kernel_matrix_mul_shared_mem (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_matrix_mul_shared_mem/main.c
+++ b/examples/cuda/test_matrix_mul_shared_mem/main.c
@@ -85,7 +85,7 @@ int kernel_matrix_mul_shared_mem (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_max_pool2d/main.c
+++ b/examples/cuda/test_max_pool2d/main.c
@@ -114,7 +114,7 @@ int kernel_max_pool2d(int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_max_pool2d/main.c
+++ b/examples/cuda/test_max_pool2d/main.c
@@ -114,7 +114,7 @@ int kernel_max_pool2d(int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles.                 */
         /**********************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_memory_leak/main.cpp
+++ b/examples/cuda/test_memory_leak/main.cpp
@@ -68,7 +68,7 @@ int kernel_memory_leak (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles. */
         hb_mc_dimension_t tg_dim = { .x = 2, .y = 2};
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init_custom_dimensions(&device, test_name, DEVICE_ID, tg_dim));
+        BSG_CUDA_CALL(hb_mc_device_init_custom_dimensions(&device, test_name, HB_MC_DEVICE_ID, tg_dim));
 
         BSG_CUDA_CALL(hb_mc_device_program_init(&device, bin_path, ALLOC_NAME, 0));
 

--- a/examples/cuda/test_memory_leak/main.cpp
+++ b/examples/cuda/test_memory_leak/main.cpp
@@ -68,7 +68,7 @@ int kernel_memory_leak (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles. */
         hb_mc_dimension_t tg_dim = { .x = 2, .y = 2};
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init_custom_dimensions(&device, test_name, 0, tg_dim));
+        BSG_CUDA_CALL(hb_mc_device_init_custom_dimensions(&device, test_name, DEVICE_ID, tg_dim));
 
         BSG_CUDA_CALL(hb_mc_device_program_init(&device, bin_path, ALLOC_NAME, 0));
 

--- a/examples/cuda/test_mulh_inference/main.c
+++ b/examples/cuda/test_mulh_inference/main.c
@@ -58,7 +58,7 @@ int kernel_mulh_inference (int argc, char **argv) {
         /* Initialize device */
         /*********************/
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, 0));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
 
         hb_mc_pod_id_t pod;
         hb_mc_device_foreach_pod_id(&device, pod)

--- a/examples/cuda/test_mulh_inference/main.c
+++ b/examples/cuda/test_mulh_inference/main.c
@@ -58,7 +58,7 @@ int kernel_mulh_inference (int argc, char **argv) {
         /* Initialize device */
         /*********************/
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID));
 
         hb_mc_pod_id_t pod;
         hb_mc_device_foreach_pod_id(&device, pod)

--- a/examples/cuda/test_multiple_binary_load/main.c
+++ b/examples/cuda/test_multiple_binary_load/main.c
@@ -63,7 +63,7 @@ int kernel_multiple_binary_load (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;
@@ -129,7 +129,7 @@ int kernel_multiple_binary_load (int argc, char **argv) {
         * Define path to binary.
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_multiple_binary_load/main.c
+++ b/examples/cuda/test_multiple_binary_load/main.c
@@ -63,7 +63,7 @@ int kernel_multiple_binary_load (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;
@@ -129,7 +129,7 @@ int kernel_multiple_binary_load (int argc, char **argv) {
         * Define path to binary.
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_profiler/main.cpp
+++ b/examples/cuda/test_profiler/main.cpp
@@ -271,7 +271,7 @@ int test_profiler (int argc, char **argv) {
 
         // Initialize device, load binary and unfreeze tiles.
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) {
                 bsg_pr_test_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_profiler/main.cpp
+++ b/examples/cuda/test_profiler/main.cpp
@@ -271,7 +271,7 @@ int test_profiler (int argc, char **argv) {
 
         // Initialize device, load binary and unfreeze tiles.
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) {
                 bsg_pr_test_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_saifgen/main.cpp
+++ b/examples/cuda/test_saifgen/main.cpp
@@ -47,7 +47,7 @@ int test_saifgen (int argc, char **argv) {
 
         // Initialize device, load binary and unfreeze tiles.
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID));
 
         // Initialize the device with a kernel file
         BSG_CUDA_CALL(hb_mc_device_program_init(&device, bin_path, "default_allocator", 0));

--- a/examples/cuda/test_saifgen/main.cpp
+++ b/examples/cuda/test_saifgen/main.cpp
@@ -47,7 +47,7 @@ int test_saifgen (int argc, char **argv) {
 
         // Initialize device, load binary and unfreeze tiles.
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, 0));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
 
         // Initialize the device with a kernel file
         BSG_CUDA_CALL(hb_mc_device_program_init(&device, bin_path, "default_allocator", 0));

--- a/examples/cuda/test_shared_mem/main.c
+++ b/examples/cuda/test_shared_mem/main.c
@@ -68,7 +68,7 @@ int kernel_shared_mem (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_shared_mem/main.c
+++ b/examples/cuda/test_shared_mem/main.c
@@ -68,7 +68,7 @@ int kernel_shared_mem (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_shared_mem_load_store/main.c
+++ b/examples/cuda/test_shared_mem_load_store/main.c
@@ -66,7 +66,7 @@ int kernel_shared_mem_load_store (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_shared_mem_load_store/main.c
+++ b/examples/cuda/test_shared_mem_load_store/main.c
@@ -66,7 +66,7 @@ int kernel_shared_mem_load_store (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_softmax/main.c
+++ b/examples/cuda/test_softmax/main.c
@@ -72,7 +72,7 @@ int kernel_softmax(int argc, char **argv)
         srand(time(0));
         int rc;
         hb_mc_device_t manycore, *mc = &manycore;
-        rc = hb_mc_device_init(mc, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(mc, test_name, HB_MC_DEVICE_ID);
         if(rc != HB_MC_SUCCESS)
         {
                 bsg_pr_err("Failed to initialize device.\n");

--- a/examples/cuda/test_softmax/main.c
+++ b/examples/cuda/test_softmax/main.c
@@ -72,7 +72,7 @@ int kernel_softmax(int argc, char **argv)
         srand(time(0));
         int rc;
         hb_mc_device_t manycore, *mc = &manycore;
-        rc = hb_mc_device_init(mc, test_name, 0);
+        rc = hb_mc_device_init(mc, test_name, DEVICE_ID);
         if(rc != HB_MC_SUCCESS)
         {
                 bsg_pr_err("Failed to initialize device.\n");

--- a/examples/cuda/test_stack_load/main.c
+++ b/examples/cuda/test_stack_load/main.c
@@ -66,7 +66,7 @@ int kernel_stack_load (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_stack_load/main.c
+++ b/examples/cuda/test_stack_load/main.c
@@ -66,7 +66,7 @@ int kernel_stack_load (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_tracer/main.cpp
+++ b/examples/cuda/test_tracer/main.cpp
@@ -73,7 +73,7 @@ int kernel_tracer (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ************************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_tracer/main.cpp
+++ b/examples/cuda/test_tracer/main.cpp
@@ -73,7 +73,7 @@ int kernel_tracer (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ************************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_vec_add/main.c
+++ b/examples/cuda/test_vec_add/main.c
@@ -73,7 +73,7 @@ int kernel_vec_add (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, 0));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
 
         hb_mc_pod_id_t pod;
         hb_mc_device_foreach_pod_id(&device, pod)

--- a/examples/cuda/test_vec_add/main.c
+++ b/examples/cuda/test_vec_add/main.c
@@ -73,7 +73,7 @@ int kernel_vec_add (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID));
 
         hb_mc_pod_id_t pod;
         hb_mc_device_foreach_pod_id(&device, pod)

--- a/examples/cuda/test_vec_add_dma/main.cpp
+++ b/examples/cuda/test_vec_add_dma/main.cpp
@@ -79,7 +79,7 @@ int kernel_vec_add (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles. */
         hb_mc_dimension_t tg_dim = { .x = 2, .y = 2};
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init_custom_dimensions(&device, test_name, 0, tg_dim));
+        BSG_CUDA_CALL(hb_mc_device_init_custom_dimensions(&device, test_name, DEVICE_ID, tg_dim));
 
         /* if DMA is not supported just return SUCCESS */
         if (!hb_mc_manycore_supports_dma_write(device.mc)

--- a/examples/cuda/test_vec_add_dma/main.cpp
+++ b/examples/cuda/test_vec_add_dma/main.cpp
@@ -79,7 +79,7 @@ int kernel_vec_add (int argc, char **argv) {
         /* Initialize device, load binary and unfreeze tiles. */
         hb_mc_dimension_t tg_dim = { .x = 2, .y = 2};
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init_custom_dimensions(&device, test_name, DEVICE_ID, tg_dim));
+        BSG_CUDA_CALL(hb_mc_device_init_custom_dimensions(&device, test_name, HB_MC_DEVICE_ID, tg_dim));
 
         /* if DMA is not supported just return SUCCESS */
         if (!hb_mc_manycore_supports_dma_write(device.mc)

--- a/examples/cuda/test_vec_add_parallel/main.c
+++ b/examples/cuda/test_vec_add_parallel/main.c
@@ -72,7 +72,7 @@ int kernel_vec_add_parallel (int argc, char **argv) {
         /* Initialize device */
         /*********************/
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID));
 
         hb_mc_pod_id_t pod;
         hb_mc_device_foreach_pod_id(&device, pod)

--- a/examples/cuda/test_vec_add_parallel/main.c
+++ b/examples/cuda/test_vec_add_parallel/main.c
@@ -72,7 +72,7 @@ int kernel_vec_add_parallel (int argc, char **argv) {
         /* Initialize device */
         /*********************/
         hb_mc_device_t device;
-        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, 0));
+        BSG_CUDA_CALL(hb_mc_device_init(&device, test_name, DEVICE_ID));
 
         hb_mc_pod_id_t pod;
         hb_mc_device_foreach_pod_id(&device, pod)

--- a/examples/cuda/test_vec_add_parallel_multi_grid/main.c
+++ b/examples/cuda/test_vec_add_parallel_multi_grid/main.c
@@ -74,7 +74,7 @@ int kernel_vec_add_parallel_multi_grid (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_vec_add_parallel_multi_grid/main.c
+++ b/examples/cuda/test_vec_add_parallel_multi_grid/main.c
@@ -74,7 +74,7 @@ int kernel_vec_add_parallel_multi_grid (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_vec_add_serial_multi_grid/main.c
+++ b/examples/cuda/test_vec_add_serial_multi_grid/main.c
@@ -74,7 +74,7 @@ int kernel_vec_add_serial_multi_grid (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_vec_add_serial_multi_grid/main.c
+++ b/examples/cuda/test_vec_add_serial_multi_grid/main.c
@@ -74,7 +74,7 @@ int kernel_vec_add_serial_multi_grid (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_vec_add_shared_mem/main.c
+++ b/examples/cuda/test_vec_add_shared_mem/main.c
@@ -73,7 +73,7 @@ int kernel_vec_add_shared_mem (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
+        rc = hb_mc_device_init(&device, test_name, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/cuda/test_vec_add_shared_mem/main.c
+++ b/examples/cuda/test_vec_add_shared_mem/main.c
@@ -73,7 +73,7 @@ int kernel_vec_add_shared_mem (int argc, char **argv) {
         * Initialize device, load binary and unfreeze tiles.
         ******************************************************************************************************************/
         hb_mc_device_t device;
-        rc = hb_mc_device_init(&device, test_name, 0);
+        rc = hb_mc_device_init(&device, test_name, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize device.\n");
                 return rc;

--- a/examples/library/test_dma/main.cpp
+++ b/examples/library/test_dma/main.cpp
@@ -50,7 +50,7 @@
 
 int test_dma (int argc, char **argv) {
     hb_mc_manycore_t mc = {};
-    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "test_dma", 0));
+    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "test_dma", DEVICE_ID));
 
     const hb_mc_config_t *cfg = hb_mc_manycore_get_config(&mc);
     // sweep from at least the cache line granularity

--- a/examples/library/test_dma/main.cpp
+++ b/examples/library/test_dma/main.cpp
@@ -50,7 +50,7 @@
 
 int test_dma (int argc, char **argv) {
     hb_mc_manycore_t mc = {};
-    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "test_dma", DEVICE_ID));
+    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "test_dma", HB_MC_DEVICE_ID));
 
     const hb_mc_config_t *cfg = hb_mc_manycore_get_config(&mc);
     // sweep from at least the cache line granularity

--- a/examples/library/test_get_cycle/main.cpp
+++ b/examples/library/test_get_cycle/main.cpp
@@ -47,7 +47,7 @@ int test_get_cycle (int argc, char **argv) {
                 return rc;
         }
 
-        rc = hb_mc_manycore_init(&mc, "manycore@test_get_cycle", DEVICE_ID);
+        rc = hb_mc_manycore_init(&mc, "manycore@test_get_cycle", HB_MC_DEVICE_ID);
         if(rc != HB_MC_SUCCESS){
                 bsg_pr_test_err("Failed to initialize manycore device: %s\n",
                                 hb_mc_strerror(rc));

--- a/examples/library/test_get_cycle/main.cpp
+++ b/examples/library/test_get_cycle/main.cpp
@@ -47,7 +47,7 @@ int test_get_cycle (int argc, char **argv) {
                 return rc;
         }
 
-        rc = hb_mc_manycore_init(&mc, "manycore@test_get_cycle", 0);
+        rc = hb_mc_manycore_init(&mc, "manycore@test_get_cycle", DEVICE_ID);
         if(rc != HB_MC_SUCCESS){
                 bsg_pr_test_err("Failed to initialize manycore device: %s\n",
                                 hb_mc_strerror(rc));

--- a/examples/library/test_manycore_alignment/main.c
+++ b/examples/library/test_manycore_alignment/main.c
@@ -52,7 +52,7 @@ int test_manycore_alignment(int argc, char *argv[]) {
 
         srand(time(0));
         
-        err = hb_mc_manycore_init(mc, TEST_NAME, 0);
+        err = hb_mc_manycore_init(mc, TEST_NAME, DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err("%s: failed to intialize manycore: %s\n",
                            __func__,

--- a/examples/library/test_manycore_alignment/main.c
+++ b/examples/library/test_manycore_alignment/main.c
@@ -52,7 +52,7 @@ int test_manycore_alignment(int argc, char *argv[]) {
 
         srand(time(0));
         
-        err = hb_mc_manycore_init(mc, TEST_NAME, DEVICE_ID);
+        err = hb_mc_manycore_init(mc, TEST_NAME, HB_MC_DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err("%s: failed to intialize manycore: %s\n",
                            __func__,

--- a/examples/library/test_manycore_atomic_packets/main.c
+++ b/examples/library/test_manycore_atomic_packets/main.c
@@ -50,7 +50,7 @@ int test_manycore_atomic_packets(int argc, char *argv[]) {
         /*****************************/
         /* Initializing the manycore */
         /*****************************/
-        BSG_CUDA_CALL(hb_mc_manycore_init(mc, "test_manycore_atomic_packets", DEVICE_ID));
+        BSG_CUDA_CALL(hb_mc_manycore_init(mc, "test_manycore_atomic_packets", HB_MC_DEVICE_ID));
 
         /*************************/
         /* Seeding the test data */

--- a/examples/library/test_manycore_atomic_packets/main.c
+++ b/examples/library/test_manycore_atomic_packets/main.c
@@ -50,7 +50,7 @@ int test_manycore_atomic_packets(int argc, char *argv[]) {
         /*****************************/
         /* Initializing the manycore */
         /*****************************/
-        BSG_CUDA_CALL(hb_mc_manycore_init(mc, "test_manycore_atomic_packets", 0));
+        BSG_CUDA_CALL(hb_mc_manycore_init(mc, "test_manycore_atomic_packets", DEVICE_ID));
 
         /*************************/
         /* Seeding the test data */

--- a/examples/library/test_manycore_compile/main.c
+++ b/examples/library/test_manycore_compile/main.c
@@ -50,7 +50,7 @@ int test_manycore_compile(int argc, char *argv[])
 {
         int rc;
         hb_mc_manycore_t manycore;
-        rc = hb_mc_manycore_init(&manycore, "manycore@test_manycore_compile", DEVICE_ID);
+        rc = hb_mc_manycore_init(&manycore, "manycore@test_manycore_compile", HB_MC_DEVICE_ID);
         if(rc != HB_MC_SUCCESS){
                 bsg_pr_test_err("Failed to initialize manycore device!\n");
                 return HB_MC_FAIL;

--- a/examples/library/test_manycore_compile/main.c
+++ b/examples/library/test_manycore_compile/main.c
@@ -50,7 +50,7 @@ int test_manycore_compile(int argc, char *argv[])
 {
         int rc;
         hb_mc_manycore_t manycore;
-        rc = hb_mc_manycore_init(&manycore, "manycore@test_manycore_compile", 0);
+        rc = hb_mc_manycore_init(&manycore, "manycore@test_manycore_compile", DEVICE_ID);
         if(rc != HB_MC_SUCCESS){
                 bsg_pr_test_err("Failed to initialize manycore device!\n");
                 return HB_MC_FAIL;

--- a/examples/library/test_manycore_credits/main.c
+++ b/examples/library/test_manycore_credits/main.c
@@ -49,7 +49,7 @@ int test_manycore_credits(int argc, char *argv[]) {
 
         srand(time(0));
         
-        rc = hb_mc_manycore_init(mc, TEST_NAME, 0);
+        rc = hb_mc_manycore_init(mc, TEST_NAME, DEVICE_ID);
         if (rc != HB_MC_SUCCESS) {
                 bsg_pr_err("%s: failed to intialize manycore: %s\n",
                            __func__,

--- a/examples/library/test_manycore_credits/main.c
+++ b/examples/library/test_manycore_credits/main.c
@@ -49,7 +49,7 @@ int test_manycore_credits(int argc, char *argv[]) {
 
         srand(time(0));
         
-        rc = hb_mc_manycore_init(mc, TEST_NAME, DEVICE_ID);
+        rc = hb_mc_manycore_init(mc, TEST_NAME, HB_MC_DEVICE_ID);
         if (rc != HB_MC_SUCCESS) {
                 bsg_pr_err("%s: failed to intialize manycore: %s\n",
                            __func__,

--- a/examples/library/test_manycore_dmem_read_write/main.cpp
+++ b/examples/library/test_manycore_dmem_read_write/main.cpp
@@ -168,7 +168,7 @@ int test_manycore_dmem_read_write (int argc, char *argv[]) {
         /********/
         /* INIT */
         /********/
-        int err = hb_mc_manycore_init(mc, TEST_NAME, 0);
+        int err = hb_mc_manycore_init(mc, TEST_NAME, DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err("%s: failed to initialize manycore: %s\n",
                            __func__, hb_mc_strerror(err));

--- a/examples/library/test_manycore_dmem_read_write/main.cpp
+++ b/examples/library/test_manycore_dmem_read_write/main.cpp
@@ -168,7 +168,7 @@ int test_manycore_dmem_read_write (int argc, char *argv[]) {
         /********/
         /* INIT */
         /********/
-        int err = hb_mc_manycore_init(mc, TEST_NAME, DEVICE_ID);
+        int err = hb_mc_manycore_init(mc, TEST_NAME, HB_MC_DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err("%s: failed to initialize manycore: %s\n",
                            __func__, hb_mc_strerror(err));

--- a/examples/library/test_manycore_dram_read_write/main.c
+++ b/examples/library/test_manycore_dram_read_write/main.c
@@ -56,7 +56,7 @@ int test_manycore_dram_read_write(int argc, char *argv[]) {
 
         srand(time(0));
         
-        err = hb_mc_manycore_init(mc, TEST_NAME, 0);
+        err = hb_mc_manycore_init(mc, TEST_NAME, DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err("%s: failed to intialize manycore: %s\n",
                            __func__,

--- a/examples/library/test_manycore_dram_read_write/main.c
+++ b/examples/library/test_manycore_dram_read_write/main.c
@@ -56,7 +56,7 @@ int test_manycore_dram_read_write(int argc, char *argv[]) {
 
         srand(time(0));
         
-        err = hb_mc_manycore_init(mc, TEST_NAME, DEVICE_ID);
+        err = hb_mc_manycore_init(mc, TEST_NAME, HB_MC_DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err("%s: failed to intialize manycore: %s\n",
                            __func__,

--- a/examples/library/test_manycore_eva/main.c
+++ b/examples/library/test_manycore_eva/main.c
@@ -85,7 +85,7 @@ int test_manycore_eva (int argc, char *argv[]) {
 
         srand(42);
 
-        rc = hb_mc_manycore_init(&mc, "manycore@test_manycore_eva", DEVICE_ID);
+        rc = hb_mc_manycore_init(&mc, "manycore@test_manycore_eva", HB_MC_DEVICE_ID);
         if(rc != HB_MC_SUCCESS){
                 bsg_pr_test_err("Failed to initialize manycore device: %s\n",
                                 hb_mc_strerror(rc));

--- a/examples/library/test_manycore_eva/main.c
+++ b/examples/library/test_manycore_eva/main.c
@@ -85,7 +85,7 @@ int test_manycore_eva (int argc, char *argv[]) {
 
         srand(42);
 
-        rc = hb_mc_manycore_init(&mc, "manycore@test_manycore_eva", 0);
+        rc = hb_mc_manycore_init(&mc, "manycore@test_manycore_eva", DEVICE_ID);
         if(rc != HB_MC_SUCCESS){
                 bsg_pr_test_err("Failed to initialize manycore device: %s\n",
                                 hb_mc_strerror(rc));

--- a/examples/library/test_manycore_eva_read_write/main.c
+++ b/examples/library/test_manycore_eva_read_write/main.c
@@ -228,7 +228,7 @@ int test_manycore_eva_read_write (int argc, char *argv[]) {
         /********/
         /* INIT */
         /********/
-        err = hb_mc_manycore_init(mc, TEST_NAME, DEVICE_ID);
+        err = hb_mc_manycore_init(mc, TEST_NAME, HB_MC_DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err("%s: failed to initialize manycore: %s\n",
                            __func__, hb_mc_strerror(err));

--- a/examples/library/test_manycore_eva_read_write/main.c
+++ b/examples/library/test_manycore_eva_read_write/main.c
@@ -228,7 +228,7 @@ int test_manycore_eva_read_write (int argc, char *argv[]) {
         /********/
         /* INIT */
         /********/
-        err = hb_mc_manycore_init(mc, TEST_NAME, 0);
+        err = hb_mc_manycore_init(mc, TEST_NAME, DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err("%s: failed to initialize manycore: %s\n",
                            __func__, hb_mc_strerror(err));

--- a/examples/library/test_manycore_init/main.c
+++ b/examples/library/test_manycore_init/main.c
@@ -108,7 +108,7 @@ int test_manycore_init(int argc, char *argv[])
     int testno, fail = 0, err;
 
     hb_mc_manycore_t initialized = {0};
-    err = hb_mc_manycore_init(&initialized, "initialized", DEVICE_ID);
+    err = hb_mc_manycore_init(&initialized, "initialized", HB_MC_DEVICE_ID);
     if (err != HB_MC_SUCCESS) {
         test_pr_err(BSG_RED("ERROR") " while initializing test suite: %s\n",
                     hb_mc_strerror(err));

--- a/examples/library/test_manycore_init/main.c
+++ b/examples/library/test_manycore_init/main.c
@@ -108,7 +108,7 @@ int test_manycore_init(int argc, char *argv[])
     int testno, fail = 0, err;
 
     hb_mc_manycore_t initialized = {0};
-    err = hb_mc_manycore_init(&initialized, "initialized", 0);
+    err = hb_mc_manycore_init(&initialized, "initialized", DEVICE_ID);
     if (err != HB_MC_SUCCESS) {
         test_pr_err(BSG_RED("ERROR") " while initializing test suite: %s\n",
                     hb_mc_strerror(err));

--- a/examples/library/test_manycore_packets/main.c
+++ b/examples/library/test_manycore_packets/main.c
@@ -73,7 +73,7 @@ int test_manycore_packets(int argc, char *argv[]) {
         /*****************************/
         /* Initializing the manycore */
         /*****************************/
-        err = hb_mc_manycore_init(mc, "test_manycore_packets", DEVICE_ID);
+        err = hb_mc_manycore_init(mc, "test_manycore_packets", HB_MC_DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err(BSG_RED("failed to initialize manycore: %s\n"), hb_mc_strerror(err));
                 return err;

--- a/examples/library/test_manycore_packets/main.c
+++ b/examples/library/test_manycore_packets/main.c
@@ -73,7 +73,7 @@ int test_manycore_packets(int argc, char *argv[]) {
         /*****************************/
         /* Initializing the manycore */
         /*****************************/
-        err = hb_mc_manycore_init(mc, "test_manycore_packets", 0);
+        err = hb_mc_manycore_init(mc, "test_manycore_packets", DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err(BSG_RED("failed to initialize manycore: %s\n"), hb_mc_strerror(err));
                 return err;

--- a/examples/library/test_manycore_vcache_sequence/main.c
+++ b/examples/library/test_manycore_vcache_sequence/main.c
@@ -53,7 +53,7 @@ int test_manycore_vcache_sequence(int argc, char *argv[]) {
 
         srand(time(0));
         
-        err = hb_mc_manycore_init(mc, TEST_NAME, 0);
+        err = hb_mc_manycore_init(mc, TEST_NAME, DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err("%s: failed to intialize manycore: %s\n",
                            __func__,

--- a/examples/library/test_manycore_vcache_sequence/main.c
+++ b/examples/library/test_manycore_vcache_sequence/main.c
@@ -53,7 +53,7 @@ int test_manycore_vcache_sequence(int argc, char *argv[]) {
 
         srand(time(0));
         
-        err = hb_mc_manycore_init(mc, TEST_NAME, DEVICE_ID);
+        err = hb_mc_manycore_init(mc, TEST_NAME, HB_MC_DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err("%s: failed to intialize manycore: %s\n",
                            __func__,

--- a/examples/library/test_packet/main.cpp
+++ b/examples/library/test_packet/main.cpp
@@ -72,7 +72,7 @@ int test_compile(int argc, char **argv)
 int test_wait (int argc, char **argv)
 {
     hb_mc_manycore_t mc = {0};
-    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "test_packet", 0));
+    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "test_packet", DEVICE_ID));
 
     hb_mc_request_packet_t write_rqst;
 

--- a/examples/library/test_packet/main.cpp
+++ b/examples/library/test_packet/main.cpp
@@ -72,7 +72,7 @@ int test_compile(int argc, char **argv)
 int test_wait (int argc, char **argv)
 {
     hb_mc_manycore_t mc = {0};
-    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "test_packet", DEVICE_ID));
+    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "test_packet", HB_MC_DEVICE_ID));
 
     hb_mc_request_packet_t write_rqst;
 

--- a/examples/library/test_pod_iteration/main.cpp
+++ b/examples/library/test_pod_iteration/main.cpp
@@ -53,7 +53,7 @@
 
 int test_pod_iteration (int argc, char **argv) {
     hb_mc_manycore_t mc = {};
-    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "test_pod_iteration", DEVICE_ID));
+    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "test_pod_iteration", HB_MC_DEVICE_ID));
 
     const hb_mc_config_t *cfg = hb_mc_manycore_get_config(&mc);
     // iterate over each pod and report its origin coordinate

--- a/examples/library/test_pod_iteration/main.cpp
+++ b/examples/library/test_pod_iteration/main.cpp
@@ -53,7 +53,7 @@
 
 int test_pod_iteration (int argc, char **argv) {
     hb_mc_manycore_t mc = {};
-    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "test_pod_iteration", 0));
+    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "test_pod_iteration", DEVICE_ID));
 
     const hb_mc_config_t *cfg = hb_mc_manycore_get_config(&mc);
     // iterate over each pod and report its origin coordinate

--- a/examples/library/test_printing/main.c
+++ b/examples/library/test_printing/main.c
@@ -56,7 +56,7 @@ static int test_printing(int argc, char *argv[])
 {
         int rc;
         hb_mc_manycore_t mc = {0};
-        rc = hb_mc_manycore_init(&mc, "manycore@test_rom", 0);
+        rc = hb_mc_manycore_init(&mc, "manycore@test_rom", DEVICE_ID);
         if(rc != HB_MC_SUCCESS){
                 bsg_pr_test_err("Failed to initialize manycore device: %s\n",
                                 hb_mc_strerror(rc));

--- a/examples/library/test_printing/main.c
+++ b/examples/library/test_printing/main.c
@@ -56,7 +56,7 @@ static int test_printing(int argc, char *argv[])
 {
         int rc;
         hb_mc_manycore_t mc = {0};
-        rc = hb_mc_manycore_init(&mc, "manycore@test_rom", DEVICE_ID);
+        rc = hb_mc_manycore_init(&mc, "manycore@test_rom", HB_MC_DEVICE_ID);
         if(rc != HB_MC_SUCCESS){
                 bsg_pr_test_err("Failed to initialize manycore device: %s\n",
                                 hb_mc_strerror(rc));

--- a/examples/library/test_read_mem_scatter_gather/main.c
+++ b/examples/library/test_read_mem_scatter_gather/main.c
@@ -130,7 +130,7 @@ static int run_tests(int argc, char *argv[])
 {
         int err, rc = HB_MC_FAIL;
 
-        err = hb_mc_manycore_init(mc, TEST_NAME, 0);
+        err = hb_mc_manycore_init(mc, TEST_NAME, DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 test_pr_err("failed to initialize manycore: %s\n",
                             hb_mc_strerror(err));

--- a/examples/library/test_read_mem_scatter_gather/main.c
+++ b/examples/library/test_read_mem_scatter_gather/main.c
@@ -130,7 +130,7 @@ static int run_tests(int argc, char *argv[])
 {
         int err, rc = HB_MC_FAIL;
 
-        err = hb_mc_manycore_init(mc, TEST_NAME, DEVICE_ID);
+        err = hb_mc_manycore_init(mc, TEST_NAME, HB_MC_DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 test_pr_err("failed to initialize manycore: %s\n",
                             hb_mc_strerror(err));

--- a/examples/library/test_rom/main.c
+++ b/examples/library/test_rom/main.c
@@ -53,7 +53,7 @@ int test_rom (int argc, char **argv) {
                 return rc;
         }
 
-        rc = hb_mc_manycore_init(&mc, "manycore@test_rom", 0);
+        rc = hb_mc_manycore_init(&mc, "manycore@test_rom", DEVICE_ID);
         if(rc != HB_MC_SUCCESS){
                 bsg_pr_test_err("Failed to initialize manycore device: %s\n",
                                 hb_mc_strerror(rc));

--- a/examples/library/test_rom/main.c
+++ b/examples/library/test_rom/main.c
@@ -53,7 +53,7 @@ int test_rom (int argc, char **argv) {
                 return rc;
         }
 
-        rc = hb_mc_manycore_init(&mc, "manycore@test_rom", DEVICE_ID);
+        rc = hb_mc_manycore_init(&mc, "manycore@test_rom", HB_MC_DEVICE_ID);
         if(rc != HB_MC_SUCCESS){
                 bsg_pr_test_err("Failed to initialize manycore device: %s\n",
                                 hb_mc_strerror(rc));

--- a/examples/library/test_vcache_flush/main.cpp
+++ b/examples/library/test_vcache_flush/main.cpp
@@ -167,7 +167,7 @@ int test_vcache_flush(int argc, char *argv[]) {
         hb_mc_epa_t addr;
         srand(0xDEADBEEF);
 
-        rc = hb_mc_manycore_init(&mc, "manycore@test_vcache_stride", 0);
+        rc = hb_mc_manycore_init(&mc, "manycore@test_vcache_stride", DEVICE_ID);
         if(rc != HB_MC_SUCCESS){
                 bsg_pr_test_err("Failed to initialize manycore device!\n");
                 return HB_MC_FAIL;

--- a/examples/library/test_vcache_flush/main.cpp
+++ b/examples/library/test_vcache_flush/main.cpp
@@ -167,7 +167,7 @@ int test_vcache_flush(int argc, char *argv[]) {
         hb_mc_epa_t addr;
         srand(0xDEADBEEF);
 
-        rc = hb_mc_manycore_init(&mc, "manycore@test_vcache_stride", DEVICE_ID);
+        rc = hb_mc_manycore_init(&mc, "manycore@test_vcache_stride", HB_MC_DEVICE_ID);
         if(rc != HB_MC_SUCCESS){
                 bsg_pr_test_err("Failed to initialize manycore device!\n");
                 return HB_MC_FAIL;

--- a/examples/library/test_vcache_sequence/main.c
+++ b/examples/library/test_vcache_sequence/main.c
@@ -45,7 +45,7 @@ int test_vcache_sequence() {
         hb_mc_manycore_t manycore = {0}, *mc = &manycore;
         int err, r = HB_MC_FAIL;
 
-        err = hb_mc_manycore_init(mc, "test_vcache_sequence", DEVICE_ID);
+        err = hb_mc_manycore_init(mc, "test_vcache_sequence", HB_MC_DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err("%s: failed to init manycore: %s\n",
                            __func__, hb_mc_strerror(err));

--- a/examples/library/test_vcache_sequence/main.c
+++ b/examples/library/test_vcache_sequence/main.c
@@ -45,7 +45,7 @@ int test_vcache_sequence() {
         hb_mc_manycore_t manycore = {0}, *mc = &manycore;
         int err, r = HB_MC_FAIL;
 
-        err = hb_mc_manycore_init(mc, "test_vcache_sequence", 0);
+        err = hb_mc_manycore_init(mc, "test_vcache_sequence", DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err("%s: failed to init manycore: %s\n",
                            __func__, hb_mc_strerror(err));

--- a/examples/library/test_vcache_simplified/main.c
+++ b/examples/library/test_vcache_simplified/main.c
@@ -60,7 +60,7 @@ int test_vcache_simplified(int argc, char *argv[]) {
 
         srand(0);
 
-        err = hb_mc_manycore_init(mc, "test_vcache_simplified", DEVICE_ID);
+        err = hb_mc_manycore_init(mc, "test_vcache_simplified", HB_MC_DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err("%s: failed to init manycore: %s\n",
                            __func__, hb_mc_strerror(err));

--- a/examples/library/test_vcache_simplified/main.c
+++ b/examples/library/test_vcache_simplified/main.c
@@ -60,7 +60,7 @@ int test_vcache_simplified(int argc, char *argv[]) {
 
         srand(0);
 
-        err = hb_mc_manycore_init(mc, "test_vcache_simplified", 0);
+        err = hb_mc_manycore_init(mc, "test_vcache_simplified", DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err("%s: failed to init manycore: %s\n",
                            __func__, hb_mc_strerror(err));

--- a/examples/library/test_vcache_stride/main.c
+++ b/examples/library/test_vcache_stride/main.c
@@ -47,7 +47,7 @@ int test_vcache_stride(int argc, char *argv[]) {
         const hb_mc_config_t *config;
         srand(time(0));
 
-        rc = hb_mc_manycore_init(&mc, "manycore@test_vcache_stride", 0);
+        rc = hb_mc_manycore_init(&mc, "manycore@test_vcache_stride", DEVICE_ID);
         if(rc != HB_MC_SUCCESS){
                 bsg_pr_test_err("Failed to initialize manycore device!\n");
                 return HB_MC_FAIL;

--- a/examples/library/test_vcache_stride/main.c
+++ b/examples/library/test_vcache_stride/main.c
@@ -47,7 +47,7 @@ int test_vcache_stride(int argc, char *argv[]) {
         const hb_mc_config_t *config;
         srand(time(0));
 
-        rc = hb_mc_manycore_init(&mc, "manycore@test_vcache_stride", DEVICE_ID);
+        rc = hb_mc_manycore_init(&mc, "manycore@test_vcache_stride", HB_MC_DEVICE_ID);
         if(rc != HB_MC_SUCCESS){
                 bsg_pr_test_err("Failed to initialize manycore device!\n");
                 return HB_MC_FAIL;

--- a/examples/specint/test_loader.c
+++ b/examples/specint/test_loader.c
@@ -85,7 +85,7 @@ int test_loader (int argc, char **argv) {
                 return err;
 
         // initialize the manycore
-        err = hb_mc_manycore_init(&manycore, test_name, DEVICE_ID);
+        err = hb_mc_manycore_init(&manycore, test_name, HB_MC_DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err("failed to initialize manycore instance: %s\n",
                            hb_mc_strerror(err));

--- a/examples/specint/test_loader.c
+++ b/examples/specint/test_loader.c
@@ -85,7 +85,7 @@ int test_loader (int argc, char **argv) {
                 return err;
 
         // initialize the manycore
-        err = hb_mc_manycore_init(&manycore, test_name, 0);
+        err = hb_mc_manycore_init(&manycore, test_name, DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err("failed to initialize manycore instance: %s\n",
                            hb_mc_strerror(err));

--- a/examples/spmd/loader.c
+++ b/examples/spmd/loader.c
@@ -102,7 +102,7 @@ int test_loader(int argc, char **argv) {
                 return err;
 
         // initialize the manycore
-        err = hb_mc_manycore_init(&manycore, test_name, 0);
+        err = hb_mc_manycore_init(&manycore, test_name, DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err("failed to initialize manycore instance: %s\n",
                            hb_mc_strerror(err));

--- a/examples/spmd/loader.c
+++ b/examples/spmd/loader.c
@@ -102,7 +102,7 @@ int test_loader(int argc, char **argv) {
                 return err;
 
         // initialize the manycore
-        err = hb_mc_manycore_init(&manycore, test_name, DEVICE_ID);
+        err = hb_mc_manycore_init(&manycore, test_name, HB_MC_DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err("failed to initialize manycore instance: %s\n",
                            hb_mc_strerror(err));

--- a/examples/spmd/test_bsg_dram_loopback_cache/main.c
+++ b/examples/spmd/test_bsg_dram_loopback_cache/main.c
@@ -102,7 +102,7 @@ int test_loopback (int argc, char **argv) {
                 return err;
 
         // initialize the manycore
-        err = hb_mc_manycore_init(&manycore, test_name, DEVICE_ID);
+        err = hb_mc_manycore_init(&manycore, test_name, HB_MC_DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err("failed to initialize manycore instance: %s\n",
                            hb_mc_strerror(err));

--- a/examples/spmd/test_bsg_dram_loopback_cache/main.c
+++ b/examples/spmd/test_bsg_dram_loopback_cache/main.c
@@ -102,7 +102,7 @@ int test_loopback (int argc, char **argv) {
                 return err;
 
         // initialize the manycore
-        err = hb_mc_manycore_init(&manycore, test_name, 0);
+        err = hb_mc_manycore_init(&manycore, test_name, DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err("failed to initialize manycore instance: %s\n",
                            hb_mc_strerror(err));

--- a/examples/spmd/test_bsg_loader_suite/main.c
+++ b/examples/spmd/test_bsg_loader_suite/main.c
@@ -630,7 +630,7 @@ static int run_npa_to_eva_tests()
 int test_loader_suite (int argc, char **argv) {
         int err, rc = HB_MC_SUCCESS;
 
-        err = hb_mc_manycore_init(&manycore, SUITE_NAME, DEVICE_ID);
+        err = hb_mc_manycore_init(&manycore, SUITE_NAME, HB_MC_DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err("%s: failed to initialize manycore: %s\n",
                              SUITE_NAME, hb_mc_strerror(err));

--- a/examples/spmd/test_bsg_loader_suite/main.c
+++ b/examples/spmd/test_bsg_loader_suite/main.c
@@ -630,7 +630,7 @@ static int run_npa_to_eva_tests()
 int test_loader_suite (int argc, char **argv) {
         int err, rc = HB_MC_SUCCESS;
 
-        err = hb_mc_manycore_init(&manycore, SUITE_NAME, 0);
+        err = hb_mc_manycore_init(&manycore, SUITE_NAME, DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err("%s: failed to initialize manycore: %s\n",
                              SUITE_NAME, hb_mc_strerror(err));

--- a/examples/spmd/test_bsg_scalar_print/main.c
+++ b/examples/spmd/test_bsg_scalar_print/main.c
@@ -105,7 +105,7 @@ int test_scalar_print (int argc, char **argv) {
                 return err;
 
         // initialize the manycore
-        err = hb_mc_manycore_init(&manycore, test_name, 0);
+        err = hb_mc_manycore_init(&manycore, test_name, DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err("failed to initialize manycore instance: %s\n",
                            hb_mc_strerror(err));

--- a/examples/spmd/test_bsg_scalar_print/main.c
+++ b/examples/spmd/test_bsg_scalar_print/main.c
@@ -105,7 +105,7 @@ int test_scalar_print (int argc, char **argv) {
                 return err;
 
         // initialize the manycore
-        err = hb_mc_manycore_init(&manycore, test_name, DEVICE_ID);
+        err = hb_mc_manycore_init(&manycore, test_name, HB_MC_DEVICE_ID);
         if (err != HB_MC_SUCCESS) {
                 bsg_pr_err("failed to initialize manycore instance: %s\n",
                            hb_mc_strerror(err));

--- a/examples/unit/L2/read-set/main.cpp
+++ b/examples/unit/L2/read-set/main.cpp
@@ -115,7 +115,7 @@ static int Test(int argc, char *argv[])
     bsg_pr_test_info("Set:             %08x\n", set);    
     
     // init
-    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "Got 99 Problems", DEVICE_ID));    
+    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "Got 99 Problems", HB_MC_DEVICE_ID));    
 
     std::vector<unsigned> data(cfg->vcache_block_words, 0x55555555);
     

--- a/examples/unit/L2/read-set/main.cpp
+++ b/examples/unit/L2/read-set/main.cpp
@@ -115,7 +115,7 @@ static int Test(int argc, char *argv[])
     bsg_pr_test_info("Set:             %08x\n", set);    
     
     // init
-    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "Got 99 Problems", 0));    
+    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "Got 99 Problems", DEVICE_ID));    
 
     std::vector<unsigned> data(cfg->vcache_block_words, 0x55555555);
     

--- a/examples/unit/L2/read-set2/main.cpp
+++ b/examples/unit/L2/read-set2/main.cpp
@@ -126,7 +126,7 @@ static int RunAll()
 
 static int Test(int argc, char *argv[])
 {
-    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "manycore", DEVICE_ID));
+    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "manycore", HB_MC_DEVICE_ID));
     BSG_CUDA_CALL(RunAll());
     BSG_CUDA_CALL(hb_mc_manycore_exit(&mc));
     return HB_MC_SUCCESS;

--- a/examples/unit/L2/read-set2/main.cpp
+++ b/examples/unit/L2/read-set2/main.cpp
@@ -126,7 +126,7 @@ static int RunAll()
 
 static int Test(int argc, char *argv[])
 {
-    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "manycore", 0));
+    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "manycore", DEVICE_ID));
     BSG_CUDA_CALL(RunAll());
     BSG_CUDA_CALL(hb_mc_manycore_exit(&mc));
     return HB_MC_SUCCESS;

--- a/examples/unit/vcore-tile/dmem-rw/main.cpp
+++ b/examples/unit/vcore-tile/dmem-rw/main.cpp
@@ -106,7 +106,7 @@ static int RunAll()
 
 static int Test(int argc, char *argv[])
 {
-    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "manycore", DEVICE_ID));
+    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "manycore", HB_MC_DEVICE_ID));
     BSG_CUDA_CALL(RunAll());
     BSG_CUDA_CALL(hb_mc_manycore_exit(&mc));
     return HB_MC_SUCCESS;

--- a/examples/unit/vcore-tile/dmem-rw/main.cpp
+++ b/examples/unit/vcore-tile/dmem-rw/main.cpp
@@ -106,7 +106,7 @@ static int RunAll()
 
 static int Test(int argc, char *argv[])
 {
-    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "manycore", 0));
+    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "manycore", DEVICE_ID));
     BSG_CUDA_CALL(RunAll());
     BSG_CUDA_CALL(hb_mc_manycore_exit(&mc));
     return HB_MC_SUCCESS;

--- a/examples/unit/vcore-tile/icache/main.cpp
+++ b/examples/unit/vcore-tile/icache/main.cpp
@@ -48,7 +48,7 @@ static int Test(int argc, char *argv[])
 {
     binary = argv[1];
     bsg_pr_info("Opening '%s'\n", binary);
-    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "manycore", 0));
+    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "manycore", DEVICE_ID));
     BSG_CUDA_CALL(RunAll());
     BSG_CUDA_CALL(hb_mc_manycore_exit(&mc));
     return HB_MC_SUCCESS;

--- a/examples/unit/vcore-tile/icache/main.cpp
+++ b/examples/unit/vcore-tile/icache/main.cpp
@@ -48,7 +48,7 @@ static int Test(int argc, char *argv[])
 {
     binary = argv[1];
     bsg_pr_info("Opening '%s'\n", binary);
-    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "manycore", DEVICE_ID));
+    BSG_CUDA_CALL(hb_mc_manycore_init(&mc, "manycore", HB_MC_DEVICE_ID));
     BSG_CUDA_CALL(RunAll());
     BSG_CUDA_CALL(hb_mc_manycore_exit(&mc));
     return HB_MC_SUCCESS;


### PR DESCRIPTION
It is essential to support non-hardcoded device ID to choose among PCIe devices

There should be zero side effect on the current simulation flows, since the default behavior is still passing `DEVICE_ID=0x0` into the flow, so all behaviors should remain unchanged.