### PR TITLE
Deprecate num_vcache_rows_p in RTL

### DIFF
--- a/hardware/hardware.mk
+++ b/hardware/hardware.mk
@@ -251,7 +251,6 @@ $(BSG_MACHINE_PATH)/bsg_bladerunner_pkg.sv: $(BSG_MACHINE_PATH)/bsg_bladerunner_
 	@echo >> $@
 	@echo "parameter int bsg_machine_pod_tiles_y_gp = $(BSG_MACHINE_POD_TILES_Y);" >> $@
 	@echo "parameter int bsg_machine_pod_tiles_x_gp = $(BSG_MACHINE_POD_TILES_X);" >> $@
-	@echo "parameter int bsg_machine_pod_llcache_rows_gp = $(BSG_MACHINE_POD_VCACHE_NUM_ROWS);" >> $@
 	@echo >> $@
 	@echo "parameter int bsg_machine_pod_tiles_subarray_y_gp = $(BSG_MACHINE_POD_TILES_SUBARRAY_Y);" >> $@
 	@echo "parameter int bsg_machine_pod_tiles_subarray_x_gp = $(BSG_MACHINE_POD_TILES_SUBARRAY_X);" >> $@

--- a/libraries/platforms/common/dpi/hardware/dpi_top.sv
+++ b/libraries/platforms/common/dpi/hardware/dpi_top.sv
@@ -34,7 +34,6 @@ module replicant_tb_top
       $display("[INFO][TESTBENCH] bsg_machine_pod_tiles_y_gp            = %d", bsg_machine_pod_tiles_y_gp);
       $display("[INFO][TESTBENCH] bsg_machine_pod_tiles_subarray_x_gp   = %d", bsg_machine_pod_tiles_subarray_x_gp);
       $display("[INFO][TESTBENCH] bsg_machine_pod_tiles_subarray_y_gp   = %d", bsg_machine_pod_tiles_subarray_y_gp);
-      $display("[INFO][TESTBENCH] bsg_machine_pod_llcache_rows_gp       = %d", bsg_machine_pod_llcache_rows_gp);
 
       $display("[INFO][TESTBENCH] bsg_machine_core_icache_line_words_gp = %d", bsg_machine_core_icache_line_words_gp);
       $display("[INFO][TESTBENCH] bsg_machine_core_icache_entries_gp    = %d", bsg_machine_core_icache_entries_gp);
@@ -231,7 +230,6 @@ module replicant_tb_top
        ,.ruche_factor_X_p(bsg_machine_noc_ruche_factor_X_gp)
        ,.barrier_ruche_factor_X_p(bsg_machine_barrier_ruche_factor_X_gp)
 
-       ,.num_vcache_rows_p(bsg_machine_pod_llcache_rows_gp)
        ,.num_vcaches_per_channel_p(bsg_machine_llcache_dram_channel_ratio_gp)
        ,.vcache_data_width_p(bsg_machine_llcache_data_width_lp)
        ,.vcache_addr_width_p(bsg_machine_llcache_addr_width_lp)


### PR DESCRIPTION
Related to [bsg_manycore PR 715](https://github.com/bespoke-silicon-group/bsg_manycore/pull/715)

This PR fixes the `bigblade-verilator` platform simulation error bug. Parameter `num_vcache_rows_p` was deprecated in the `bsg_nonsynth_manycore_testbench` module, need to update `dpi_top` accordingly.