### PR TITLE
bigblade-verilator: increase macOS simulator stack

### DIFF
--- a/libraries/platforms/bigblade-verilator/link.mk
+++ b/libraries/platforms/bigblade-verilator/link.mk
@@ -180,6 +180,12 @@ $(SIMSCS): LDFLAGS += -lz
 $(SIMSCS): LDFLAGS += $(DYNAMIC_LOADER_LIB)
 $(SIMSCS): LDFLAGS += -lpthread
 ifeq ($(shell uname -s),Darwin)
+# macOS defaults the main thread to an 8 MiB stack. Larger simulations can
+# exceed that limit in host-side application code, so request a larger stack in
+# the Mach-O executable while allowing callers to override it.
+SIMSC_DARWIN_STACK_SIZE ?= 0x2000000
+$(SIMSCS): LDFLAGS += -Wl,-stack_size,$(SIMSC_DARWIN_STACK_SIZE)
+
 # DPI exports live in Verilator's static model archive. Apple ld does not
 # extract that object solely for undefined callbacks in a linked dylib, so
 # force one export; the containing object supplies the complete DPI API.


### PR DESCRIPTION
## Summary
- request a 32 MiB main-thread stack in Darwin simsc Mach-O binaries
- keep the stack size configurable with SIMSC_DARWIN_STACK_SIZE
- leave non-Darwin linking unchanged

## Validation
- relinked the 16x8 (128-core) Verilator model on macOS
- verified LC_MAIN reports stacksize 33554432 while the shell limit remains 8176 KiB
- ran the 1,048,576-word-per-array HammerBench memcpy case that previously crashed with Thread stack size exceeded
- BSG REGRESSION TEST PASSED without changing ulimit
- verified a command-line SIMSC_DARWIN_STACK_SIZE override reaches the linker