### PR TITLE
Small multipod machine file

### DIFF
--- a/examples/library/test_dma/main.cpp
+++ b/examples/library/test_dma/main.cpp
@@ -86,7 +86,12 @@ int test_dma (int argc, char **argv) {
                 BSG_CUDA_CALL(hb_mc_manycore_dma_write_no_cache_ainv(&mc, &addr, &data_i, sizeof(data_i)));
             }
         }
+    }
 
+    hb_mc_config_foreach_pod(pod, cfg)
+    {
+        // iterate over each bank
+        hb_mc_coordinate_t bank;
         hb_mc_config_pod_foreach_dram(bank, pod, cfg)
         {
             unsigned bitidx;

--- a/libraries/bsg_manycore.cpp
+++ b/libraries/bsg_manycore.cpp
@@ -156,6 +156,7 @@ int  hb_mc_manycore_init(hb_mc_manycore_t *mc, const char *name, hb_mc_manycore_
         // Initialize the underlying machine
         if ((err = hb_mc_platform_init(mc, id)) != HB_MC_SUCCESS){
                 free((void*)mc->name);
+                bsg_pr_err("%s: Failed to initialize platform\n", __func__);
                 return err;
         }
 
@@ -163,6 +164,7 @@ int  hb_mc_manycore_init(hb_mc_manycore_t *mc, const char *name, hb_mc_manycore_
         if ((err = hb_mc_manycore_init_config(mc)) != HB_MC_SUCCESS){
                 free((void*)mc->name);
                 hb_mc_platform_cleanup(mc);
+                bsg_pr_err("%s: Failed to initialize config\n", __func__);
                 return err;
         }
 
@@ -170,6 +172,7 @@ int  hb_mc_manycore_init(hb_mc_manycore_t *mc, const char *name, hb_mc_manycore_
         if ((err = hb_mc_manycore_eva_init(mc)) != HB_MC_SUCCESS){
                 free((void*)mc->name);
                 hb_mc_platform_cleanup(mc);
+                bsg_pr_err("%s: Failed to initialize eva maps\n", __func__);
                 return err;
         }
 
@@ -177,6 +180,7 @@ int  hb_mc_manycore_init(hb_mc_manycore_t *mc, const char *name, hb_mc_manycore_
         if ((err = hb_mc_responders_init(mc))){
                 hb_mc_platform_cleanup(mc);
                 free((void*)mc->name);
+                bsg_pr_err("%s: Failed to initialize responders\n", __func__);
                 return err;
         }
 
@@ -184,6 +188,7 @@ int  hb_mc_manycore_init(hb_mc_manycore_t *mc, const char *name, hb_mc_manycore_
         if ((err = hb_mc_platform_wait_reset_done(mc)) != HB_MC_SUCCESS) {
                 hb_mc_platform_cleanup(mc);
                 free((void*)mc->name);
+                bsg_pr_err("%s: Failed to wait for reset to complete\n", __func__);
                 return err;
         }
 
@@ -191,6 +196,7 @@ int  hb_mc_manycore_init(hb_mc_manycore_t *mc, const char *name, hb_mc_manycore_
         if ((err = hb_mc_manycore_enable_dram(mc)) != HB_MC_SUCCESS){
                 hb_mc_platform_cleanup(mc);
                 free((void*)mc->name);
+                bsg_pr_err("%s: Failed to enable dram\n", __func__);
                 return err;
         }
 
@@ -198,6 +204,7 @@ int  hb_mc_manycore_init(hb_mc_manycore_t *mc, const char *name, hb_mc_manycore_
         if ((err = hb_mc_manycore_vcache_init(mc)) != HB_MC_SUCCESS) {
                 hb_mc_platform_cleanup(mc);
                 free((void*)mc->name);
+                bsg_pr_err("%s: Failed to initialize vcaches\n", __func__);
                 return err;
         }
 
@@ -205,6 +212,7 @@ int  hb_mc_manycore_init(hb_mc_manycore_t *mc, const char *name, hb_mc_manycore_
         if ((err = hb_mc_dma_init(mc)) != HB_MC_SUCCESS) {
                 hb_mc_platform_cleanup(mc);
                 free((void*)mc->name);
+                bsg_pr_err("%s: Failed to initialize dma\n", __func__);
                 return err;
         }
 

--- a/libraries/bsg_manycore.cpp
+++ b/libraries/bsg_manycore.cpp
@@ -209,11 +209,10 @@ int  hb_mc_manycore_init(hb_mc_manycore_t *mc, const char *name, hb_mc_manycore_
         }
 
         // initialize dma
-        if ((err = hb_mc_dma_init(mc)) != HB_MC_SUCCESS) {
-                hb_mc_platform_cleanup(mc);
-                free((void*)mc->name);
-                bsg_pr_err("%s: Failed to initialize dma\n", __func__);
-                return err;
+        err = hb_mc_dma_init(mc);
+        if (err != HB_MC_SUCCESS) {
+                bsg_pr_warn("%s: Failed to initialize dma\n", __func__);
+                mc->config.enable_dma = 0;
         }
 
         return HB_MC_SUCCESS;

--- a/libraries/bsg_manycore.cpp
+++ b/libraries/bsg_manycore.cpp
@@ -209,10 +209,11 @@ int  hb_mc_manycore_init(hb_mc_manycore_t *mc, const char *name, hb_mc_manycore_
         }
 
         // initialize dma
-        err = hb_mc_dma_init(mc);
-        if (err != HB_MC_SUCCESS) {
-                bsg_pr_warn("%s: Failed to initialize dma\n", __func__);
-                mc->config.enable_dma = 0;
+        if ((err = hb_mc_dma_init(mc)) != HB_MC_SUCCESS) {
+                hb_mc_platform_cleanup(mc);
+                free((void*)mc->name);
+                bsg_pr_err("%s: Failed to initialize dma\n", __func__);
+                return err;
         }
 
         return HB_MC_SUCCESS;

--- a/libraries/bsg_manycore_cuda.cpp
+++ b/libraries/bsg_manycore_cuda.cpp
@@ -538,8 +538,13 @@ int hb_mc_device_init (hb_mc_device_t *device,
         XMALLOC(device->mc);
         *(device->mc) = {0};
 
-        BSG_MANYCORE_CALL(device->mc, hb_mc_manycore_init(device->mc, name, id))
-
+        //BSG_MANYCORE_CALL(device->mc, hb_mc_manycore_init(device->mc, name, id))
+        int r = hb_mc_manycore_init(device->mc, name, id);
+        if (r != HB_MC_SUCCESS) {
+            bsg_pr_err("Instance %s: %s: failed to initialize manycore: %s\n",
+                       name, __func__, hb_mc_strerror(r));
+                return r;
+        }
         // enumerate pods
         const hb_mc_config_t *cfg = hb_mc_manycore_get_config(device->mc);
         hb_mc_dimension_t pod_geometry = hb_mc_config_pods(cfg);

--- a/libraries/features/dma/bsg_manycore_dma.h
+++ b/libraries/features/dma/bsg_manycore_dma.h
@@ -12,7 +12,8 @@
  */
 static inline int hb_mc_dma_supports_write(const hb_mc_manycore_t *mc)
 {
-        return hb_mc_config_memsys_feature_dma(hb_mc_manycore_get_config(mc)) == 1;
+        return hb_mc_config_memsys_feature_dma(hb_mc_manycore_get_config(mc)) == 1
+                && mc->config.enable_dma == 1;
 }
 
 /**
@@ -22,7 +23,8 @@ static inline int hb_mc_dma_supports_write(const hb_mc_manycore_t *mc)
  */
 static inline int hb_mc_dma_supports_read(const hb_mc_manycore_t *mc)
 {
-        return hb_mc_config_memsys_feature_dma(hb_mc_manycore_get_config(mc)) == 1;
+        return hb_mc_config_memsys_feature_dma(hb_mc_manycore_get_config(mc)) == 1
+            && mc->config.enable_dma == 1;
 }
 
 /**

--- a/libraries/features/dma/bsg_manycore_dma.h
+++ b/libraries/features/dma/bsg_manycore_dma.h
@@ -12,8 +12,7 @@
  */
 static inline int hb_mc_dma_supports_write(const hb_mc_manycore_t *mc)
 {
-        return hb_mc_config_memsys_feature_dma(hb_mc_manycore_get_config(mc)) == 1
-                && mc->config.enable_dma == 1;
+        return hb_mc_config_memsys_feature_dma(hb_mc_manycore_get_config(mc)) == 1;
 }
 
 /**
@@ -23,8 +22,7 @@ static inline int hb_mc_dma_supports_write(const hb_mc_manycore_t *mc)
  */
 static inline int hb_mc_dma_supports_read(const hb_mc_manycore_t *mc)
 {
-        return hb_mc_config_memsys_feature_dma(hb_mc_manycore_get_config(mc)) == 1
-            && mc->config.enable_dma == 1;
+        return hb_mc_config_memsys_feature_dma(hb_mc_manycore_get_config(mc)) == 1;
 }
 
 /**

--- a/libraries/features/dma/simulation/bsg_manycore_dma.cpp
+++ b/libraries/features/dma/simulation/bsg_manycore_dma.cpp
@@ -139,8 +139,9 @@ int hb_mc_dma_init_pod_XxYy_hbm(hb_mc_manycore_t *mc)
     hb_mc_idx_t bank_id = 0;
     // 1. iterate over the east half of the chip
     // 2. iterate over each pod row
-    // 3. iterate over north-then-south of the pod row
-    // 4. iterate over absolute x coordinate (0, total-x/2)
+    // 3. iterate over pods x from east to west on this side
+    // 4. iterate over north-then-south of the pod row
+    // 5. iterate over x from east to west of the pod
     hb_mc_idx_t total_x = mc->config.pods.x * mc->config.pod_shape.x;
     hb_mc_idx_t pods_y = mc->config.pods.y;
     hb_mc_idx_t pods_x = mc->config.pods.x;

--- a/libraries/features/dma/simulation/bsg_manycore_dma.cpp
+++ b/libraries/features/dma/simulation/bsg_manycore_dma.cpp
@@ -7,7 +7,7 @@
 
 /* these are convenience macros that are only good for one line prints */
 #define dma_pr_dbg(mc, fmt, ...)                   \
-        bsg_pr_dbg("%s: " fmt, mc->name, ##__VA_ARGS__)
+        bsg_pr_dbg("%s: %s: " fmt, mc->name, __func__,  ##__VA_ARGS__)
 
 #define dma_pr_err(mc, fmt, ...)                   \
         bsg_pr_err("%s: " fmt, mc->name, ##__VA_ARGS__)
@@ -249,8 +249,8 @@ int hb_mc_dma_init_pod_X4Y4_X16_test_mem(hb_mc_manycore_t *mc)
                         unsigned long vcache_id = hb_mc_config_dram_id(cfg, vcache);
                         cache_id_to_memory_id[vcache_id] = memory;
                         cache_id_to_bank_id[vcache_id] = bank;
-                        dma_pr_dbg(mc, "%s: mapping vcache @ (%d,%d) in pod (%d,%d) to memory %d and bank %d\n",
-                                   __func__, vcache.x, vcache.y, pod.x, pod.y, memory, bank);
+                        dma_pr_dbg(mc, "mapping vcache @ (%d,%d) in pod (%d,%d) to memory %d and bank %d\n",
+                                   vcache.x, vcache.y, pod.x, pod.y, memory, bank);
                 }
         }
 
@@ -338,8 +338,8 @@ static int hb_mc_dma_npa_to_buffer(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa,
         unsigned long channels = hb_mc_config_get_dram_channels(cfg);
         unsigned long caches_per_channel = caches/channels;
 
-        dma_pr_dbg(mc, "%s: caches = %lu, channels = %lu, caches_per_channel = %lu\n",
-                        __func__, caches, channels, caches_per_channel);
+        dma_pr_dbg(mc, "caches = %lu, channels = %lu, caches_per_channel = %lu\n",
+                        caches, channels, caches_per_channel);
 
         /*
           Figure out which memory channel and bank this NPA maps to.
@@ -369,8 +369,8 @@ static int hb_mc_dma_npa_to_buffer(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa,
         address_t addr = hb_mc_memsys_map_to_physical_channel_address(&cfg->memsys, cache_addr);
 
 
-        dma_pr_dbg(mc, "%s: Mapped %s to Channel %2lu, Address 0x%08lx\n",
-                        __func__, hb_mc_npa_to_string(npa, npa_str, sizeof(npa_str)), id, addr);
+        dma_pr_dbg(mc, "Mapped %s to Channel %2lu, Address 0x%08lx\n",
+                   hb_mc_npa_to_string(npa, npa_str, sizeof(npa_str)), id, addr);
 
         /*
           Don't overflow memory if you can help it.
@@ -428,8 +428,8 @@ int hb_mc_dma_read(hb_mc_manycore_t *mc,
 
         char npa_str[256];
 
-        dma_pr_dbg(mc, "%s: Reading %3zu bytes from %s\n",
-                        __func__, sz, hb_mc_npa_to_string(npa, npa_str, sizeof(npa_str)));
+        dma_pr_dbg(mc, "Reading %3zu bytes from %s\n",
+                   sz, hb_mc_npa_to_string(npa, npa_str, sizeof(npa_str)));
 
         memcpy(data, reinterpret_cast<void*>(membuffer), sz);
 

--- a/libraries/features/dma/simulation/bsg_manycore_dma.cpp
+++ b/libraries/features/dma/simulation/bsg_manycore_dma.cpp
@@ -69,6 +69,32 @@ int hb_mc_dma_init_pod_X4Y4_X16_hbm(hb_mc_manycore_t *mc)
 }
 
 /**
+ * Initializes a specialized DRAM bank to channel map for the 2x2 pod
+ */
+static
+int hb_mc_dma_init_pod_X2Y2_hbm(hb_mc_manycore_t *mc)
+{
+        hb_mc_coordinate_t pod;
+
+        unsigned long caches_per_channel =
+                hb_mc_vcache_num_caches(mc) /
+                hb_mc_config_get_dram_channels(&mc->config);
+
+        hb_mc_config_foreach_pod(pod, &mc->config)
+        {
+                int east_not_west = pod.x >= mc->config.pods.x/2;
+                hb_mc_coordinate_t dram;
+                hb_mc_config_pod_foreach_dram(dram, pod, &mc->config)
+                {
+                        hb_mc_idx_t id = hb_mc_config_dram_id(&mc->config, dram);
+                        cache_id_to_memory_id[id] = east_not_west ? 1 : 0;
+                        cache_id_to_bank_id[id] = id % caches_per_channel;
+                }
+        }
+        return HB_MC_SUCCESS;
+}
+
+/**
  * Initializes a specialized DRAM bank to channel map 1x1 pod model of the BigBlade Chip
  */
 static
@@ -210,6 +236,8 @@ int hb_mc_dma_init(hb_mc_manycore_t *mc)
         if (mc->config.memsys.id == HB_MC_MEMSYS_ID_HBM2) {
                 if (mc->config.pods.x == 4 && mc->config.pods.y == 4) {
                         return hb_mc_dma_init_pod_X4Y4_X16_hbm(mc);
+                } else if (mc->config.pods.x == 2 && mc->config.pods.y == 2) {
+                        return hb_mc_dma_init_pod_X2Y2_hbm(mc);
                 } else if (mc->config.pods.x == 1 && mc->config.pods.y == 1) {
                         return hb_mc_dma_init_pod_X1Y1_X16_hbm(mc);
                 } else {

--- a/libraries/features/dma/simulation/bsg_manycore_dma.cpp
+++ b/libraries/features/dma/simulation/bsg_manycore_dma.cpp
@@ -73,6 +73,7 @@ int hb_mc_dma_init_pod_X4Y4_X16_hbm(hb_mc_manycore_t *mc)
 /**
  * Returns 1 if the dram is in the east half of the chip, 0 otherwise
  */
+static
 int dram_east_not_west(hb_mc_manycore_t*mc, hb_mc_coordinate_t dram)
 {
         hb_mc_idx_t base_x = hb_mc_config_get_vcore_base_x(&mc->config);
@@ -118,33 +119,6 @@ int hb_mc_dma_init_pod_XxYy_hbm(hb_mc_manycore_t *mc)
                 }
         }
         return HB_MC_SUCCESS;
-}
-
-/**
- * Initializes a specialized DRAM bank to channel map for the 2x2 pod
- */
-static
-int hb_mc_dma_init_pod_X2Y2_hbm(hb_mc_manycore_t *mc)
-{
-        return hb_mc_dma_init_pod_XxYy_hbm(mc);
-}
-
-/**
- * Initializes a specialized DRAM bank to channel map 2x1 pod model
- */
-static
-int hb_mc_dma_init_pod_X2Y1_hbm(hb_mc_manycore_t *mc)
-{
-        return hb_mc_dma_init_pod_XxYy_hbm(mc);
-}
-
-/**
- * Initializes a specialized DRAM bank to channel map 1x2 pod model
- */
-static
-int hb_mc_dma_init_pod_X1Y2_hbm(hb_mc_manycore_t *mc)
-{
-        return hb_mc_dma_init_pod_XxYy_hbm(mc);
 }
 
 /**

--- a/libraries/features/dma/simulation/bsg_manycore_dma.cpp
+++ b/libraries/features/dma/simulation/bsg_manycore_dma.cpp
@@ -289,17 +289,8 @@ int hb_mc_dma_init(hb_mc_manycore_t *mc)
         if (mc->config.memsys.id == HB_MC_MEMSYS_ID_HBM2) {
                 if (mc->config.pods.x == 4 && mc->config.pods.y == 4) {
                         return hb_mc_dma_init_pod_X4Y4_X16_hbm(mc);
-                } else if (mc->config.pods.x == 2 && mc->config.pods.y == 2) {
-                        return hb_mc_dma_init_pod_X2Y2_hbm(mc);
-                } else if (mc->config.pods.x == 2 && mc->config.pods.y == 1) {
-                        return hb_mc_dma_init_pod_X2Y1_hbm(mc);
-                } else if (mc->config.pods.x == 1 && mc->config.pods.y == 2) {
-                        return hb_mc_dma_init_pod_X1Y2_hbm(mc);
-                } else if (mc->config.pods.x == 1 && mc->config.pods.y == 1) {
-                        return hb_mc_dma_init_pod_X1Y1_X16_hbm(mc);
                 } else {
-                        // Pod arrangement not recognized
-                        return HB_MC_FAIL;
+                        return hb_mc_dma_init_pod_XxYy_hbm(mc);
                 }
         } else if (mc->config.memsys.id == HB_MC_MEMSYS_ID_TESTMEM
                    && mc->config.pod_shape.x == 16

--- a/machines/pod_X1Y2_ruche_X4Y2_hbm/Makefile.machine.include
+++ b/machines/pod_X1Y2_ruche_X4Y2_hbm/Makefile.machine.include
@@ -1,0 +1,157 @@
+# Copyright (c) 2019, University of Washington All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+############################################################################################
+# pod_X2Y2_ruche_X16Y8_hbm                                                                 #
+# 4 pods (2 pods high, 2 pods wide)                                                        #
+# 128 RISC-V Tiles per pod, 16 tiles wide, 8 tiles tall                                    # 
+# Last level caches on the top and bottom of each column                                   #
+# Each last-level cache is mapped to a separate HBM bank                                   #
+# There are two HBM channels.                                                              #
+# There is a vanilla, 2D mesh network augmented with Ruche links                           #
+############################################################################################
+
+# Change these parameters to define your machine. All other parameters should remain constant.
+
+# Chip Pod Dimensions
+BSG_MACHINE_PODS_X                    = 1
+BSG_MACHINE_PODS_Y                    = 2
+
+# 1 GHz Core Clock
+BSG_MACHINE_PODS_CYCLE_TIME_PS         = 666
+
+# Heterogeneous tile composition. Must be a 1-d array equal to the
+# number of tiles, or shorthand (default:0)
+# 0 is for Vanilla Core (RV32).
+# Anything else should be described here :)
+BSG_MACHINE_HETERO_TYPE_VEC           = default:0
+
+# Network Parameters
+# BSG_MACHINE_NETWORK_CFG longer has an effect, fixed at e_network_half_ruche_x
+BSG_MACHINE_NETWORK_CFG               = e_network_half_ruche_x
+BSG_MACHINE_RUCHE_FACTOR_X            = 3
+BSG_MACHINE_ENABLE_HW_BARRIER         = 1
+BSG_MACHINE_BARRIER_RUCHE_FACTOR_X    = 3
+BSG_MACHINE_WH_RUCHE_FACTOR           = 2
+
+# Memory System Parameters
+BSG_MACHINE_DRAM_INCLUDED             = 1
+BSG_MACHINE_MEM_DRAMSIM3_PKG          = bsg_dramsim3_hbm2_8gb_x128_pkg
+BSG_MACHINE_MEM_CFG                   = e_vcache_hbm2
+
+# Enable DMA;
+# Enable transferring data between host and device by bypassing the vcache using the CUDA function:
+# hb_mc_device_transfer_data_to_device();
+# hb_mc_device_transfer_data_to_host();
+BSG_MACHINE_ENABLE_DMA                = 1
+
+# Enable DRAM pod dimensions
+# Northwest (top-left) corner X by Y pods have DRAM enabled, other pods have DRAM disabled
+# DRAM disabled pods will skip loading program into DRAM (program must fit within icache)
+BSG_MACHINE_ENABLE_DRAM_PODS_X        = $(BSG_MACHINE_PODS_X)
+BSG_MACHINE_ENABLE_DRAM_PODS_Y        = $(BSG_MACHINE_PODS_Y)
+
+# Victim Cache Parameters
+BSG_MACHINE_VCACHE_PER_DRAM_CHANNEL   = 16
+BSG_MACHINE_VCACHE_SET                = 64
+BSG_MACHINE_VCACHE_WAY                = 8
+BSG_MACHINE_VCACHE_LINE_WORDS         = 32
+BSG_MACHINE_VCACHE_STRIPE_WORDS       = $(BSG_MACHINE_VCACHE_LINE_WORDS)
+BSG_MACHINE_VCACHE_WORD_TRACKING      = 1
+BSG_MACHINE_VCACHE_IPOLY_HASHING      = 0
+# Only applies to Non-blocking Cache
+BSG_MACHINE_VCACHE_MISS_FIFO_ELS      = 32
+
+# Number of vcache tile rows in a cache pod on either side of a tile pod
+BSG_MACHINE_POD_VCACHE_NUM_ROWS       = 1
+
+# NOC Coordinate Widths (Rarely Changed)
+BSG_MACHINE_NOC_COORD_X_WIDTH         = 7
+BSG_MACHINE_NOC_COORD_Y_WIDTH         = 7
+
+# Pod Tile Dimensions (Rarely Changed)
+BSG_MACHINE_POD_TILES_X               = 4
+BSG_MACHINE_POD_TILES_Y               = 2
+
+# Pod Tile subarray dimensions (Rarely changed, for physical design only)
+BSG_MACHINE_POD_TILES_SUBARRAY_X      = 1
+BSG_MACHINE_POD_TILES_SUBARRAY_Y      = 1
+
+# Host Coordinate (Rarely Changed)
+BSG_MACHINE_HOST_COORD_X              = 4
+BSG_MACHINE_HOST_COORD_Y              = 0
+
+BSG_MACHINE_HOST_X_CORD              = $(BSG_MACHINE_HOST_COORD_X)
+BSG_MACHINE_HOST_Y_CORD              = $(BSG_MACHINE_HOST_COORD_Y)
+
+# Manycore Origin (Rarely Changed)
+BSG_MACHINE_ORIGIN_COORD_X            = 4
+BSG_MACHINE_ORIGIN_COORD_Y            = 2
+
+# Cache-DRAM Interface Width (Rarely Changed)
+BSG_MACHINE_VCACHE_DMA_DATA_WIDTH     = 32
+
+# IO flow control parameters. (Rarely Changed)
+BSG_MACHINE_IO_EP_CREDITS             = 32
+BSG_MACHINE_IO_HOST_CREDITS           = $(BSG_MACHINE_IO_EP_CREDITS)
+BSG_MACHINE_IO_REMOTE_LOAD_CAP        = $(BSG_MACHINE_IO_EP_CREDITS)
+
+##################### Constants and Computations #####################
+
+# Aliases required for memsys.mk, and others.
+# Specific to the HBM2E chip we're modeling (8GB, 4-stack/8-channel)
+__BSG_MACHINE_DRAMSIM3_CHIP_SIZE_IN_WORDS := $(shell echo 2^29 | bc) # 2GB?
+__BSG_MACHINE_DRAMSIM3_CHIP_CH_SIZE_IN_WORDS := $(shell echo $(__BSG_MACHINE_DRAMSIM3_CHIP_SIZE_IN_WORDS)/8 | bc)
+
+BSG_MACHINE_POD_TILES                := $(shell echo $(BSG_MACHINE_POD_TILES_X)*$(BSG_MACHINE_POD_TILES_Y) | bc)
+BSG_MACHINE_NUM_PODS                 := $(shell echo $(BSG_MACHINE_PODS_X)*$(BSG_MACHINE_PODS_Y) | bc)
+BSG_MACHINE_NUM_VCACHE               := $(shell echo $(BSG_MACHINE_POD_TILES_X)*2*$(BSG_MACHINE_NUM_PODS) | bc)
+BSG_MACHINE_DRAM_CHANNELS            := $(shell echo $(BSG_MACHINE_NUM_VCACHE)/$(BSG_MACHINE_VCACHE_PER_DRAM_CHANNEL) | bc)
+
+BSG_MACHINE_DRAM_WORDS               := $(shell echo $(__BSG_MACHINE_DRAMSIM3_CHIP_CH_SIZE_IN_WORDS)*$(BSG_MACHINE_DRAM_CHANNELS) | bc)
+BSG_MACHINE_DRAM_PER_CACHE_WORDS      = $(shell echo "$(BSG_MACHINE_DRAM_WORDS) / $(BSG_MACHINE_NUM_VCACHE)" | bc)
+
+# Aliases Required for BSG Manycore
+BSG_MACHINE_GLOBAL_X                  = $(BSG_MACHINE_POD_TILES_X)
+BSG_MACHINE_GLOBAL_Y                  = $(BSG_MACHINE_POD_TILES_Y)
+BSG_MACHINE_DRAM_BANK_WORDS           = $(BSG_MACHINE_DRAM_PER_CACHE_WORDS)
+BSG_MACHINE_DRAM_BANK_SIZE_WORDS      = $(BSG_MACHINE_DRAM_BANK_WORDS)
+BSG_MACHINE_VCACHE_BLOCK_SIZE_WORDS   = $(BSG_MACHINE_VCACHE_LINE_WORDS)
+BSG_MACHINE_NUM_VCACHE_ROWS           = $(BSG_MACHINE_POD_VCACHE_NUM_ROWS)
+
+BSG_MACHINE_MAX_EPA_WIDTH             = 28
+BSG_MACHINE_DATA_WIDTH                = 32
+
+# Define BSG_MACHINE_NAME
+BSG_MACHINE_NAME                      =BSG_PX$(BSG_MACHINE_PODS_X)PY$(BSG_MACHINE_PODS_Y)
+BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_DX$(BSG_MACHINE_POD_TILES_X)DY$(BSG_MACHINE_POD_TILES_Y)
+BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(BSG_MACHINE_MEM_CFG:e_%=%)
+
+# This flag has to be always 0 by default. Conditional
+# assignment allows user to set this flag through
+# environment when required.
+BSG_MACHINE_BRANCH_TRACE_EN          ?= 0

--- a/machines/pod_X2Y1_ruche_X4Y2_hbm/Makefile.machine.include
+++ b/machines/pod_X2Y1_ruche_X4Y2_hbm/Makefile.machine.include
@@ -1,0 +1,157 @@
+# Copyright (c) 2019, University of Washington All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+############################################################################################
+# pod_X2Y2_ruche_X16Y8_hbm                                                                 #
+# 4 pods (2 pods high, 2 pods wide)                                                        #
+# 128 RISC-V Tiles per pod, 16 tiles wide, 8 tiles tall                                    # 
+# Last level caches on the top and bottom of each column                                   #
+# Each last-level cache is mapped to a separate HBM bank                                   #
+# There are two HBM channels.                                                              #
+# There is a vanilla, 2D mesh network augmented with Ruche links                           #
+############################################################################################
+
+# Change these parameters to define your machine. All other parameters should remain constant.
+
+# Chip Pod Dimensions
+BSG_MACHINE_PODS_X                    = 2
+BSG_MACHINE_PODS_Y                    = 1
+
+# 1 GHz Core Clock
+BSG_MACHINE_PODS_CYCLE_TIME_PS         = 666
+
+# Heterogeneous tile composition. Must be a 1-d array equal to the
+# number of tiles, or shorthand (default:0)
+# 0 is for Vanilla Core (RV32).
+# Anything else should be described here :)
+BSG_MACHINE_HETERO_TYPE_VEC           = default:0
+
+# Network Parameters
+# BSG_MACHINE_NETWORK_CFG longer has an effect, fixed at e_network_half_ruche_x
+BSG_MACHINE_NETWORK_CFG               = e_network_half_ruche_x
+BSG_MACHINE_RUCHE_FACTOR_X            = 3
+BSG_MACHINE_ENABLE_HW_BARRIER         = 1
+BSG_MACHINE_BARRIER_RUCHE_FACTOR_X    = 3
+BSG_MACHINE_WH_RUCHE_FACTOR           = 2
+
+# Memory System Parameters
+BSG_MACHINE_DRAM_INCLUDED             = 1
+BSG_MACHINE_MEM_DRAMSIM3_PKG          = bsg_dramsim3_hbm2_8gb_x128_pkg
+BSG_MACHINE_MEM_CFG                   = e_vcache_hbm2
+
+# Enable DMA;
+# Enable transferring data between host and device by bypassing the vcache using the CUDA function:
+# hb_mc_device_transfer_data_to_device();
+# hb_mc_device_transfer_data_to_host();
+BSG_MACHINE_ENABLE_DMA                = 1
+
+# Enable DRAM pod dimensions
+# Northwest (top-left) corner X by Y pods have DRAM enabled, other pods have DRAM disabled
+# DRAM disabled pods will skip loading program into DRAM (program must fit within icache)
+BSG_MACHINE_ENABLE_DRAM_PODS_X        = $(BSG_MACHINE_PODS_X)
+BSG_MACHINE_ENABLE_DRAM_PODS_Y        = $(BSG_MACHINE_PODS_Y)
+
+# Victim Cache Parameters
+BSG_MACHINE_VCACHE_PER_DRAM_CHANNEL   = 16
+BSG_MACHINE_VCACHE_SET                = 64
+BSG_MACHINE_VCACHE_WAY                = 8
+BSG_MACHINE_VCACHE_LINE_WORDS         = 32
+BSG_MACHINE_VCACHE_STRIPE_WORDS       = $(BSG_MACHINE_VCACHE_LINE_WORDS)
+BSG_MACHINE_VCACHE_WORD_TRACKING      = 1
+BSG_MACHINE_VCACHE_IPOLY_HASHING      = 0
+# Only applies to Non-blocking Cache
+BSG_MACHINE_VCACHE_MISS_FIFO_ELS      = 32
+
+# Number of vcache tile rows in a cache pod on either side of a tile pod
+BSG_MACHINE_POD_VCACHE_NUM_ROWS       = 1
+
+# NOC Coordinate Widths (Rarely Changed)
+BSG_MACHINE_NOC_COORD_X_WIDTH         = 7
+BSG_MACHINE_NOC_COORD_Y_WIDTH         = 7
+
+# Pod Tile Dimensions (Rarely Changed)
+BSG_MACHINE_POD_TILES_X               = 4
+BSG_MACHINE_POD_TILES_Y               = 2
+
+# Pod Tile subarray dimensions (Rarely changed, for physical design only)
+BSG_MACHINE_POD_TILES_SUBARRAY_X      = 1
+BSG_MACHINE_POD_TILES_SUBARRAY_Y      = 1
+
+# Host Coordinate (Rarely Changed)
+BSG_MACHINE_HOST_COORD_X              = 4
+BSG_MACHINE_HOST_COORD_Y              = 0
+
+BSG_MACHINE_HOST_X_CORD              = $(BSG_MACHINE_HOST_COORD_X)
+BSG_MACHINE_HOST_Y_CORD              = $(BSG_MACHINE_HOST_COORD_Y)
+
+# Manycore Origin (Rarely Changed)
+BSG_MACHINE_ORIGIN_COORD_X            = 4
+BSG_MACHINE_ORIGIN_COORD_Y            = 2
+
+# Cache-DRAM Interface Width (Rarely Changed)
+BSG_MACHINE_VCACHE_DMA_DATA_WIDTH     = 32
+
+# IO flow control parameters. (Rarely Changed)
+BSG_MACHINE_IO_EP_CREDITS             = 32
+BSG_MACHINE_IO_HOST_CREDITS           = $(BSG_MACHINE_IO_EP_CREDITS)
+BSG_MACHINE_IO_REMOTE_LOAD_CAP        = $(BSG_MACHINE_IO_EP_CREDITS)
+
+##################### Constants and Computations #####################
+
+# Aliases required for memsys.mk, and others.
+# Specific to the HBM2E chip we're modeling (8GB, 4-stack/8-channel)
+__BSG_MACHINE_DRAMSIM3_CHIP_SIZE_IN_WORDS := $(shell echo 2^29 | bc) # 2GB?
+__BSG_MACHINE_DRAMSIM3_CHIP_CH_SIZE_IN_WORDS := $(shell echo $(__BSG_MACHINE_DRAMSIM3_CHIP_SIZE_IN_WORDS)/8 | bc)
+
+BSG_MACHINE_POD_TILES                := $(shell echo $(BSG_MACHINE_POD_TILES_X)*$(BSG_MACHINE_POD_TILES_Y) | bc)
+BSG_MACHINE_NUM_PODS                 := $(shell echo $(BSG_MACHINE_PODS_X)*$(BSG_MACHINE_PODS_Y) | bc)
+BSG_MACHINE_NUM_VCACHE               := $(shell echo $(BSG_MACHINE_POD_TILES_X)*2*$(BSG_MACHINE_NUM_PODS) | bc)
+BSG_MACHINE_DRAM_CHANNELS            := $(shell echo $(BSG_MACHINE_NUM_VCACHE)/$(BSG_MACHINE_VCACHE_PER_DRAM_CHANNEL) | bc)
+
+BSG_MACHINE_DRAM_WORDS               := $(shell echo $(__BSG_MACHINE_DRAMSIM3_CHIP_CH_SIZE_IN_WORDS)*$(BSG_MACHINE_DRAM_CHANNELS) | bc)
+BSG_MACHINE_DRAM_PER_CACHE_WORDS      = $(shell echo "$(BSG_MACHINE_DRAM_WORDS) / $(BSG_MACHINE_NUM_VCACHE)" | bc)
+
+# Aliases Required for BSG Manycore
+BSG_MACHINE_GLOBAL_X                  = $(BSG_MACHINE_POD_TILES_X)
+BSG_MACHINE_GLOBAL_Y                  = $(BSG_MACHINE_POD_TILES_Y)
+BSG_MACHINE_DRAM_BANK_WORDS           = $(BSG_MACHINE_DRAM_PER_CACHE_WORDS)
+BSG_MACHINE_DRAM_BANK_SIZE_WORDS      = $(BSG_MACHINE_DRAM_BANK_WORDS)
+BSG_MACHINE_VCACHE_BLOCK_SIZE_WORDS   = $(BSG_MACHINE_VCACHE_LINE_WORDS)
+BSG_MACHINE_NUM_VCACHE_ROWS           = $(BSG_MACHINE_POD_VCACHE_NUM_ROWS)
+
+BSG_MACHINE_MAX_EPA_WIDTH             = 28
+BSG_MACHINE_DATA_WIDTH                = 32
+
+# Define BSG_MACHINE_NAME
+BSG_MACHINE_NAME                      =BSG_PX$(BSG_MACHINE_PODS_X)PY$(BSG_MACHINE_PODS_Y)
+BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_DX$(BSG_MACHINE_POD_TILES_X)DY$(BSG_MACHINE_POD_TILES_Y)
+BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(BSG_MACHINE_MEM_CFG:e_%=%)
+
+# This flag has to be always 0 by default. Conditional
+# assignment allows user to set this flag through
+# environment when required.
+BSG_MACHINE_BRANCH_TRACE_EN          ?= 0

--- a/machines/pod_X2Y2_ruche_X4Y2_hbm/Makefile.machine.include
+++ b/machines/pod_X2Y2_ruche_X4Y2_hbm/Makefile.machine.include
@@ -1,0 +1,157 @@
+# Copyright (c) 2019, University of Washington All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+############################################################################################
+# pod_X2Y2_ruche_X16Y8_hbm                                                                 #
+# 4 pods (2 pods high, 2 pods wide)                                                        #
+# 128 RISC-V Tiles per pod, 16 tiles wide, 8 tiles tall                                    # 
+# Last level caches on the top and bottom of each column                                   #
+# Each last-level cache is mapped to a separate HBM bank                                   #
+# There are two HBM channels.                                                              #
+# There is a vanilla, 2D mesh network augmented with Ruche links                           #
+############################################################################################
+
+# Change these parameters to define your machine. All other parameters should remain constant.
+
+# Chip Pod Dimensions
+BSG_MACHINE_PODS_X                    = 2
+BSG_MACHINE_PODS_Y                    = 2
+
+# 1 GHz Core Clock
+BSG_MACHINE_PODS_CYCLE_TIME_PS         = 666
+
+# Heterogeneous tile composition. Must be a 1-d array equal to the
+# number of tiles, or shorthand (default:0)
+# 0 is for Vanilla Core (RV32).
+# Anything else should be described here :)
+BSG_MACHINE_HETERO_TYPE_VEC           = default:0
+
+# Network Parameters
+# BSG_MACHINE_NETWORK_CFG longer has an effect, fixed at e_network_half_ruche_x
+BSG_MACHINE_NETWORK_CFG               = e_network_half_ruche_x
+BSG_MACHINE_RUCHE_FACTOR_X            = 3
+BSG_MACHINE_ENABLE_HW_BARRIER         = 1
+BSG_MACHINE_BARRIER_RUCHE_FACTOR_X    = 3
+BSG_MACHINE_WH_RUCHE_FACTOR           = 2
+
+# Memory System Parameters
+BSG_MACHINE_DRAM_INCLUDED             = 1
+BSG_MACHINE_MEM_DRAMSIM3_PKG          = bsg_dramsim3_hbm2_8gb_x128_pkg
+BSG_MACHINE_MEM_CFG                   = e_vcache_hbm2
+
+# Enable DMA;
+# Enable transferring data between host and device by bypassing the vcache using the CUDA function:
+# hb_mc_device_transfer_data_to_device();
+# hb_mc_device_transfer_data_to_host();
+BSG_MACHINE_ENABLE_DMA                = 1
+
+# Enable DRAM pod dimensions
+# Northwest (top-left) corner X by Y pods have DRAM enabled, other pods have DRAM disabled
+# DRAM disabled pods will skip loading program into DRAM (program must fit within icache)
+BSG_MACHINE_ENABLE_DRAM_PODS_X        = $(BSG_MACHINE_PODS_X)
+BSG_MACHINE_ENABLE_DRAM_PODS_Y        = $(BSG_MACHINE_PODS_Y)
+
+# Victim Cache Parameters
+BSG_MACHINE_VCACHE_PER_DRAM_CHANNEL   = 16
+BSG_MACHINE_VCACHE_SET                = 64
+BSG_MACHINE_VCACHE_WAY                = 8
+BSG_MACHINE_VCACHE_LINE_WORDS         = 32
+BSG_MACHINE_VCACHE_STRIPE_WORDS       = $(BSG_MACHINE_VCACHE_LINE_WORDS)
+BSG_MACHINE_VCACHE_WORD_TRACKING      = 1
+BSG_MACHINE_VCACHE_IPOLY_HASHING      = 0
+# Only applies to Non-blocking Cache
+BSG_MACHINE_VCACHE_MISS_FIFO_ELS      = 32
+
+# Number of vcache tile rows in a cache pod on either side of a tile pod
+BSG_MACHINE_POD_VCACHE_NUM_ROWS       = 1
+
+# NOC Coordinate Widths (Rarely Changed)
+BSG_MACHINE_NOC_COORD_X_WIDTH         = 7
+BSG_MACHINE_NOC_COORD_Y_WIDTH         = 7
+
+# Pod Tile Dimensions (Rarely Changed)
+BSG_MACHINE_POD_TILES_X               = 4
+BSG_MACHINE_POD_TILES_Y               = 2
+
+# Pod Tile subarray dimensions (Rarely changed, for physical design only)
+BSG_MACHINE_POD_TILES_SUBARRAY_X      = 1
+BSG_MACHINE_POD_TILES_SUBARRAY_Y      = 1
+
+# Host Coordinate (Rarely Changed)
+BSG_MACHINE_HOST_COORD_X              = 4
+BSG_MACHINE_HOST_COORD_Y              = 0
+
+BSG_MACHINE_HOST_X_CORD              = $(BSG_MACHINE_HOST_COORD_X)
+BSG_MACHINE_HOST_Y_CORD              = $(BSG_MACHINE_HOST_COORD_Y)
+
+# Manycore Origin (Rarely Changed)
+BSG_MACHINE_ORIGIN_COORD_X            = 4
+BSG_MACHINE_ORIGIN_COORD_Y            = 2
+
+# Cache-DRAM Interface Width (Rarely Changed)
+BSG_MACHINE_VCACHE_DMA_DATA_WIDTH     = 32
+
+# IO flow control parameters. (Rarely Changed)
+BSG_MACHINE_IO_EP_CREDITS             = 32
+BSG_MACHINE_IO_HOST_CREDITS           = $(BSG_MACHINE_IO_EP_CREDITS)
+BSG_MACHINE_IO_REMOTE_LOAD_CAP        = $(BSG_MACHINE_IO_EP_CREDITS)
+
+##################### Constants and Computations #####################
+
+# Aliases required for memsys.mk, and others.
+# Specific to the HBM2E chip we're modeling (8GB, 4-stack/8-channel)
+__BSG_MACHINE_DRAMSIM3_CHIP_SIZE_IN_WORDS := $(shell echo 2^29 | bc) # 2GB?
+__BSG_MACHINE_DRAMSIM3_CHIP_CH_SIZE_IN_WORDS := $(shell echo $(__BSG_MACHINE_DRAMSIM3_CHIP_SIZE_IN_WORDS)/8 | bc)
+
+BSG_MACHINE_POD_TILES                := $(shell echo $(BSG_MACHINE_POD_TILES_X)*$(BSG_MACHINE_POD_TILES_Y) | bc)
+BSG_MACHINE_NUM_PODS                 := $(shell echo $(BSG_MACHINE_PODS_X)*$(BSG_MACHINE_PODS_Y) | bc)
+BSG_MACHINE_NUM_VCACHE               := $(shell echo $(BSG_MACHINE_POD_TILES_X)*2*$(BSG_MACHINE_NUM_PODS) | bc)
+BSG_MACHINE_DRAM_CHANNELS            := $(shell echo $(BSG_MACHINE_NUM_VCACHE)/$(BSG_MACHINE_VCACHE_PER_DRAM_CHANNEL) | bc)
+
+BSG_MACHINE_DRAM_WORDS               := $(shell echo $(__BSG_MACHINE_DRAMSIM3_CHIP_CH_SIZE_IN_WORDS)*$(BSG_MACHINE_DRAM_CHANNELS) | bc)
+BSG_MACHINE_DRAM_PER_CACHE_WORDS      = $(shell echo "$(BSG_MACHINE_DRAM_WORDS) / $(BSG_MACHINE_NUM_VCACHE)" | bc)
+
+# Aliases Required for BSG Manycore
+BSG_MACHINE_GLOBAL_X                  = $(BSG_MACHINE_POD_TILES_X)
+BSG_MACHINE_GLOBAL_Y                  = $(BSG_MACHINE_POD_TILES_Y)
+BSG_MACHINE_DRAM_BANK_WORDS           = $(BSG_MACHINE_DRAM_PER_CACHE_WORDS)
+BSG_MACHINE_DRAM_BANK_SIZE_WORDS      = $(BSG_MACHINE_DRAM_BANK_WORDS)
+BSG_MACHINE_VCACHE_BLOCK_SIZE_WORDS   = $(BSG_MACHINE_VCACHE_LINE_WORDS)
+BSG_MACHINE_NUM_VCACHE_ROWS           = $(BSG_MACHINE_POD_VCACHE_NUM_ROWS)
+
+BSG_MACHINE_MAX_EPA_WIDTH             = 28
+BSG_MACHINE_DATA_WIDTH                = 32
+
+# Define BSG_MACHINE_NAME
+BSG_MACHINE_NAME                      =BSG_PX$(BSG_MACHINE_PODS_X)PY$(BSG_MACHINE_PODS_Y)
+BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_DX$(BSG_MACHINE_POD_TILES_X)DY$(BSG_MACHINE_POD_TILES_Y)
+BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(BSG_MACHINE_MEM_CFG:e_%=%)
+
+# This flag has to be always 0 by default. Conditional
+# assignment allows user to set this flag through
+# environment when required.
+BSG_MACHINE_BRANCH_TRACE_EN          ?= 0


### PR DESCRIPTION
* Adds a 2x2, 2x1, and 1x2 pods machine for simulation with each pod shaped as 4x2.
* Fixes a buggy print in CUDA on init when it tries to report failure.
* Adds clarifying error prints in manycore.cpp.