### PR TITLE
bigblade-verilator: default Darwin execution to one thread

### DIFF
--- a/libraries/platforms/bigblade-verilator/README.md
+++ b/libraries/platforms/bigblade-verilator/README.md
@@ -11,11 +11,15 @@ available simulator variants are:
 - `profile/simsc`: core, cache, router, and memory profiler output
 - `debug/simsc`: FST waveform generation
 
-The execution model uses 16 Verilator worker threads by default. For a
-conservative first build, set `VERILATOR_THREADS=1` when invoking an application
-target, for example `gmake VERILATOR_THREADS=1 exec.log`. The thread count is
-fixed when the model is generated; run `gmake platform.link.clean` before
-rebuilding the same machine with a different value.
+The execution model defaults to one Verilator worker thread on macOS and 16 on
+other hosts. Override it when invoking an application target, for example
+`gmake VERILATOR_THREADS=4 exec.log`. Small models can run slower when host
+threading overhead exceeds the available parallel work, so benchmark before
+increasing the macOS default.
+
+The requested worker count is stored with the generated execution model.
+Changing `VERILATOR_THREADS` invalidates and rebuilds that model, preventing an
+existing model with a different thread count from being reused silently.
 
 Generated C++ is split at 10,000 statements by default to keep individual
 translation units tractable for Clang. Override `VERILATOR_OUTPUT_SPLIT` and

--- a/libraries/platforms/bigblade-verilator/link.mk
+++ b/libraries/platforms/bigblade-verilator/link.mk
@@ -116,8 +116,15 @@ $(BSG_MACHINExPLATFORM_PATH)/exec/V$(BSG_DESIGN_TOP).mk: VDEFINES += BSG_MACHINE
 $(BSG_MACHINExPLATFORM_PATH)/exec/V$(BSG_DESIGN_TOP).mk: VDEFINES += BSG_MACHINE_DISABLE_PC_HISTOGRAM
 
 # See comment in bsg_nonsynth_manycore_testbench.v
+ifeq ($(shell uname -s),Darwin)
+VERILATOR_THREADS ?= 1
+else
 VERILATOR_THREADS ?= 16
+endif
+VERILATOR_THREADS_CONFIG := $(BSG_MACHINExPLATFORM_PATH)/exec/.verilator_threads
+
 $(BSG_MACHINExPLATFORM_PATH)/exec/V$(BSG_DESIGN_TOP).mk: VERILATOR_VFLAGS += --threads $(VERILATOR_THREADS)
+$(BSG_MACHINExPLATFORM_PATH)/exec/V$(BSG_DESIGN_TOP).mk: $(VERILATOR_THREADS_CONFIG)
 $(BSG_MACHINExPLATFORM_PATH)/exec/V$(BSG_DESIGN_TOP).mk: VDEFINES += VERILATOR_WORKAROUND_DISABLE_VCORE_TRACE
 $(BSG_MACHINExPLATFORM_PATH)/exec/V$(BSG_DESIGN_TOP).mk: VDEFINES += VERILATOR_WORKAROUND_DISABLE_VCORE_COVERAGE
 $(BSG_MACHINExPLATFORM_PATH)/exec/V$(BSG_DESIGN_TOP).mk: VDEFINES += VERILATOR_WORKAROUND_DISABLE_VCACHE_PROFILING
@@ -136,10 +143,23 @@ $(BSG_MACHINExPLATFORM_PATH)/debug/V$(BSG_DESIGN_TOP).mk: VDEFINES += BSG_VERILA
 # $(BSG_MACHINExPLATFORM_PATH)/operf/V$(BSG_DESIGN_TOP).mk: VERILATOR_VFLAGS += --prof-cfuncs
 
 # TODO: Don't like pattern matching. Better way?
+.PHONY: verilator-threads-force
+verilator-threads-force:
+
+$(VERILATOR_THREADS_CONFIG): verilator-threads-force | $(BSG_MACHINExPLATFORM_PATH)/exec
+	@case "$(VERILATOR_THREADS)" in \
+	  ''|*[!0-9]*) echo "BSG MAKE ERROR: VERILATOR_THREADS must be a positive integer"; exit 1;; \
+	esac
+	@test "$(VERILATOR_THREADS)" -gt 0 || \
+	  { echo "BSG MAKE ERROR: VERILATOR_THREADS must be a positive integer"; exit 1; }
+	@if test ! -f "$@" || test "$$(cat "$@")" != "$(VERILATOR_THREADS)"; then \
+	  printf '%s\n' "$(VERILATOR_THREADS)" > "$@"; \
+	fi
+
 $(FRAGS): %/V$(BSG_DESIGN_TOP).mk : | %
 $(FRAGS): $(VHEADERS) $(VSOURCES)
 	$(info BSG_INFO: Running verilator)
-	@$(VERILATOR) -Mdir $(dir $@) --cc $(VERILATOR_CFLAGS) $(VERILATOR_VFLAGS) $^ --top-module $(BSG_DESIGN_TOP)
+	@$(VERILATOR) -Mdir $(dir $@) --cc $(VERILATOR_CFLAGS) $(VERILATOR_VFLAGS) $(filter-out $(VERILATOR_THREADS_CONFIG),$^) --top-module $(BSG_DESIGN_TOP)
 
 # Static library build rules
 $(LIBS): %/V$(BSG_DESIGN_TOP)__ALL.a : %/V$(BSG_DESIGN_TOP).mk


### PR DESCRIPTION
## Summary

- default BigBlade Verilator execution models to one worker on Darwin
- retain the existing 16-worker default on other hosts
- validate that VERILATOR_THREADS is a positive integer
- record the selected worker count as a generated-model dependency so changing it rebuilds the model
- document benchmarking before increasing the macOS worker count

## Motivation

The previous default generated 16-worker models on macOS, and the worker count was not part of the Make dependency graph. A later VERILATOR_THREADS override could therefore silently reuse a model generated with another count.

For the identical 4x2 workloads on Apple Silicon:

- memcpy: 4.10 s with 16 workers versus 1.04 s with one worker
- SGEMM N=64, NITER=1: 7.11 s with 16 workers versus 1.73 s with one worker

## Validation

- generated Vreplicant_tb_top::threads() returns 1 with the Darwin default
- canonical memcpy and SGEMM simulations pass
- VERILATOR_THREADS=bogus fails without changing the stored configuration
- a repeated one-worker build leaves the generated model and simsc unchanged
- a dry run changing the count to 2 schedules Verilator with --threads 2