### PR TITLE
Replace python2 with unversioned python

### DIFF
--- a/libraries/platforms/bigblade-fpga/hardware.mk
+++ b/libraries/platforms/bigblade-fpga/hardware.mk
@@ -38,7 +38,7 @@ ASCII_TO_ROM_PY = $(BASEJUMP_STL_DIR)/bsg_mem/bsg_ascii_to_rom.py
 
 hardware.configuration: $(BSG_MACHINE_PATH)/bsg_bladerunner_configuration.sv
 $(BSG_MACHINE_PATH)/bsg_bladerunner_configuration.sv: $(BSG_MACHINE_PATH)/bsg_bladerunner_configuration.rom
-	env python2 $(ASCII_TO_ROM_PY) $< bsg_bladerunner_configuration > $@
+	env python $(ASCII_TO_ROM_PY) $< bsg_bladerunner_configuration > $@
 
 .PRECIOUS: $(BSG_MACHINE_PATH)/bsg_bladerunner_configuration.sv
 

--- a/libraries/platforms/common/dpi/hardware.mk
+++ b/libraries/platforms/common/dpi/hardware.mk
@@ -48,11 +48,11 @@ VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_reset_gen.sv
 
 POD_TRACE_GEN_PY = $(BSG_MANYCORE_DIR)/testbenches/py/pod_trace_gen.py
 $(BSG_MACHINE_PATH)/bsg_tag_boot_rom.tr: $(BSG_MACHINE_PATH)/Makefile.machine.include
-	env python2 $(POD_TRACE_GEN_PY) $(BSG_MACHINE_PODS_X) $(BSG_MACHINE_PODS_Y) $(BSG_MACHINE_NOC_COORD_X_WIDTH) > $@
+	env python $(POD_TRACE_GEN_PY) $(BSG_MACHINE_PODS_X) $(BSG_MACHINE_PODS_Y) $(BSG_MACHINE_NOC_COORD_X_WIDTH) > $@
 
 ASCII_TO_ROM_PY = $(BASEJUMP_STL_DIR)/bsg_mem/bsg_ascii_to_rom.py
 $(BSG_MACHINE_PATH)/bsg_tag_boot_rom.sv: $(BSG_MACHINE_PATH)/bsg_tag_boot_rom.tr
-	env python2 $(ASCII_TO_ROM_PY) $< bsg_tag_boot_rom > $@
+	env python $(ASCII_TO_ROM_PY) $< bsg_tag_boot_rom > $@
 
 VSOURCES += $(BASEJUMP_STL_DIR)/bsg_test/bsg_trace_replay.sv
 VSOURCES += $(BSG_MACHINE_PATH)/bsg_tag_boot_rom.sv

--- a/libraries/platforms/deprecated/aws-fpga/hardware.mk
+++ b/libraries/platforms/deprecated/aws-fpga/hardware.mk
@@ -79,7 +79,7 @@ VSOURCES += $(BASEJUMP_STL_DIR)/bsg_misc/bsg_cycle_counter.v
 VSOURCES += $(BSG_MACHINE_PATH)/bsg_bladerunner_configuration.v
 ASCII_TO_ROM_PY = $(BASEJUMP_STL_DIR)/bsg_mem/bsg_ascii_to_rom.py
 $(BSG_MACHINE_PATH)/bsg_bladerunner_configuration.v: $(BSG_MACHINE_PATH)/bsg_bladerunner_configuration.rom
-	env python2 $(ASCII_TO_ROM_PY) $< bsg_bladerunner_configuration > $@
+	env python $(ASCII_TO_ROM_PY) $< bsg_bladerunner_configuration > $@
 
 ################################################################################
 # Top-level file


### PR DESCRIPTION
Support OS that does not have python2 installed (like Rocky 9)

On CentOS 7: unversioned `python` call is pointing to `python2`, so behavior is unchanged
On Rocky 8 and 9: unversioned `python` call is equivalent to `python3`. With the [latest basejump_stl PR](https://github.com/bespoke-silicon-group/basejump_stl/pull/732), python3 can generate the same rom as before.

Side effect: Users on Rocky 8 and 9 must upgrade to the latest basejump_stl