### PR TITLE
VCS Platform CADENV Optimizations

### DIFF
--- a/cadenv.mk
+++ b/cadenv.mk
@@ -48,7 +48,10 @@ endif
 ifneq ("$(wildcard $(CL_DIR)/../bsg_cadenv/cadenv.mk)","")
 include $(CL_DIR)/../bsg_cadenv/cadenv.mk
 # We use vcs-mx, so we re-define VCS_HOME in the environment
+# If vcs-mx does not exist, we fall back to regular vcs
+ifdef VCSMX_HOME
 export VCS_HOME=$(VCSMX_HOME)
+endif
 else
 $(warning $(shell echo -e "$(ORANGE)BSG MAKE WARN: Couldn't find bsg_cadenv. User must configure CAD Environment.$(NC)"))
 endif

--- a/libraries/platforms/bigblade-vcs/execution.mk
+++ b/libraries/platforms/bigblade-vcs/execution.mk
@@ -63,7 +63,7 @@ dve: debug.vpd
 	$(DVE) -full64 -vpd $< &
 
 verdi: debug.fsdb
-	verdi -ssf $< &
+	$(VERDI_BIN)/verdi -ssf $< &
 
 platform.execution.clean:
 	rm -rf saifgen.log exec.log profile.log exec.log debug.vpd debug.fsdb

--- a/libraries/platforms/bigblade-vcs/link.mk
+++ b/libraries/platforms/bigblade-vcs/link.mk
@@ -100,7 +100,7 @@ $(BSG_MACHINExPLATFORM_PATH)/repl $(BSG_MACHINExPLATFORM_PATH)/exec $(BSG_MACHIN
 	mkdir -p $@
 
 %/simv: $(VCS_VSOURCES) | $(BSG_PLATFORM_PATH)/libbsg_manycore_runtime.so $(BSG_PLATFORM_PATH)/libbsg_manycore_regression.so %
-	vcs -top replicant_tb_top $(VCS_VSOURCES) $(VCS_FLAGS) -Mdirectory=$@.tmp -l $@.vcs.log -o $@
+	$(VCS_BIN)/vcs -top replicant_tb_top $(VCS_VSOURCES) $(VCS_FLAGS) -Mdirectory=$@.tmp -l $@.vcs.log -o $@
 
 .PRECIOUS:$(BSG_MACHINExPLATFORM_PATH)/exec/simv
 .PRECIOUS:$(BSG_MACHINExPLATFORM_PATH)/repl/simv

--- a/platform.mk
+++ b/platform.mk
@@ -90,10 +90,6 @@ ifeq ($(BSG_PLATFORM),bigblade-vcs)
 # export VCS_HOME = <VCS installation home path>
 # # VERDI Path
 # export VERDI_HOME = <VERDI installation home path>
-# # Add VCS_HOME and VERDI_HOME to PATH
-# VCS_BIN = $(VCS_HOME)/bin
-# VERDI_BIN = $(VERDI_HOME)/bin
-# export PATH:=$(PATH):$(VCS_BIN):$(VERDI_BIN)
 
 # Environment Variables Checking
 ifndef LM_LICENSE_FILE
@@ -107,6 +103,8 @@ ifndef VERDI_HOME
 $(warning $(shell echo -e "$(RED)BSG MAKE ERROR: Neither VERDI_HOME nor DVE is defined$(NC)"))
 endif
 endif
+VCS_BIN = $(VCS_HOME)/bin
+VERDI_BIN = $(VERDI_HOME)/bin
 endif
 
 


### PR DESCRIPTION
Fixes #856 

- Fall back to vcs if vcs-mx does not exist on the machine
- Define `VCS_BIN` and `VERDI_BIN` so that we no longer rely on the system PATH, and we can choose between vcs and vcs-mx explicitly